### PR TITLE
net: ban obsolete nodes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5922,12 +5922,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         if(fObsolete)
         {
-            if(!pfrom->fWrongVersion) {
-                pfrom->fWrongVersion = true;
-                LogPrintf("peer=%d using obsolete version %i; disconnecting (reason: %s)\n", pfrom->id, pfrom->nVersion, reason);
-            }
             pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE, reason);
             LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 10);
             return false;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2414,7 +2414,7 @@ bool CAddrDB::Read(CAddrMan& addr, CDataStream& ssPeers)
 unsigned int ReceiveFloodSize() { return 1000*GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000*GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 
-CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn, bool fWrongVersionIn) :
+CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNameIn, bool fInboundIn) :
     ssSend(SER_NETWORK, INIT_PROTO_VERSION),
     addr(addrIn),
     nKeyedNetGroup(CalculateKeyedNetGroup(addrIn)),
@@ -2438,7 +2438,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fOneShot = false;
     fClient = false; // set by version message
     fInbound = fInboundIn;
-    fWrongVersion = fWrongVersionIn;
     fNetworkNode = false;
     fSuccessfullyConnected = false;
     fDisconnect = false;

--- a/src/net.h
+++ b/src/net.h
@@ -359,7 +359,6 @@ public:
     bool fNetworkNode;
     bool fSuccessfullyConnected;
     bool fDisconnect;
-    bool fWrongVersion;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs
@@ -447,7 +446,7 @@ public:
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 
-    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false, bool fWrongVersion = false);
+    CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
     ~CNode();
 
 private:


### PR DESCRIPTION
Related to https://github.com/NAVCoin/navcoin-core/issues/166

This patch bans nodes with obsolete versions instead of keeping the socket open.

Issue was solved in my own environment.

Testing and confirmation in other systems required.