### PR TITLE
gui: accepts uri to sign messages

### DIFF
--- a/src/qt/navcoin.cpp
+++ b/src/qt/navcoin.cpp
@@ -456,6 +456,7 @@ void NavCoinApplication::initializeResult(int retval)
 
             window->addWallet(NavCoinGUI::DEFAULT_WALLET, walletModel);
             window->setCurrentWallet(NavCoinGUI::DEFAULT_WALLET);
+            paymentServer->setWalletModel(walletModel);
 
             connect(walletModel, SIGNAL(coinsSent(CWallet*,SendCoinsRecipient,QByteArray)),
                              paymentServer, SLOT(fetchPaymentACK(CWallet*,const SendCoinsRecipient&,QByteArray)));

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -478,12 +478,12 @@ void PaymentServer::handleURIOrFile(const QString& s)
 
             QString signature = (QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
 
-            QUrl fetchUrlConstructed(s.mid(NAVCOIN_IPC_PREFIX.length()) + "&s=" + QUrl::toPercentEncoding(signature));
+            QUrl fetchUrlConstructed(s.mid(NAVCOIN_IPC_PREFIX.length()));
 
             Q_EMIT message(tr("Verify address"), tr("Message signed."),
                            CClientUIInterface::ICON_INFORMATION);
 
-            sendSignature(fetchUrlConstructed);
+            sendSignature(fetchUrlConstructed, signature);
 
         }
         else if (uri.hasQueryItem("r")) // payment request URI
@@ -714,13 +714,15 @@ void PaymentServer::fetchRequest(const QUrl& url)
     netManager->get(netRequest);
 }
 
-void PaymentServer::sendSignature(const QUrl& url)
+void PaymentServer::sendSignature(const QUrl& url, const QString data)
 {
     QNetworkRequest netRequest;
     netRequest.setUrl(url);
     netRequest.setRawHeader("User-Agent", CLIENT_NAME.c_str());
-    netRequest.setRawHeader("Accept", NIP01_MIMETYPE_SIGNEDMSG);
-    netManager->get(netRequest);
+    netRequest.setHeader(QNetworkRequest::ContentTypeHeader,  NIP01_MIMETYPE_SIGNEDMSG);
+    QByteArray postData;
+    postData.append(data);
+    netManager->post(netRequest, postData);
 }
 
 void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction)

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -423,7 +423,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
 #else
         QUrlQuery uri((QUrl(s)));
 #endif
-        if (uri.hasQueryItem("m") && uri.hasQueryItem("a")) // payment request URI
+        if (uri.hasQueryItem("m") && uri.hasQueryItem("a")) // sign message URI
         {
             QByteArray temp;
             temp.append(uri.queryItemValue("m"));

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -437,15 +437,15 @@ void PaymentServer::handleURIOrFile(const QString& s)
             CNavCoinAddress addr(uri.queryItemValue("a").toStdString());
             if (!addr.IsValid())
             {
-                Q_EMIT message(tr("Verify address"), tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("The provided address is invalid.") + QString(" ") + tr("Please check the address and try again."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
             CKeyID keyID;
             if (!addr.GetKeyID(keyID))
             {
-                Q_EMIT message(tr("Verify address"), tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("The provided address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -460,8 +460,8 @@ void PaymentServer::handleURIOrFile(const QString& s)
             CKey key;
             if (!pwalletMain->GetKey(keyID, key))
             {
-                Q_EMIT message(tr("Verify address"), tr("Private key for the entered address is not available."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("Private key for the provided address is not available."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -473,7 +473,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
             if (!key.SignCompact(ss.GetHash(), vchSig))
             {
                 Q_EMIT message(tr("Verify address"),tr("Message signing failed."),
-                               CClientUIInterface::ICON_WARNING);
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -815,7 +815,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                        CClientUIInterface::ICON_INFORMATION);
         else
             Q_EMIT message(tr("Verify address"), tr("Something went wrong."),
-                       CClientUIInterface::ICON_WARNING);
+                       CClientUIInterface::MSG_ERROR);
     }
     else if (requestType == BIP70_MESSAGE_PAYMENTREQUEST)
     {

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -135,7 +135,7 @@ private:
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
-    void sendSignature(const QUrl& url);
+    void sendSignature(const QUrl& url, const QString data);
 
     // Setup networking
     void initNetManager();

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -87,6 +87,8 @@ public:
 
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
+    // WalletModel is used for unlocking the wallet when signing messages
+    void setWalletModel(WalletModel *walletModel);
 
     // Verify that the payment request network matches the client network
     static bool verifyNetwork(const payments::PaymentDetails& requestDetails);
@@ -133,6 +135,7 @@ private:
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
+    void sendSignature(const QUrl& url);
 
     // Setup networking
     void initNetManager();
@@ -146,6 +149,7 @@ private:
     QNetworkAccessManager* netManager;  // Used to fetch payment requests
 
     OptionsModel *optionsModel;
+    WalletModel *model;
 };
 
 #endif // NAVCOIN_QT_PAYMENTSERVER_H


### PR DESCRIPTION
Adds support for signing messages through URIs. This will allow a website to verify the identity of an address owner.

When user clicks in a URI in the format:

navcoin:http://domain/?m=random_string&a=address

The wallet will try to sign the message random_string with the address and if successful will make a request including the resulting signature to:

http://domain/?m=random_string&a=address&s=signature