### PR TITLE
Consider NIL state to accept votes

### DIFF
--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -289,7 +289,7 @@ bool CFund::CPaymentRequest::CanVote() const {
     CFund::CProposal parent;
     if(!CFund::FindProposal(proposalhash, parent))
         return false;
-    return nAmount >= parent.GetAvailable() && fState != ACCEPTED && fState != REJECTED;
+    return nAmount >= parent.GetAvailable() && fState == NIL;
 }
 
 bool CFund::IsValidProposal(CTransaction tx)

--- a/src/consensus/cfund.h
+++ b/src/consensus/cfund.h
@@ -214,7 +214,7 @@ public:
     }
 
     bool CanVote() const {
-        return fState != ACCEPTED && fState != REJECTED && fState != EXPIRED && fState != PENDING_FUNDS;
+        return fState == NIL;
     }
 
     bool CanRequestPayments() const {


### PR DESCRIPTION
Instead of rejecting invalid states, it considers NIL as the only valid state for accepting votes.