### PR TITLE
Change ifelse branches in CountVotes()

### DIFF
--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -390,7 +390,7 @@ bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
             CBlockIndex* pblockindex = mapBlockIndex[blockhash];
             return (pblockindex->GetBlockTime() + nDeadline < currentTime);
         }
-        return (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
+        return (fState == EXPIRED) || (nVotingCycle > Params().GetConsensus().nCyclesProposalVoting && (CanVote() || fState == EXPIRED));
     } else {
         return (nDeadline < currentTime);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4060,29 +4060,35 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                     fUpdate = true;
                 }
 
-                if(proposal.IsExpired(pindexNew->GetBlockTime()) && proposal.fState != CFund::EXPIRED) {
-                    if(proposal.fState == CFund::ACCEPTED) {
-                        pindexNew->nCFSupply += proposal.GetAvailable();
-                        pindexNew->nCFLocked -= proposal.GetAvailable();
-                    }
-                    proposal.fState = CFund::EXPIRED;
-                    proposal.blockhash = pindexNew->GetBlockHash();
-                    fUpdate = true;
-                } else if(proposal.IsRejected() && proposal.fState != CFund::REJECTED) {
-                    proposal.fState = CFund::REJECTED;
-                    proposal.blockhash = pindexNew->GetBlockHash();
-                    fUpdate = true;
-                } else if(proposal.IsAccepted() && (proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_FUNDS)) {
-                    if(pindexNew->nCFSupply >= proposal.GetAvailable()) {
-                        pindexNew->nCFSupply -= proposal.GetAvailable();
-                        pindexNew->nCFLocked += proposal.GetAvailable();
-                        proposal.fState = CFund::ACCEPTED;
+                if(proposal.IsExpired(pindexNew->GetBlockTime())) {
+                    if (proposal.fState != CFund::EXPIRED) {
+                        if (proposal.fState == CFund::ACCEPTED) {
+                            pindexNew->nCFSupply += proposal.GetAvailable();
+                            pindexNew->nCFLocked -= proposal.GetAvailable();
+                        }
+                        proposal.fState = CFund::EXPIRED;
                         proposal.blockhash = pindexNew->GetBlockHash();
                         fUpdate = true;
-                    } else if(proposal.fState != CFund::PENDING_FUNDS) {
-                        proposal.fState = CFund::PENDING_FUNDS;
-                        proposal.blockhash = uint256();
+                    }
+                } else if(proposal.IsRejected()) {
+                    if (proposal.fState != CFund::REJECTED) {
+                        proposal.fState = CFund::REJECTED;
+                        proposal.blockhash = pindexNew->GetBlockHash();
                         fUpdate = true;
+                    }
+                } else if(proposal.IsAccepted()) {
+                    if((proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_FUNDS)) {
+                        if(pindexNew->nCFSupply >= proposal.GetAvailable()) {
+                            pindexNew->nCFSupply -= proposal.GetAvailable();
+                            pindexNew->nCFLocked += proposal.GetAvailable();
+                            proposal.fState = CFund::ACCEPTED;
+                            proposal.blockhash = pindexNew->GetBlockHash();
+                            fUpdate = true;
+                        } else if(proposal.fState != CFund::PENDING_FUNDS) {
+                            proposal.fState = CFund::PENDING_FUNDS;
+                            proposal.blockhash = uint256();
+                            fUpdate = true;
+                        }
                     }
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3983,14 +3983,18 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                     fUpdate = true;
                 }
 
-                if(prequest.IsExpired() && prequest.fState != CFund::EXPIRED) {
-                    prequest.fState = CFund::EXPIRED;
-                    prequest.blockhash = pindexNew->GetBlockHash();
-                    fUpdate = true;
-                } else if(prequest.IsRejected() && prequest.fState != CFund::REJECTED) {
-                    prequest.fState = CFund::REJECTED;
-                    prequest.blockhash = pindexNew->GetBlockHash();
-                    fUpdate = true;
+                if(prequest.IsExpired()) {
+                    if (prequest.fState != CFund::EXPIRED) {
+                        prequest.fState = CFund::EXPIRED;
+                        prequest.blockhash = pindexNew->GetBlockHash();
+                        fUpdate = true;
+                    }
+                } else if(prequest.IsRejected()) {
+                    if (prequest.fState != CFund::REJECTED) {
+                        prequest.fState = CFund::REJECTED;
+                        prequest.blockhash = pindexNew->GetBlockHash();
+                        fUpdate = true;
+                    }
                 } else if(prequest.fState == CFund::NIL){
                     if(proposal.fState == CFund::ACCEPTED && prequest.IsAccepted()) {
                         if(prequest.nAmount <= pindexNew->nCFLocked && prequest.nAmount <= proposal.GetAvailable()) {


### PR DESCRIPTION
This PR fixes a bug in the logic of the CountVotes() function which can cause a proposal to morph from a Expired state back to an Accepted state when a node reindex the chainstate db and the proposal expired being accepted.

The fix involves changing the structure of some conditionals, so in the case when a proposal state and status do not match the next else if branches are not triggered. It also considers a proposal unexpired state as always expired. See the changes list for more details.

This issue is critical as it can cause two different states in different nodes and a fork in the network.