### PR TITLE
Added new DNSSEC trust anchor for KSK rollover

### DIFF
--- a/src/utils/dns_utils.cpp
+++ b/src/utils/dns_utils.cpp
@@ -54,11 +54,16 @@ namespace
  */
 
 /** return the built in root DS trust anchor */
-static const char*
+static const char* const*
 get_builtin_ds(void)
 {
-    return
-            ". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n";
+  static const char * const ds[] =
+  {
+    ". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n",
+    ". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n",
+    NULL
+  };
+  return ds;
 }
 
 /************************************************************
@@ -194,8 +199,13 @@ DNSResolver::DNSResolver() : m_data(new DNSResolverData())
         ub_ctx_resolvconf(m_data->m_ub_context, NULL);
         ub_ctx_hosts(m_data->m_ub_context, NULL);
     }
-
-    ub_ctx_add_ta(m_data->m_ub_context, string_copy(::get_builtin_ds()));
+    
+    const char * const *ds = ::get_builtin_ds();
+    while (*ds)
+    {
+        MINFO("adding trust anchor: " << *ds);
+        ub_ctx_add_ta(m_data->m_ub_context, string_copy(*ds++));
+    }
 }
 
 DNSResolver::~DNSResolver()


### PR DESCRIPTION
Updated  dns_util to add new trust anchor for KSK rollover scheduled for 11th October.
More info about this change: https://www.icann.org/resources/pages/ksk-rollover