### PR TITLE
Restart testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -383,7 +383,7 @@ public:
         uint32_t nTimestamp = 1545341312;
         uint256 hashGenesisBlock = uint256S("0x0000a2ed763c6efc24bbb3ac8d9f1ab9e8f1e7100d5221ad80815cd7b369dc2c");
         uint256 hashMerkleRoot = uint256S("0x02128838f2516796eb04f5b3fd143a7786001301dc5ffcfd2b2c687a2864aae9");
-        uint32_t nNonce = 2043537527;
+        uint32_t nNonce = 2043585747;
 	    
         genesis = CreateGenesisBlockTestnet(nTimestamp, nNonce, 0x1d00ffff, 1, 0);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -264,7 +264,7 @@ public:
 static CMainParams mainParams;
 
 /**
- * Testnet (v3)
+ * Testnet (v4)
  */
 class CTestNetParams : public CChainParams {
 public:

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -264,7 +264,7 @@ public:
 static CMainParams mainParams;
 
 /**
- * Testnet (v4)
+ * Testnet (v3)
  */
 class CTestNetParams : public CChainParams {
 public:

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -381,8 +381,8 @@ public:
         bnProofOfWorkLimit = arith_uint256(~arith_uint256() >> 16);
     
         uint32_t nTimestamp = 1545341312;
-        uint256 hashGenesisBlock = uint256S("0x0000c493d0f928a9f0a0eb0e0d88d871f4f5ab8bacc308f77bb0e8c7adee1307");
-        uint256 hashMerkleRoot = uint256S("0xf3f3286d731fc322d34f6a7c4df3eecfc1abaa6032350acf6cd363eb34edf574");
+        uint256 hashGenesisBlock = uint256S("0x0000a2ed763c6efc24bbb3ac8d9f1ab9e8f1e7100d5221ad80815cd7b369dc2c");
+        uint256 hashMerkleRoot = uint256S("0x02128838f2516796eb04f5b3fd143a7786001301dc5ffcfd2b2c687a2864aae9");
         uint32_t nNonce = 2043537527;
 	    
         genesis = CreateGenesisBlockTestnet(nTimestamp, nNonce, 0x1d00ffff, 1, 0);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -380,7 +380,7 @@ public:
         nPruneAfterHeight = 1000;
         bnProofOfWorkLimit = arith_uint256(~arith_uint256() >> 16);
     
-        uint32_t nTimestamp = 1541978905;
+        uint32_t nTimestamp = 1545341312;
         uint256 hashGenesisBlock = uint256S("0x0000c493d0f928a9f0a0eb0e0d88d871f4f5ab8bacc308f77bb0e8c7adee1307");
         uint256 hashMerkleRoot = uint256S("0xf3f3286d731fc322d34f6a7c4df3eecfc1abaa6032350acf6cd363eb34edf574");
         uint32_t nNonce = 2043537527;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -47,7 +47,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 44445;
-        strDataDir = "testnet3";
+        strDataDir = "testnet4";
     }
 };
 static CBaseTestNetParams testNetParams;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -47,7 +47,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 44445;
-        strDataDir = "testnet4";
+        strDataDir = "testnet3";
     }
 };
 static CBaseTestNetParams testNetParams;


### PR DESCRIPTION
This patch creates a new testnet (v4).

Binaries with this patch can be found here: http://178.128.55.160/restart-testnet/