### PR TITLE
fix: #117 ignores coinstake output when calculating witness merkle root

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -168,7 +168,7 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated)
 uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated, bool fIgnoreCoinStake)
 {
     std::vector<uint256> leaves;
-    leaves.resize(block.vtx.size());
+    leaves.resize(block.vtx.size() - (fIgnoreCoinStake ? 1 : 0));
     leaves[0].SetNull(); // The witness hash of the coinbase is 0.
     for (size_t s = fIgnoreCoinStake ? 2 : 1; s < block.vtx.size(); s++) {
         leaves[s - (fIgnoreCoinStake ? 1 : 0)] = block.vtx[s].GetWitnessHash();


### PR DESCRIPTION
The witness commitment is calculated when a new block template is created before the coin stake is added. This can cause the witness merkle root hash to be different when later checked in a completely constructed block broadcasted to the network. This patch takes in consideration if the coin stake should be ignored, preventing the last leaf of the tree to be an empty hash.