### PR TITLE
fix cold staking report

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3165,10 +3165,10 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
         nElement++;
 
         // use the cached amount if available
-        if (pcoin->fCreditCached && pcoin->fDebitCached)
+        if ((pcoin->fCreditCached || pcoin->fColdStakingCreditCached) && (pcoin->fDebitCached || pcoin->fColdStakingDebitCached))
             nAmount = pcoin->nCreditCached  + pcoin->nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
         else
-            nAmount = pcoin->GetCredit(ISMINE_SPENDABLE_STAKABLE) - pcoin->GetDebit(ISMINE_SPENDABLE_STAKABLE);
+            nAmount = pcoin->GetCredit(ISMINE_SPENDABLE) + pcoin->GetCredit(ISMINE_STAKABLE) - pcoin->GetDebit(ISMINE_SPENDABLE) - pcoin->GetDebit(ISMINE_STAKABLE);
 
 
         // scan the range

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3166,7 +3166,7 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
 
         // use the cached amount if available
         if (pcoin->fCreditCached && pcoin->fDebitCached)
-            nAmount = pcoin->nCreditCached  + nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
+            nAmount = pcoin->nCreditCached  + pcoin->nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
         else
             nAmount = pcoin->GetCredit(ISMINE_SPENDABLE_STAKABLE) - pcoin->GetDebit(ISMINE_SPENDABLE_STAKABLE);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3166,9 +3166,9 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
 
         // use the cached amount if available
         if (pcoin->fCreditCached && pcoin->fDebitCached)
-            nAmount = pcoin->nCreditCached - pcoin->nDebitCached;
+            nAmount = pcoin->nCreditCached  + nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
         else
-            nAmount = pcoin->GetCredit(ISMINE_SPENDABLE) - pcoin->GetDebit(ISMINE_SPENDABLE);
+            nAmount = pcoin->GetCredit(ISMINE_SPENDABLE_STAKABLE) - pcoin->GetDebit(ISMINE_SPENDABLE_STAKABLE);
 
 
         // scan the range


### PR DESCRIPTION
This PR fixes a bug where the cold staking coins were not correctly accounted in the output of the RPC command `getstakereport` or the report shown on the GUI Main tab.