### PR TITLE
RPC tests: fixes merkle_blocks.py to exclude 1st coinbase

### DIFF
--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -41,7 +41,7 @@ class MerkleBlockTest(NavCoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        node0utxos = self.nodes[0].listunspent(1, 104)
+        node0utxos = self.nodes[0].listunspent(1, 104) // We generated 105 blocks so we are excluding the first block which contains 59 mill~ NAV
         tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
         txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
         tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -41,7 +41,7 @@ class MerkleBlockTest(NavCoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        node0utxos = self.nodes[0].listunspent(1)
+        node0utxos = self.nodes[0].listunspent(1, 104)
         tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
         txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
         tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})


### PR DESCRIPTION
Fixes one of the tests in #416.

merkle_blocks.py fails randomly on Travis (see https://travis-ci.org/NAVCoin/navcoin-core/jobs/493122877) due to "absurdly-high-fee" error here:

```
        node0utxos = self.nodes[0].listunspent(1)
        tx1 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
        txid1 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransaction(tx1)["hex"])
```
`node0utxos` is a list of 55 unspent coinbase outputs from generating 55 blocks in the test environment, which are mostly 50 NAV each. However, the first coinbase is 59,800,000 NAV and if this is popped from the list, it will cause a fee error. 

Setting maximum confirmations to `listunspent()` will avoid the 1st coinbase.