### PR TITLE
Uses txblockhash to check if proposal is expired

### DIFF
--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -386,8 +386,8 @@ bool CFund::CProposal::IsRejected() const {
 
 bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
     if(nVersion >= 2) {
-        if (fState == ACCEPTED && mapBlockIndex.count(blockhash) > 0) {
-            CBlockIndex* pblockindex = mapBlockIndex[blockhash];
+        if (fState == ACCEPTED && mapBlockIndex.count(txblockhash) > 0) {
+            CBlockIndex* pblockindex = mapBlockIndex[txblockhash];
             return (pblockindex->GetBlockTime() + nDeadline < currentTime);
         }
         return (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
@@ -407,8 +407,8 @@ void CFund::CProposal::ToJson(UniValue& ret) const {
     ret.push_back(Pair("paymentAddress", Address));
     if(nVersion >= 2) {
         ret.push_back(Pair("proposalDuration", (uint64_t)nDeadline));
-        if (fState == ACCEPTED && mapBlockIndex.count(blockhash) > 0) {
-            CBlockIndex* pblockindex = mapBlockIndex[blockhash];
+        if (fState == ACCEPTED && mapBlockIndex.count(txblockhash) > 0) {
+            CBlockIndex* pblockindex = mapBlockIndex[txblockhash];
             ret.push_back(Pair("expiresOn", pblockindex->GetBlockTime() + (uint64_t)nDeadline));
         }
     } else {

--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -386,8 +386,8 @@ bool CFund::CProposal::IsRejected() const {
 
 bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
     if(nVersion >= 2) {
-        if (fState == ACCEPTED && mapBlockIndex.count(txblockhash) > 0) {
-            CBlockIndex* pblockindex = mapBlockIndex[txblockhash];
+        if (fState == ACCEPTED && mapBlockIndex.count(blockhash) > 0) {
+            CBlockIndex* pblockindex = mapBlockIndex[blockhash];
             return (pblockindex->GetBlockTime() + nDeadline < currentTime);
         }
         return (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
@@ -407,8 +407,8 @@ void CFund::CProposal::ToJson(UniValue& ret) const {
     ret.push_back(Pair("paymentAddress", Address));
     if(nVersion >= 2) {
         ret.push_back(Pair("proposalDuration", (uint64_t)nDeadline));
-        if (fState == ACCEPTED && mapBlockIndex.count(txblockhash) > 0) {
-            CBlockIndex* pblockindex = mapBlockIndex[txblockhash];
+        if (fState == ACCEPTED && mapBlockIndex.count(blockhash) > 0) {
+            CBlockIndex* pblockindex = mapBlockIndex[blockhash];
             ret.push_back(Pair("expiresOn", pblockindex->GetBlockTime() + (uint64_t)nDeadline));
         }
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4066,7 +4066,6 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                         pindexNew->nCFLocked -= proposal.GetAvailable();
                     }
                     proposal.fState = CFund::EXPIRED;
-                    proposal.blockhash = pindexNew->GetBlockHash();
                     fUpdate = true;
                 } else if(proposal.IsRejected() && proposal.fState != CFund::REJECTED) {
                     proposal.fState = CFund::REJECTED;


### PR DESCRIPTION
This PR fixes a bug in the logic where it's checked if a proposal is expired.

A proposal's timestamp is compared against that of the blockhash parameter (which reflects the block where the last state change happened, assumed to be the block where the proposal was accepted). This parameter is updated again when a proposal is expired, hence moving forward the expiry date and moving the proposal back to its previous state.

The fix involves not updating the block hash of a proposal when it expires.

This issue is critical as it can cause two different states in different nodes and a fork in the network.