### PR TITLE
Fix cfundstats RPC command

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -937,8 +937,11 @@ UniValue listproposals(const UniValue& params, bool fHelp)
     if(pblocktree->GetProposalIndex(vec))
     {
         BOOST_FOREACH(const CFund::CProposal& proposal, vec) {
-            if((showAll && !proposal.IsExpired(pindexBestHeader->GetBlockTime()))
-               || (showPending  &&  proposal.fState == CFund::NIL)
+            if((showAll && (!proposal.IsExpired(pindexBestHeader->GetBlockTime())
+                            || proposal.fState == CFund::PENDING_VOTING_PREQ
+                            || proposal.fState == CFund::PENDING_FUNDS))
+               || (showPending  && (proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_VOTING_PREQ
+                                    || proposal.fState == CFund::PENDING_FUNDS))
                || (showAccepted && (proposal.fState == CFund::ACCEPTED || proposal.IsAccepted()))
                || (showRejected && (proposal.fState == CFund::REJECTED || proposal.IsRejected()))
                || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime()))) {
@@ -1047,7 +1050,7 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
         UniValue op(UniValue::VOBJ);
         op.push_back(Pair("str", proposal.strDZeel));
         op.push_back(Pair("hash", proposal.hash.ToString()));
-        op.push_back(Pair("amount", proposal.nAmount));
+        op.push_back(Pair("amount", ValueFromAmount(proposal.nAmount)));
         op.push_back(Pair("yes", it->second.first));
         op.push_back(Pair("no", it->second.second));
         votesProposals.push_back(op);
@@ -1059,10 +1062,10 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
         if(!CFund::FindProposal(prequest.proposalhash, proposal))
             continue;
         UniValue op(UniValue::VOBJ);
-        op.push_back(Pair("hash", proposal.hash.ToString()));
+        op.push_back(Pair("hash", prequest.hash.ToString()));
         op.push_back(Pair("proposalDesc", proposal.strDZeel));
         op.push_back(Pair("desc", prequest.strDZeel));
-        op.push_back(Pair("amount", (float)prequest.nAmount/COIN));
+        op.push_back(Pair("amount", ValueFromAmount(prequest.nAmount));
         op.push_back(Pair("yes", it->second.first));
         op.push_back(Pair("no", it->second.second));
         votesPaymentRequests.push_back(op);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -937,11 +937,8 @@ UniValue listproposals(const UniValue& params, bool fHelp)
     if(pblocktree->GetProposalIndex(vec))
     {
         BOOST_FOREACH(const CFund::CProposal& proposal, vec) {
-            if((showAll && (!proposal.IsExpired(pindexBestHeader->GetBlockTime())
-                            || proposal.fState == CFund::PENDING_VOTING_PREQ
-                            || proposal.fState == CFund::PENDING_FUNDS))
-               || (showPending  && (proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_VOTING_PREQ
-                                    || proposal.fState == CFund::PENDING_FUNDS))
+            if((showAll && !proposal.IsExpired(pindexBestHeader->GetBlockTime()))
+               || (showPending  &&  proposal.fState == CFund::NIL)
                || (showAccepted && (proposal.fState == CFund::ACCEPTED || proposal.IsAccepted()))
                || (showRejected && (proposal.fState == CFund::REJECTED || proposal.IsRejected()))
                || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime()))) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1062,7 +1062,7 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
         op.push_back(Pair("hash", prequest.hash.ToString()));
         op.push_back(Pair("proposalDesc", proposal.strDZeel));
         op.push_back(Pair("desc", prequest.strDZeel));
-        op.push_back(Pair("amount", ValueFromAmount(prequest.nAmount));
+        op.push_back(Pair("amount", ValueFromAmount(prequest.nAmount)));
         op.push_back(Pair("yes", it->second.first));
         op.push_back(Pair("no", it->second.second));
         votesPaymentRequests.push_back(op);


### PR DESCRIPTION
The ``cfundstats`` RPC command was incorrectly showing for payment requests the hash of its parent proposal instead of its own hash. 

This patch fixes this bug and also correctly shows the required amount from the voted proposals and payment requests.