### PR TITLE
Disables spam protection while IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7472,7 +7472,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
         }
 
-        if(GetBoolArg("-headerspamfilter", DEFAULT_HEADER_SPAM_FILTER))
+        if(GetBoolArg("-headerspamfilter", DEFAULT_HEADER_SPAM_FILTER) && !IsInitialBlockDownload())
         {
             LOCK(cs_main);
             CValidationState state;


### PR DESCRIPTION
This PR disables the header spam protection while initial block download, as it could cause false positives.