### PR TITLE
Trivial: Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the working repository for NAV Coin 4.2.0, our fork of bitcoin-core 0.13
 
 For more information please visit the website:
 
-https://navcoin.org/project-roadmap/
+https://navhub.org/roadmap/
 
 [![Build Status](https://travis-ci.org/NAVCoin/navcoin-core.svg?branch=master)](https://travis-ci.org/NAVCoin/navcoin-core)
 


### PR DESCRIPTION
Hi there - just a quick fix not related to other patches, so I pushed to master and didn't make a topic branch.