### PR TITLE
validateaddress doc typo for isstakable attribute

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -191,7 +191,7 @@ UniValue validateaddress(const UniValue& params, bool fHelp)
             "  \"stakingaddress\" : \"navcoinaddress\", (string) The navcoin staking address part of a cold staking address\n"
             "  \"spendingaddress\" : \"navcoinaddress\", (string) The navcoin spending address part of a cold staking address\n"
             "  \"ismine\" : true|false,        (boolean) If the address is yours or not\n"
-            "  \"ismine\" : true|false,        (boolean) If the coins from the address are stakable or not\n"
+            "  \"isstakable\" : true|false,    (boolean) If the coins from the address are stakable or not\n"
             "  \"iswatchonly\" : true|false,   (boolean) If the address is watchonly\n"
             "  \"isscript\" : true|false,      (boolean) If the key is a script\n"
             "  \"iscoldstaking\" : true|false,        (boolean) If the address is a cold staking address or not\n"


### PR DESCRIPTION
The help for validateaddress specified the ismine field twice. The second should be isstakable