### PR TITLE
fixed type of donatefund second argument closes #279

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -123,6 +123,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "coinstakeoutputs", 0 },
     { "coinstakeinputs", 0 },
     { "forcetransactions", 0 },
+    { "donatefund", 1 },
 
 };
 


### PR DESCRIPTION
#279 

fixed. I pushed to v4.3.0-rc branch since v4.3 already has this function