### PR TITLE
new gui tx category for orphans

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -18,7 +18,7 @@
  */
 bool TransactionRecord::showTransaction(const CWalletTx &wtx)
 {
-    if (wtx.IsCoinBase() || wtx.IsCoinStake())
+    if (wtx.IsCoinBase())
     {
         // Ensures we show generated coins / mined transactions at depth 1
         if (!wtx.IsInMainChain())
@@ -79,7 +79,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 if (wtx.IsCoinBase())
                 {
                     // Generated
-                    sub.type = TransactionRecord::Generated;
+                    sub.type = wtx.IsInMainChain() ? TransactionRecord::Generated : TransactionRecord::Orphan;;
                     if(i > 0)
                         sub.type = TransactionRecord::CFundPayment;
                 }
@@ -90,7 +90,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     if (hashPrev == hash)
                         continue; // last coinstake output
 
-                    sub.type = TransactionRecord::Generated;
+                    sub.type = wtx.IsInMainChain() ? TransactionRecord::Generated : TransactionRecord::Orphan;
                     sub.credit = nNet > 0 ? nNet : wtx.GetValueOut() - nDebit;
                     hashPrev = hash;
                 }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -80,7 +80,8 @@ public:
         SendToSelf,
         AnonTx,
         CFund,
-        CFundPayment
+        CFundPayment,
+        Orphan
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -388,6 +388,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Staked");
+    case TransactionRecord::Orphan:
+        return tr("Orphan");
     default:
         return QString();
     }
@@ -400,6 +402,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     case TransactionRecord::AnonTx:
         return QIcon(":/icons/ghost");
     case TransactionRecord::Generated:
+    case TransactionRecord::Orphan:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
@@ -434,6 +437,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::SendToAddress:
     case TransactionRecord::CFundPayment:
     case TransactionRecord::Generated:
+    case TransactionRecord::Orphan:
         return lookupAddress(wtx->address, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
@@ -453,6 +457,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
+    case TransactionRecord::Orphan:
         {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
         if(label.isEmpty())

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -91,6 +91,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::CFund));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Staked"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Orphan"), TransactionFilterProxy::TYPE(TransactionRecord::Orphan));
     typeWidget->addItem(tr("Community Fund"), TransactionFilterProxy::TYPE(TransactionRecord::CFund) |
                         TransactionFilterProxy::TYPE(TransactionRecord::CFundPayment));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));


### PR DESCRIPTION
4.2.0 started hiding orphan stakes in the transactions list causing confusion in the users as OS notifications were still showing while the stakes did not appear.

Because it's not possible to predict whether a stake is going to be orphan or not until a different valid tip of the chain is considered by the network, we can't prevent those notifications to show.

I propose creating a new transaction category specific for Orphan stakes.

This PR introduces the necessary changes.