### PR TITLE
Deducts inputs value from cold stake

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -37,7 +37,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
     CAmount nCredit = wtx.GetCredit(ISMINE_ALL);
-    CAmount nDebit = wtx.GetDebit(ISMINE_ALL);
+    CAmount nDebit = wtx.GetDebit((wtx.IsCoinStake() && wtx.vout[1].scriptPubKey.IsColdStaking()) ? ISMINE_STAKABLE : ISMINE_ALL);
     CAmount nCFundCredit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;
     uint256 hash = wtx.GetHash(), hashPrev = uint256();


### PR DESCRIPTION
NavCoin core GUI was not deducting the input value of a Cold Stake showing an incorrect total amount since commit 8e4298f4cbf1b1dc0a9bad9569859e19cee601ee.

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/24814046/49800402-b1113380-fd47-11e8-8c68-64bdf0dc3de9.png">

This patch correctly accounts inputs if they are stakable but not spendable.

<img width="890" alt="image" src="https://user-images.githubusercontent.com/24814046/49800462-d8680080-fd47-11e8-8758-ab68a96d3691.png">
