### PR TITLE
V4.1.2 cfund check db

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1387,6 +1387,14 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                                 "Only rebuild the block database if you are sure that your computer's date and time are correct");
                         break;
                     }
+                    int nTipHeight = 0;
+                    if(tip)
+                        nTipHeight = tip->nHeight;
+                    if(nTipHeight > 0 && nTipHeight != pcfundindex->ReadTipHeight()) {
+                        strLoadError = _("The community fund database looks to be corrupted. "
+                                "You will need to rebuild the block database.");
+                        break;
+                    }
                 }
 
                 if (!CVerifyDB().VerifyDB(chainparams, pcoinsdbview, GetArg("-checklevel", DEFAULT_CHECKLEVEL),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3120,6 +3120,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (!pcfundindex->WritePaymentRequestIndex(paymentRequestIndex))
         return AbortNode(state, "Failed to write payment request index");
 
+    if (!pcfundindex->WriteTipHeight(pindex->nHeight))
+        return AbortNode(state, "Failed to write tip height to proposal db");
+
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3120,9 +3120,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (!pcfundindex->WritePaymentRequestIndex(paymentRequestIndex))
         return AbortNode(state, "Failed to write payment request index");
 
-    if (!pcfundindex->WriteTipHeight(pindex->nHeight))
-        return AbortNode(state, "Failed to write tip height to proposal db");
-
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 
@@ -3278,6 +3275,9 @@ void PruneAndFlush() {
 /** Update chainActive and related internal data structures. */
 void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
     chainActive.SetTip(pindexNew);
+
+    if (!pcfundindex->WriteTipHeight(pindexNew->nHeight))
+        return AbortNode(state, "Failed to write tip height to proposal db");
 
     // New best block
     nTimeBestReceived = GetTime();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3277,7 +3277,7 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
     chainActive.SetTip(pindexNew);
 
     if (!pcfundindex->WriteTipHeight(pindexNew->nHeight))
-        return AbortNode(state, "Failed to write tip height to proposal db");
+        AbortNode("Failed to write tip height to proposal db", "");
 
     // New best block
     nTimeBestReceived = GetTime();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -20,6 +20,7 @@ static const char DB_COINS = 'c';
 static const char DB_BLOCK_FILES = 'f';
 static const char DB_TXINDEX = 't';
 static const char DB_PROPINDEX = 'p';
+static const char DB_PROP_TIP_HEIGHT = 't';
 static const char DB_PREQINDEX = 'r';
 static const char DB_ADDRESSINDEX = 'a';
 static const char DB_ADDRESSUNSPENTINDEX = 'u';
@@ -266,6 +267,18 @@ bool CCFundDB::GetPaymentRequestIndex(std::vector<CFund::CPaymentRequest>&vect) 
     }
 
     return true;
+}
+
+
+bool CCFundDB::WriteTipHeight(int nHeight) {
+    return Write(DB_PROP_TIP_HEIGHT, nHeight);
+}
+
+int CCFundDB::ReadTipHeight() {
+    int nHeight = 0;
+    if (!Read(DB_PROP_TIP_HEIGHT, nHeight))
+        return 0;
+    return nHeight;
 }
 
 bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -181,6 +181,8 @@ public:
     bool WritePaymentRequestIndex(const std::vector<std::pair<uint256, CFund::CPaymentRequest> >&vect);
     bool GetPaymentRequestIndex(std::vector<CFund::CPaymentRequest>&vect);
     bool UpdatePaymentRequestIndex(const std::vector<std::pair<uint256, CFund::CPaymentRequest> >&vect);
+    bool WriteTipHeight(int nHeight);
+    int ReadTipHeight();
 };
 
 #endif // NAVCOIN_TXDB_H


### PR DESCRIPTION
If the CFund DB is removed or corrupted there'll be incongruences on the state of the proposals and differences in the consensus between nodes.

CFund DB should be rebuilt in case it is not synced up to tip of the chain.