### PR TITLE
V4.1.2 cfund prio fee

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3535,7 +3535,7 @@ bool CountVotes(CValidationState& state, CBlockIndex *pindexNew, const CBlock *p
                         proposal.fState = CFund::EXPIRED;
                         fUpdate = true;
                     }
-                    if(proposal.IsRejected() && proposal.fState != CFund::REJECTED) {
+                    else if(proposal.IsRejected() && proposal.fState != CFund::REJECTED) {
                         proposal.fState = CFund::REJECTED;
                         fUpdate = true;
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3527,7 +3527,7 @@ bool CountVotes(CValidationState& state, CBlockIndex *pindexNew, const CBlock *p
                         proposal.nVotesYes = 0;
                         fUpdate = true;
                     }
-                    if(proposal.IsExpired(pindexNew->GetMedianTimePast() && proposal.fState != CFund::EXPIRED)) {
+                    if(proposal.IsExpired(pindexNew->GetMedianTimePast()) && proposal.fState != CFund::EXPIRED) {
                         if(proposal.fState == CFund::ACCEPTED) {
                             pindexNew->nCFSupply += proposal.GetAvailable();
                             pindexNew->nCFLocked -= proposal.GetAvailable();

--- a/src/qt/navcoin.cpp
+++ b/src/qt/navcoin.cpp
@@ -456,6 +456,7 @@ void NavCoinApplication::initializeResult(int retval)
 
             window->addWallet(NavCoinGUI::DEFAULT_WALLET, walletModel);
             window->setCurrentWallet(NavCoinGUI::DEFAULT_WALLET);
+            paymentServer->setWalletModel(walletModel);
 
             connect(walletModel, SIGNAL(coinsSent(CWallet*,SendCoinsRecipient,QByteArray)),
                              paymentServer, SLOT(fetchPaymentACK(CWallet*,const SendCoinsRecipient&,QByteArray)));

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -478,12 +478,12 @@ void PaymentServer::handleURIOrFile(const QString& s)
 
             QString signature = (QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
 
-            QUrl fetchUrlConstructed(s.mid(NAVCOIN_IPC_PREFIX.length()) + "&s=" + QUrl::toPercentEncoding(signature));
+            QUrl fetchUrlConstructed(s.mid(NAVCOIN_IPC_PREFIX.length()));
 
             Q_EMIT message(tr("Verify address"), tr("Message signed."),
                            CClientUIInterface::ICON_INFORMATION);
 
-            sendSignature(fetchUrlConstructed);
+            sendSignature(fetchUrlConstructed, signature);
 
         }
         else if (uri.hasQueryItem("r")) // payment request URI
@@ -714,13 +714,15 @@ void PaymentServer::fetchRequest(const QUrl& url)
     netManager->get(netRequest);
 }
 
-void PaymentServer::sendSignature(const QUrl& url)
+void PaymentServer::sendSignature(const QUrl& url, const QString data)
 {
     QNetworkRequest netRequest;
     netRequest.setUrl(url);
     netRequest.setRawHeader("User-Agent", CLIENT_NAME.c_str());
-    netRequest.setRawHeader("Accept", NIP01_MIMETYPE_SIGNEDMSG);
-    netManager->get(netRequest);
+    netRequest.setHeader(QNetworkRequest::ContentTypeHeader,  NIP01_MIMETYPE_SIGNEDMSG);
+    QByteArray postData;
+    postData.append(data);
+    netManager->post(netRequest, postData);
 }
 
 void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction)

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -423,7 +423,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
 #else
         QUrlQuery uri((QUrl(s)));
 #endif
-        if (uri.hasQueryItem("m") && uri.hasQueryItem("a")) // payment request URI
+        if (uri.hasQueryItem("m") && uri.hasQueryItem("a")) // sign message URI
         {
             QByteArray temp;
             temp.append(uri.queryItemValue("m"));

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -437,15 +437,15 @@ void PaymentServer::handleURIOrFile(const QString& s)
             CNavCoinAddress addr(uri.queryItemValue("a").toStdString());
             if (!addr.IsValid())
             {
-                Q_EMIT message(tr("Verify address"), tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("The provided address is invalid.") + QString(" ") + tr("Please check the address and try again."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
             CKeyID keyID;
             if (!addr.GetKeyID(keyID))
             {
-                Q_EMIT message(tr("Verify address"), tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("The provided address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -460,8 +460,8 @@ void PaymentServer::handleURIOrFile(const QString& s)
             CKey key;
             if (!pwalletMain->GetKey(keyID, key))
             {
-                Q_EMIT message(tr("Verify address"), tr("Private key for the entered address is not available."),
-                               CClientUIInterface::ICON_WARNING);
+                Q_EMIT message(tr("Verify address"), tr("Private key for the provided address is not available."),
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -473,7 +473,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
             if (!key.SignCompact(ss.GetHash(), vchSig))
             {
                 Q_EMIT message(tr("Verify address"),tr("Message signing failed."),
-                               CClientUIInterface::ICON_WARNING);
+                               CClientUIInterface::MSG_ERROR);
                 return;
             }
 
@@ -815,7 +815,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                        CClientUIInterface::ICON_INFORMATION);
         else
             Q_EMIT message(tr("Verify address"), tr("Something went wrong."),
-                       CClientUIInterface::ICON_WARNING);
+                       CClientUIInterface::MSG_ERROR);
     }
     else if (requestType == BIP70_MESSAGE_PAYMENTREQUEST)
     {

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -135,7 +135,7 @@ private:
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
-    void sendSignature(const QUrl& url);
+    void sendSignature(const QUrl& url, const QString data);
 
     // Setup networking
     void initNetManager();

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -87,6 +87,8 @@ public:
 
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel *optionsModel);
+    // WalletModel is used for unlocking the wallet when signing messages
+    void setWalletModel(WalletModel *walletModel);
 
     // Verify that the payment request network matches the client network
     static bool verifyNetwork(const payments::PaymentDetails& requestDetails);
@@ -133,6 +135,7 @@ private:
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
     bool processPaymentRequest(const PaymentRequestPlus& request, SendCoinsRecipient& recipient);
     void fetchRequest(const QUrl& url);
+    void sendSignature(const QUrl& url);
 
     // Setup networking
     void initNetManager();
@@ -146,6 +149,7 @@ private:
     QNetworkAccessManager* netManager;  // Used to fetch payment requests
 
     OptionsModel *optionsModel;
+    WalletModel *model;
 };
 
 #endif // NAVCOIN_QT_PAYMENTSERVER_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -18,7 +18,7 @@
  */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx)
 {
-    if (wtx.IsCoinBase())
+    if (wtx.IsCoinBase() || wtx.IsCoinStake())
     {
         // Ensures we show generated coins / mined transactions at depth 1
         if (!wtx.IsInMainChain())

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -53,6 +53,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         //
         // Credit
         //
+        unsigned int i = 0;
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
         {
             isminetype mine = wallet->IsMine(txout);
@@ -79,6 +80,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 {
                     // Generated
                     sub.type = TransactionRecord::Generated;
+                    if(i > 0)
+                        sub.type = TransactionRecord::CFundPayment;
                 }
                 if (wtx.IsCoinStake())
                 {
@@ -102,6 +105,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
                 parts.append(sub);
             }
+            i++;
         }
     }
     else

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -79,7 +79,8 @@ public:
         RecvFromOther,
         SendToSelf,
         AnonTx,
-        CFund
+        CFund,
+        CFundPayment
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -373,6 +373,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     {
     case TransactionRecord::CFund:
         return tr("Sent to");
+    case TransactionRecord::CFundPayment:
+        return tr("Community Fund Payment");
     case TransactionRecord::AnonTx:
         return tr("Private Payment");
     case TransactionRecord::RecvWithAddress:
@@ -421,9 +423,11 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     switch(wtx->type)
     {
     case TransactionRecord::CFund:
-        return "Community Fund Contribution";
+        return tr("Community Fund Contribution");
+    case TransactionRecord::CFundPayment:
+        return tr("Community Fund Payment");
     case TransactionRecord::AnonTx:
-        return "Private Payment";
+        return tr("Private Payment");
     case TransactionRecord::RecvFromOther:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RecvWithAddress:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -426,14 +426,13 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     {
     case TransactionRecord::CFund:
         return tr("Community Fund Contribution");
-    case TransactionRecord::CFundPayment:
-        return tr("Community Fund Payment");
     case TransactionRecord::AnonTx:
         return tr("Private Payment");
     case TransactionRecord::RecvFromOther:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
+    case TransactionRecord::CFundPayment:
     case TransactionRecord::Generated:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -403,9 +403,11 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
+    case TransactionRecord::CFundPayment:
         return QIcon(":/icons/tx_input");
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
+    case TransactionRecord::CFund:
         return QIcon(":/icons/tx_output");
     default:
         return QIcon(":/icons/tx_inout");

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -84,7 +84,8 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
 
     typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
     typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
-                                        TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
+                                        TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther) |
+                                        TransactionFilterProxy::TYPE(TransactionRecord::CFundPayment));
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::CFund));

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -86,7 +86,8 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
                                         TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
-                                  TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
+                                  TransactionFilterProxy::TYPE(TransactionRecord::SendToOther) |
+                                  TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Staked"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -90,7 +90,8 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Staked"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    typeWidget->addItem(tr("Community Fund Contribution"), TransactionFilterProxy::TYPE(TransactionRecord::CFund));
+    typeWidget->addItem(tr("Community Fund Contribution"), TransactionFilterProxy::TYPE(TransactionRecord::CFund) |
+                        TransactionFilterProxy::TYPE(TransactionRecord::CFundPayment));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -90,6 +90,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Staked"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Community Fund Contribution"), TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -91,7 +91,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Staked"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    typeWidget->addItem(tr("Community Fund Contribution"), TransactionFilterProxy::TYPE(TransactionRecord::CFund) |
+    typeWidget->addItem(tr("Community Fund"), TransactionFilterProxy::TYPE(TransactionRecord::CFund) |
                         TransactionFilterProxy::TYPE(TransactionRecord::CFundPayment));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -33,7 +33,6 @@ static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
-
 CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true, false, 64)
 {
 }
@@ -214,6 +213,8 @@ bool CCFundDB::GetProposalIndex(std::vector<CFund::CProposal>&vect) {
             break;
         }
     }
+
+    std::sort(vect.begin(), vect.end(), make_member_comparer<std::greater>(&CFund::CProposal::nFee));
 
     return true;
 }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -14,6 +14,7 @@
 #include "spentindex.h"
 #include "timestampindex.h"
 
+#include <functional>
 #include <map>
 #include <string>
 #include <utility>
@@ -45,6 +46,26 @@ static const int64_t nMaxBlockDBCache = 2;
 static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
+
+template<typename T, typename M, template<typename> class C = std::less>
+struct member_comparer : std::binary_function<T, T, bool>
+{
+    explicit member_comparer(M T::*p) : p_(p) { }
+
+    bool operator ()(T const& lhs, T const& rhs) const
+    {
+        return C<M>()(lhs.*p_, rhs.*p_);
+    }
+
+private:
+    M T::*p_;
+};
+
+template<template<typename> class C, typename T, typename M>
+member_comparer<T, M, C> make_member_comparer(M T::*p)
+{
+    return member_comparer<T, M, C>(p);
+}
 
 struct CDiskTxPos : public CDiskBlockPos
 {


### PR DESCRIPTION
CFund proposals are stored using LevelDB, being the hash of the proposal the key. This causes proposals to be randomly prioritised when, for example, there are no enough funds on the fund and the consensus protocol needs to decide which proposal is the first with right to claim coins.
To solve this CCFundDB::GetProposalIndex() should sort the vector based on the paid fee of the proposal, so proposals with a higher fee are prioritised.
#147 