### PR TITLE
Cfund new propoal alert toolbar [X] button fix

### DIFF
--- a/src/NavCoin4-Qt.files
+++ b/src/NavCoin4-Qt.files
@@ -91,6 +91,9 @@ protocol.cpp
 protocol.h
 pubkey.cpp
 pubkey.h
+qt/forms/cfund_voting.cpp
+qt/forms/cfund_voting.h
+qt/forms/cfund_voting.ui
 random.cpp
 random.h
 rest.cpp

--- a/src/NavCoin4-Qt.files
+++ b/src/NavCoin4-Qt.files
@@ -91,9 +91,6 @@ protocol.cpp
 protocol.h
 pubkey.cpp
 pubkey.h
-qt/forms/cfund_voting.cpp
-qt/forms/cfund_voting.h
-qt/forms/cfund_voting.ui
 random.cpp
 random.h
 rest.cpp

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1836,7 +1836,7 @@ void NavCoinGUI::updateStakingStatus()
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
                 QAbstractButton* pButtonOpen = msgbox.addButton(tr("Open Voting Window"), QMessageBox::YesRole);
                 QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
-                pButtonClose>setVisible(false);
+                pButtonClose->setVisible(false);
                 this->lastDialogShown = GetTimeNow();
 
                 msgbox.exec();

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1835,7 +1835,7 @@ void NavCoinGUI::updateStakingStatus()
                 msgbox.setCheckBox(cb);
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
                 QAbstractButton* pButtonOpen = msgbox.addButton(tr("Open Voting Window"), QMessageBox::YesRole);
-                QAbstractButton* pButtonOpen = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
+                QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
                 this->lastDialogShown = GetTimeNow();
 
                 msgbox.exec();

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1833,9 +1833,9 @@ void NavCoinGUI::updateStakingStatus()
                 msgbox.setText(tr("There are new proposals or payment requests in the Community Fund.<br><br>As a staker it's important to engage in the voting process.<br><br>Please cast your vote using the voting dialog!"));
                 msgbox.setIcon(QMessageBox::Icon::Warning);
                 msgbox.setCheckBox(cb);
+                QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
                 QAbstractButton* pButtonOpen = msgbox.addButton(tr("Open Voting Window"), QMessageBox::YesRole);
-                QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
                 this->lastDialogShown = GetTimeNow();
 
                 msgbox.exec();

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1835,6 +1835,7 @@ void NavCoinGUI::updateStakingStatus()
                 msgbox.setCheckBox(cb);
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
                 QAbstractButton* pButtonOpen = msgbox.addButton(tr("Open Voting Window"), QMessageBox::YesRole);
+                QAbstractButton* pButtonOpen = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
                 this->lastDialogShown = GetTimeNow();
 
                 msgbox.exec();

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1833,9 +1833,10 @@ void NavCoinGUI::updateStakingStatus()
                 msgbox.setText(tr("There are new proposals or payment requests in the Community Fund.<br><br>As a staker it's important to engage in the voting process.<br><br>Please cast your vote using the voting dialog!"));
                 msgbox.setIcon(QMessageBox::Icon::Warning);
                 msgbox.setCheckBox(cb);
-                QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
                 QAbstractButton* pButtonInfo = msgbox.addButton(tr("Read about the Community Fund"), QMessageBox::YesRole);
                 QAbstractButton* pButtonOpen = msgbox.addButton(tr("Open Voting Window"), QMessageBox::YesRole);
+                QAbstractButton* pButtonClose = msgbox.addButton(tr("Close"), QMessageBox::RejectRole);
+                pButtonClose>setVisible(false);
                 this->lastDialogShown = GetTimeNow();
 
                 msgbox.exec();


### PR DESCRIPTION
The CFund new proposal alert pop currently cannot be closed using the [X] button, this patch attempts to remedy that.

QT seems to have a bug wherein if there is no button with `QMessageBox::RejectRole` assigned to it, the [X] button in the toolbar will not work.

To fix this I have added a close button with this functionality and hidden it, which allows the [X] to work as intended but also prevents people from dismissing the window instantly by clicking on a big 'Close' button.