### PR TITLE
Private Payment

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -372,7 +372,7 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     switch(wtx->type)
     {
     case TransactionRecord::AnonTx:
-        return tr("Anonymous send");
+        return tr("Private Payment");
     case TransactionRecord::RecvWithAddress:
         return tr("Received with");
     case TransactionRecord::RecvFromOther:


### PR DESCRIPTION
Change `anonymous sens` to `Private Payment` to be in line with the core wallet. Windows (in this case) notification pops up and calls it anonymous. Core wallet labels payment as `Private Payment`