### PR TITLE
add support to ban nodes based on broadcasted version

### DIFF
--- a/doc/release-notes/release-notes-4.3.0.md
+++ b/doc/release-notes/release-notes-4.3.0.md
@@ -23,6 +23,7 @@ You can now register a OpenAlias address at http://openalias.nav.community/
 New RPC command `resolveopenalias` resolves an OpenAlias address to a NavCoin address
 Added support for sending to OpenAlias addresses in the GUI, when parsing URIs and the RPC commands validateaddress and sendtoaddress
 New argument `-requirednssec` to set whether DNSSEC validation is required to resolve openalias addresses (true by default).
+Added support to ban nodes with determined wallet versions using the config parameter `banversion`
 Update copyright notice
 
 ## Wallet support for bootstrapping

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -401,6 +401,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-addanonserver=<ip>", _("Add a NavTech node to use for private transactions"));
     strUsage += HelpMessageOpt("-banscore=<n>", strprintf(_("Threshold for disconnecting misbehaving peers (default: %u)"), DEFAULT_BANSCORE_THRESHOLD));
     strUsage += HelpMessageOpt("-bantime=<n>", strprintf(_("Number of seconds to keep misbehaving peers from reconnecting (default: %u)"), DEFAULT_MISBEHAVING_BANTIME));
+    strUsage += HelpMessageOpt("-banversion=<string>", strprintf(_("Version of wallet to be banned")));
     strUsage += HelpMessageOpt("-bind=<addr>", _("Bind to given address and always listen on it. Use [host]:port notation for IPv6"));
     strUsage += HelpMessageOpt("-connect=<ip>", _("Connect only to the specified node(s)"));
     strUsage += HelpMessageOpt("-devnet", _("Uses the devnet network"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6081,6 +6081,25 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                   pfrom->cleanSubVer, pfrom->nVersion,
                   pfrom->nStartingHeight, addrMe.ToString(), pfrom->id,
                   remoteAddr);
+	    
+        std::vector<std::string> vBannedVersions = mapMultiArgs["-banversion"];
+        bool fBanned = false;
+
+        for (unsigned int i = 0; i <= vBannedVersions.size(); i++)
+        {
+            if(vBannedVersions[i] == pfrom->cleanSubVer)
+            {
+                fBanned = true;
+                break;
+            }
+        }
+
+        if(fBanned)
+        {
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 100);
+            return false;
+        }
 
         int64_t nTimeOffset = nTime - GetTime();
         pfrom->nTimeOffset = nTimeOffset;
@@ -7431,7 +7450,7 @@ bool SendMessages(CNode* pto)
                     LogPrintf("Warning: not banning local peer %s!\n", pto->addr.ToString());
                 else
                 {
-                    // CNode::Ban(pto->addr, BanReasonNodeMisbehaving);
+                    CNode::Ban(pto->addr, BanReasonNodeMisbehaving);
                 }
             }
             state.fShouldBan = false;


### PR DESCRIPTION
This PR adds support for a new config parameter:

- banversion

Example of use:

banversion=/NavCoin:4.1.0/
banversion=/NavCoin:4.1.1/

Nodes broadcasting the specified versions will be banned for 24h. This helps to reduce an excessive traffic in the nodes caused by old wallets constantly sending blocks with old consensus rules.