### PR TITLE
Add -acceptversionbit

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -423,6 +423,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));
     strUsage += HelpMessageOpt("-rejectversionbit=<n>", _("Reject a suggested version bit"));
+    strUsage += HelpMessageOpt("-acceptversionbit=<n>", _("Accept a suggested version bit"));
     strUsage += HelpMessageOpt("-requirednssec", _("Requires DNS Sec for OpenAlias requests (default: true)"));
     strUsage += HelpMessageOpt("-seednode=<ip>", _("Connect to a node to retrieve peer addresses, and disconnect"));
 #ifdef ENABLE_WALLET

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -136,29 +136,43 @@ public:
 
 }
 
-bool IsVersionBitRejected(const Consensus::Params& params, Consensus::DeploymentPos pos){
+bool IsVersionBitRejected(const Consensus::Params& params, Consensus::DeploymentPos pos)
+{
 
     bool isRejected = false;
 
-    std::vector<std::string>& versionBitVotes = mapMultiArgs["-rejectversionbit"];
+    std::vector<std::string>& versionBitVotesRejected = mapMultiArgs["-rejectversionbit"];
+    std::vector<std::string>& versionBitVotesAccepted = mapMultiArgs["-acceptversionbit"];
 
     int bitTest = params.vDeployments[pos].bit;
 
-     BOOST_FOREACH(std::string rejectedBit, versionBitVotes) {
-         if (isdigit(rejectedBit[0])) {
+    BOOST_FOREACH(std::string acceptedBit, versionBitVotesAccepted)
+    {
+        if (isdigit(acceptedBit[0]))
+        {
+          int rBit =  stoi(acceptedBit);
+          if(rBit == bitTest)
+              return false;
+        }
+    }
 
-           int rBit =  stoi(rejectedBit);
-           if(rBit == bitTest) {
-                isRejected = true;
+    for (unsigned int i = 0; i < rejectedVersionBitsByDefault.size(); i++)
+    {
+        if (rejectedVersionBitsByDefault[i] == bitTest)
+            return true;
+    }
 
-                return isRejected;
-
-           }
-         }
-     }
+    BOOST_FOREACH(std::string rejectedBit, versionBitVotesRejected)
+    {
+        if (isdigit(rejectedBit[0]))
+        {
+            int rBit =  stoi(rejectedBit);
+            if(rBit == bitTest)
+                return true;
+        }
+    }
 
     return isRejected;
-
 }
 
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -54,6 +54,8 @@ static const int32_t nCFundAccSpreadVersionMask = 0x00004000;
 static const int32_t nCFundAmountV2Mask = 0x00010000;
 static const int32_t nStaticRewardVersionMask = 0x00008000;
 
+static const std::vector<int> rejectedVersionBitsByDefault = {};
+
 enum ThresholdState {
     THRESHOLD_DEFINED,
     THRESHOLD_STARTED,


### PR DESCRIPTION
This PR introduces the concept of version bits rejected by default (defined in rejectedVersionBitsByDefault src/versionbits.h) and adds support to the argument -acceptversionbit to be used to vote for version bits which are rejected by default.