### PR TITLE
disable darkmode on Mojave

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -100,6 +100,9 @@
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
   
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>True</string>
+
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>


### PR DESCRIPTION
This patch fixes #403 by disabling dark mode in MacOS Mojave. @matt-auckland found the same issue at https://github.com/bitcoin/bitcoin/pull/14593 where the conclusion was to disable dark mode until Qt has further support for darkmode. The fix is taken from there.