### PR TITLE
fixes #388: cache cfund votes and add bench log

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3871,7 +3871,7 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
 
     std::map<uint256, bool> vSeen;
 
-    if (fUndo || nBlocks == 1) {
+    if (fUndo || nBlocks == 1 || vCacheProposalsToUpdate.empty() || vCachePaymentRequestToUpdate.empty()) {
         vCacheProposalsToUpdate.clear();
         vCachePaymentRequestToUpdate.clear();
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3858,6 +3858,9 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     return true;
 }
 
+std::map<uint256, std::pair<int, int>> vCacheProposalsToUpdate;
+std::map<uint256, std::pair<int, int>> vCachePaymentRequestToUpdate;
+
 void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
 {
     int64_t nTimeStart = GetTimeMicros();
@@ -3866,13 +3869,16 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
     int nBlocks = (pindexNew->nHeight % Params().GetConsensus().nBlocksPerVotingCycle) + 1;
     CBlockIndex* pindexblock = pindexNew;
 
-    std::map<uint256, std::pair<int, int>> vCacheProposalsToUpdate;
-    std::map<uint256, std::pair<int, int>> vCachePaymentRequestToUpdate;
     std::map<uint256, bool> vSeen;
 
-    vCacheProposalsToUpdate.clear();
-    vCachePaymentRequestToUpdate.clear();
+    if (fUndo || nBlocks == 1) {
+        vCacheProposalsToUpdate.clear();
+        vCachePaymentRequestToUpdate.clear();
+    } else {
+        nBlocks = 1;
+    }
 
+    int64_t nTimeStart2 = GetTimeMicros();
     while(nBlocks > 0 && pindexblock != NULL) {
         vSeen.clear();
         for(unsigned int i = 0; i < pindexblock->vProposalVotes.size(); i++) {
@@ -3911,9 +3917,13 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
         pindexblock = pindexblock->pprev;
         nBlocks--;
     }
+    int64_t nTimeEnd2 = GetTimeMicros();
+    LogPrint("bench-cfund", "  - CFund count votes from headers: %.2fms\n", (nTimeEnd2 - nTimeStart2) * 0.001);
+
 
     vSeen.clear();
 
+    int64_t nTimeStart3 = GetTimeMicros();
     std::map<uint256, std::pair<int, int>>::iterator it;
     std::vector<std::pair<uint256, CFund::CProposal>> vecProposalsToUpdate;
     std::vector<std::pair<uint256, CFund::CPaymentRequest>> vecPaymentRequestsToUpdate;
@@ -3941,9 +3951,12 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
     if (!pblocktree->UpdateProposalIndex(vecProposalsToUpdate)) {
         AbortNode(state, "Failed to write proposal index");
     }
+    int64_t nTimeEnd3 = GetTimeMicros();
+    LogPrint("bench-cfund", "  - CFund update votes: %.2fms\n", (nTimeEnd3 - nTimeStart3) * 0.001);
 
     std::vector<CFund::CPaymentRequest> vecPaymentRequest;
 
+    int64_t nTimeStart4 = GetTimeMicros();
     if(pblocktree->GetPaymentRequestIndex(vecPaymentRequest)){
         for(unsigned int i = 0; i < vecPaymentRequest.size(); i++) {
             vecPaymentRequestsToUpdate.clear();
@@ -4026,9 +4039,12 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
     } else {
         AbortNode(state, "Failed to read payment request index, please restart with -reindex-chainstate");
     }
+    int64_t nTimeEnd4 = GetTimeMicros();
+    LogPrint("bench-cfund", "  - CFund update payment request status: %.2fms\n", (nTimeEnd4 - nTimeStart4) * 0.001);
 
     std::vector<CFund::CProposal> vecProposal;
 
+    int64_t nTimeStart5 = GetTimeMicros();
     if(pblocktree->GetProposalIndex(vecProposal)){
         for(unsigned int i = 0; i < vecProposal.size(); i++) {
             bool fUpdate = false;
@@ -4116,6 +4132,9 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
     } else {
         AbortNode(state, "Failed to read proposal index, please restart with -reindex-chainstate");
     }
+    int64_t nTimeEnd5 = GetTimeMicros();
+
+    LogPrint("bench-cfund", "  - CFund update proposal status: %.2fms\n", (nTimeEnd5 - nTimeStart5) * 0.001);
 
     if (!pblocktree->UpdatePaymentRequestIndex(vecPaymentRequestsToUpdate)) {
         AbortNode(state, "Failed to write payment request index");
@@ -4126,7 +4145,7 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
     }
 
     int64_t nTimeEnd = GetTimeMicros();
-    LogPrint("bench", "- CFund count votes: %.2fms\n", (nTimeEnd - nTimeStart) * 0.001);
+    LogPrint("bench", "- CFund total CountVotes() function: %.2fms\n", (nTimeEnd - nTimeStart) * 0.001);
 }
 
 /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -965,47 +965,50 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
             + HelpExampleRpc("cfundstats", "")
         );
 
-    int nBlocks = (pindexBestHeader->nHeight % Params().GetConsensus().nBlocksPerVotingCycle);
-    CBlockIndex* pindexblock = pindexBestHeader;
+    CFund::CProposal proposal; CFund::CPaymentRequest prequest;
 
-    std::map<uint256, std::pair<int, int>> vCacheProposals;
-    std::map<uint256, std::pair<int, int>> vCachePaymentRequest;
+    int nBlocks = (chainActive.Tip()->nHeight % Params().GetConsensus().nBlocksPerVotingCycle) + 1;
+    CBlockIndex* pindexblock = chainActive.Tip();
+
+    std::map<uint256, bool> vSeen;
+    std::map<uint256, std::pair<int, int>> vCacheProposalsRPC;
+    std::map<uint256, std::pair<int, int>> vCachePaymentRequestRPC;
+
+    vCacheProposalsRPC.clear();
+    vCachePaymentRequestRPC.clear();
 
     while(nBlocks > 0 && pindexblock != NULL) {
-        std::map<uint256, bool> vSeen;
+        vSeen.clear();
         for(unsigned int i = 0; i < pindexblock->vProposalVotes.size(); i++) {
-            CFund::CProposal proposal;
             if(!CFund::FindProposal(pindexblock->vProposalVotes[i].first, proposal))
                 continue;
             if(vSeen.count(pindexblock->vProposalVotes[i].first) == 0) {
-                if(vCacheProposals.count(pindexblock->vProposalVotes[i].first) == 0)
-                    vCacheProposals[pindexblock->vProposalVotes[i].first] = make_pair(0, 0);
+                if(vCacheProposalsRPC.count(pindexblock->vProposalVotes[i].first) == 0)
+                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first] = make_pair(0, 0);
                 if(pindexblock->vProposalVotes[i].second)
-                    vCacheProposals[pindexblock->vProposalVotes[i].first].first += 1;
+                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first].first += 1;
                 else
-                    vCacheProposals[pindexblock->vProposalVotes[i].first].second += 1;
+                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first].second += 1;
                 vSeen[pindexblock->vProposalVotes[i].first]=true;
             }
         }
         for(unsigned int i = 0; i < pindexblock->vPaymentRequestVotes.size(); i++) {
-            CFund::CPaymentRequest prequest; CFund::CProposal proposal;
             if(!CFund::FindPaymentRequest(pindexblock->vPaymentRequestVotes[i].first, prequest))
                 continue;
             if(!CFund::FindProposal(prequest.proposalhash, proposal))
                 continue;
             if (mapBlockIndex.count(proposal.blockhash) == 0)
                 continue;
-
             CBlockIndex* pindexblockparent = mapBlockIndex[proposal.blockhash];
             if(pindexblockparent == NULL)
                 continue;
             if(vSeen.count(pindexblock->vPaymentRequestVotes[i].first) == 0) {
-                if(vCachePaymentRequest.count(pindexblock->vPaymentRequestVotes[i].first) == 0)
-                    vCachePaymentRequest[pindexblock->vPaymentRequestVotes[i].first] = make_pair(0, 0);
+                if(vCachePaymentRequestRPC.count(pindexblock->vPaymentRequestVotes[i].first) == 0)
+                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first] = make_pair(0, 0);
                 if(pindexblock->vPaymentRequestVotes[i].second)
-                    vCachePaymentRequest[pindexblock->vPaymentRequestVotes[i].first].first += 1;
+                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first].first += 1;
                 else
-                    vCachePaymentRequest[pindexblock->vPaymentRequestVotes[i].first].second += 1;
+                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first].second += 1;
                 vSeen[pindexblock->vPaymentRequestVotes[i].first]=true;
             }
         }
@@ -1043,7 +1046,7 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
     UniValue votesPaymentRequests(UniValue::VARR);
 
     std::map<uint256, std::pair<int, int>>::iterator it;
-    for(it = vCacheProposals.begin(); it != vCacheProposals.end(); it++) {
+    for(it = vCacheProposalsRPC.begin(); it != vCacheProposalsRPC.end(); it++) {
         CFund::CProposal proposal;
         if(!CFund::FindProposal(it->first, proposal))
             continue;
@@ -1055,7 +1058,7 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
         op.push_back(Pair("no", it->second.second));
         votesProposals.push_back(op);
     }
-    for(it = vCachePaymentRequest.begin(); it != vCachePaymentRequest.end(); it++) {
+    for(it = vCachePaymentRequestRPC.begin(); it != vCachePaymentRequestRPC.end(); it++) {
         CFund::CPaymentRequest prequest; CFund::CProposal proposal;
         if(!CFund::FindPaymentRequest(it->first, prequest))
             continue;


### PR DESCRIPTION
Solves #388.

Keeps a cache of the community fund votes to avoid an unnecessary recalculation per block which was causing extreme slow synchronization in the order of 0,25-0,3s per block.

After applying the patch the CountVotes() function takes an average of 32ms.