### PR TITLE
RPC tests: Fix while loops of cfund tests causing random test fails

### DIFF
--- a/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
@@ -58,11 +58,12 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
         assert(self.nodes[0].getpaymentrequest(paymentrequestid0)["status"] == "pending")
         assert(self.nodes[0].cfundstats()["funds"]["locked"] == locked_accepted)
 
-        # Wait for the proposal to expire
-        while int(time.time()) <= int(self.nodes[0].getproposal(proposalid0)["expiresOn"]):
-            time.sleep(1)
-
         blocks=slow_gen(self.nodes[0], 1)
+
+        # Wait for the proposal to expire
+        while int(self.nodes[0].getblock(blocks[0])["time"]) <= int(self.nodes[0].getproposal(proposalid0)["expiresOn"]):
+            blocks=slow_gen(self.nodes[0], 1)
+            time.sleep(1)
 
         assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired waiting for end of voting period")
 

--- a/qa/rpc-tests/cfund-proposal-state-accept.py
+++ b/qa/rpc-tests/cfund-proposal-state-accept.py
@@ -154,11 +154,12 @@ class CommunityFundProposalStateTest(NavCoinTestFramework):
         self.nodes[0].invalidateblock(blocks[-1])
         assert(self.nodes[0].getproposal(proposalid0)["votingCycle"] == votingCycle_after_state_change)
 
-        # Wait for the proposal to expire
-        while int(time.time()) <= int(self.nodes[0].getproposal(proposalid0)["expiresOn"]):
-            time.sleep(1)
-
         blocks=slow_gen(self.nodes[0], 1)
+
+        # Wait for the proposal to expire
+        while int(self.nodes[0].getblock(blocks[0])["time"]) <= int(self.nodes[0].getproposal(proposalid0)["expiresOn"]):
+            blocks=slow_gen(self.nodes[0], 1)
+            time.sleep(1)
 
         assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired waiting for end of voting period")
 


### PR DESCRIPTION
The while loops in these tests are designed to wait until a proposal is expired. However previously, these two tests would fail randomly at the assert immediately following the while loop. 

`time.time()` returns values inconsistent with the block times of the test blockchain, recorded in `nTime` of each block, sometimes by up to 100s. 

The purpose of the test is not to compare `time.time()` but to test whether a block with `nTime` exceeding a proposal's deadline will be correctly marked as expired. Hence the while loop has been revised to reflect this.

The running time of these tests is also reduced.

Fixes two tests in #416.