### PR TITLE
Community Fund RPC commands

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1602,7 +1602,7 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
-    { "blockchain",         "cfundstats",             &cfundstats,             true  },
+    { "communityfund",      "cfundstats",             &cfundstats,             true  },
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       true  },
     { "blockchain",         "getblockcount",          &getblockcount,          true  },
@@ -1617,13 +1617,13 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getmempooldescendants",  &getmempooldescendants,  true  },
     { "blockchain",         "getmempoolentry",        &getmempoolentry,        true  },
     { "blockchain",         "getmempoolinfo",         &getmempoolinfo,         true  },
-    { "blockchain",         "getproposal",            &getproposal,            true  },
-    { "blockchain",         "getpaymentrequest",      &getpaymentrequest,      true  },
+    { "communityfund",      "getproposal",            &getproposal,            true  },
+    { "communityfund",      "getpaymentrequest",      &getpaymentrequest,      true  },
     { "blockchain",         "getrawmempool",          &getrawmempool,          true  },
     { "blockchain",         "gettxout",               &gettxout,               true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
-    { "blockchain",         "listproposals",          &listproposals,          true  },
+    { "communityfund",      "listproposals",          &listproposals,          true  },
 
     /* Not shown in help */
     { "hidden",             "invalidateblock",        &invalidateblock,        true  },


### PR DESCRIPTION
Related to #332 and #331 

- Shows help for proposalvotelist and paymentrequestvotelist
- Shows proposals and payment requests in pending state without vote
- Categorises cfund rpc commands under own category

Tests need to be added