### PR TITLE
Allow getrawtransaction verbose mode to be activated with int or bool

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -319,7 +319,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
     bool fVerbose = false;
     if (params.size() > 1 && !params[1].isNull()) {
         if (params[1].isNum()) {
-            if (params[1].get_int() == 1) {
+            if (params[1].get_int() != 0) {
                 fVerbose = true;
             }
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -256,7 +256,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
             "\nArguments:\n"
             "1. \"txid\"      (string, required) The transaction id\n"
-            "2. verbose       (numeric|boolean, optional, default=0) If 0, return a string, other return a json object\n"
+            "2. verbose       (numeric|boolean, optional, default=0) If 0|false, return a string, other return a json object\n"
 
             "\nResult (if verbose is not set or set to 0):\n"
             "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n"
@@ -317,17 +317,15 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
     uint256 hash = ParseHashV(params[0], "parameter 1");
 
     bool fVerbose = false;
-        if (params.size() > 1) {
-        if (!params[1].isNull()) {
-            if (params[1].isNum() && params[1].get_int() != 0) {
-                fVerbose = true;
-            }
-            else if(params[1].isBool() && params[1].isTrue()) {
-                fVerbose = true;
-            }
-            else {
-                throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type provided. Verbose parameter must be an int or boolean.");
-            }
+    if (params.size() > 1 && !params[1].isNull()) {
+        if (params[1].isNum() && params[1].get_int() != 0) {
+            fVerbose = true;
+        }
+        else if(params[1].isBool() && params[1].isTrue()) {
+            fVerbose = true;
+        }
+        else {
+            throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type provided. Verbose parameter must be an int or boolean.");
         }
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -318,7 +318,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
     bool fVerbose = false;
     if (params.size() > 1 && !params[1].isNull()) {
-        if (params[1].isNum() && params[1].get_int() != 0) {
+        if (params[1].isNum() && params[1].get_int() == 1) {
             fVerbose = true;
         }
         else if(params[1].isBool() && params[1].isTrue()) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -318,11 +318,15 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
     bool fVerbose = false;
     if (params.size() > 1 && !params[1].isNull()) {
-        if (params[1].isNum() && params[1].get_int() == 1) {
-            fVerbose = true;
+        if (params[1].isNum()) {
+            if (params[1].get_int() == 1) {
+                fVerbose = true;
+            }
         }
-        else if(params[1].isBool() && params[1].isTrue()) {
-            fVerbose = true;
+        else if(params[1].isBool()) {
+            if (params[1].isTrue()) {
+                fVerbose = true;
+            }
         }
         else {
             throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type provided. Verbose parameter must be an int or boolean.");

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -256,7 +256,7 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
 
             "\nArguments:\n"
             "1. \"txid\"      (string, required) The transaction id\n"
-            "2. verbose       (numeric, optional, default=0) If 0, return a string, other return a json object\n"
+            "2. verbose       (numeric|boolean, optional, default=0) If 0, return a string, other return a json object\n"
 
             "\nResult (if verbose is not set or set to 0):\n"
             "\"data\"      (string) The serialized, hex-encoded data for 'txid'\n"
@@ -310,13 +310,27 @@ UniValue getrawtransaction(const UniValue& params, bool fHelp)
             + HelpExampleCli("getrawtransaction", "\"mytxid\"")
             + HelpExampleCli("getrawtransaction", "\"mytxid\" 1")
             + HelpExampleRpc("getrawtransaction", "\"mytxid\", 1")
+            + HelpExampleRpc("getrawtransaction", "\"mytxid\" true")
+            + HelpExampleRpc("getrawtransaction", "\"mytxid\", true")
         );
 
     uint256 hash = ParseHashV(params[0], "parameter 1");
 
     bool fVerbose = false;
-    if (params.size() > 1)
-        fVerbose = (params[1].get_int() != 0);
+        if (params.size() > 1) {
+        if (!params[1].isNull()) {
+            if (params[1].isNum() && params[1].get_int() != 0) {
+                fVerbose = true;
+            }
+            else if(params[1].isBool() && params[1].isTrue()) {
+                fVerbose = true;
+            }
+            else {
+                throw JSONRPCError(RPC_TYPE_ERROR, "Invalid type provided. Verbose parameter must be an int or boolean.");
+            }
+        }
+    }
+
 
     CTransaction tx;
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -59,6 +59,8 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), runtime_error);
+    BOOST_CHECK_NO_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed 1"));
+    BOOST_CHECK_NO_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed true"));
 
     BOOST_CHECK_THROW(CallRPC("createrawtransaction"), runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), runtime_error);


### PR DESCRIPTION
NBitcoin compares verbose mode using boolean. 
Extending getrawtranasction to use both int and boolean flags.
