### PR TITLE
Fixed coldstaking_spending.py 

### DIFF
--- a/qa/rpc-tests/coldstaking_spending.py
+++ b/qa/rpc-tests/coldstaking_spending.py
@@ -7,7 +7,6 @@ from test_framework.test_framework import NavCoinTestFramework
 from test_framework.util import *
 class ColdStakingSpending(NavCoinTestFramework):
     """Tests spending and staking to/from a spending wallet."""
-    
     # set up num of nodes
     def __init__(self):
         super().__init__()

--- a/qa/rpc-tests/coldstaking_spending.py
+++ b/qa/rpc-tests/coldstaking_spending.py
@@ -5,10 +5,9 @@
 import decimal
 from test_framework.test_framework import NavCoinTestFramework
 from test_framework.util import *
-#/TODO leave comments for how much is sent in each func call
 class ColdStakingSpending(NavCoinTestFramework):
     """Tests spending and staking to/from a spending wallet."""
-
+    
     # set up num of nodes
     def __init__(self):
         super().__init__()
@@ -148,8 +147,6 @@ class ColdStakingSpending(NavCoinTestFramework):
         assert(send_worked == True)
         
         slow_gen(self.nodes[0], 1)
-        # self.sync_all()
-
 
         # send to our staking address
         send_worked = False

--- a/qa/rpc-tests/coldstaking_spending.py
+++ b/qa/rpc-tests/coldstaking_spending.py
@@ -90,7 +90,6 @@ class ColdStakingSpending(NavCoinTestFramework):
         # sent ~all funds to coldstaking address where we do not own the staking key hence our 
         # staking weight will be 0 as our recieved BLOCK_REWARD navcoin isn't mature enough to count towards
         # our staking weight
-        print("staking weight is {}".format(staking_weight_post_send / 100000000.0- BLOCK_REWARD))
         assert((staking_weight_post_send / 100000000.0) - BLOCK_REWARD <= 1)
 
         """test spending from a cold staking address with the spending key"""
@@ -166,9 +165,6 @@ class ColdStakingSpending(NavCoinTestFramework):
             print(e)
             
         assert(send_worked == True)
-
-        """print block count"""
-        print("BLOCK COUNT: {}".format(self.nodes[0].getblockcount()))        
 
     def send_raw_transaction(self, decoded_raw_transaction, to_address, change_address, amount):
         # create a raw tx


### PR DESCRIPTION
The test outcome was previously non-deterministic due to changing minimum fees for the same type of transaction, the test used to also fail in general due to the send_raw_transaction() function definition.

I have added more transaction padding considering this test is not testing the amount we send is correct but is testing whether we can send and whether funds have been received. I have made some assert statements more strict as well.