### PR TITLE
WIP: Use navexplorer.com as the explorer to view transactions

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -121,7 +121,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
         }
     }
 #if QT_VERSION >= 0x040700
-    ui->thirdPartyTxUrls->setPlaceholderText("https://chainz.cryptoid.info/nav/tx.dws?%s.htm");
+    ui->thirdPartyTxUrls->setPlaceholderText("https://www.navexplorer.com/tx/%s");
 #endif
 
     ui->unit->setModel(new NavCoinUnits(this));

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -72,8 +72,8 @@ void OptionsModel::Init(bool resetSettings)
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 
     if (!settings.contains("strThirdPartyTxUrls"))
-        settings.setValue("strThirdPartyTxUrls", "https://chainz.cryptoid.info/nav/tx.dws?%s.htm");
-    strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "https://chainz.cryptoid.info/nav/tx.dws?%s.htm").toString();
+        settings.setValue("strThirdPartyTxUrls", "https://www.navexplorer.com/tx/%s");
+    strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "https://www.navexplorer.com/tx/%s").toString();
 
     if (!settings.contains("fCoinControlFeatures"))
         settings.setValue("fCoinControlFeatures", false);


### PR DESCRIPTION
Updated nav core wallet to use navexplorer.com as the block explorer for user transactions in the qt GUI.
