### PR TITLE
Simplification of SyncTransaction

### DIFF
--- a/doc/release-notes/release-notes-4.6.0.md
+++ b/doc/release-notes/release-notes-4.6.0.md
@@ -30,6 +30,10 @@ This PR adds a new RPC command to export the existing master private key encoded
 `dumpmnemonic` It admits an argument specifying the language.
 Support for two new wallet options (`-importmnemonic` and `-mnemoniclanguage`) have also been added to allow to create a new wallet from the specified mnemonic.
 
+## Fix wrong balance after orphan stakes
+<[Pull Request 438](https://github.com/NAVCoin/navcoin-core/pull/438)>
+This PR fixes an historical issue which made the wallet show a wrong balance after orphan stakes.
+
 ## Other updates to the NavCoin client, docs and codebase
 
 - Update FreeType depend file to 2.7.1 <[Pull Request 433](https://github.com/NAVCoin/navcoin-core/pull/433)> <[Commit 6025758](60257582df85c07b794ceb186e2289eada4d3832)>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2033,8 +2033,14 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
       log(pindexNew->nChainWork.getdouble())/log(2.0), DateTimeStrFormat("%Y-%m-%d %H:%M:%S",
       pindexNew->GetBlockTime()));
+    CBlock block;
     CBlockIndex *tip = chainActive.Tip();
     assert (tip);
+    if (ReadBlockFromDisk(block, pindexNew, chainparams.GetConsensus())) {
+        BOOST_FOREACH(const CTransaction &tx, block.vtx) {
+            SyncWithWallets(tx, tip, NULL, false);
+        }
+    }
     LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
       tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", tip->GetBlockTime()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2036,7 +2036,7 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     CBlock block;
     CBlockIndex *tip = chainActive.Tip();
     assert (tip);
-    if (ReadBlockFromDisk(block, pindexNew, chainparams.GetConsensus())) {
+    if (ReadBlockFromDisk(block, pindexNew, Params().GetConsensus())) {
         BOOST_FOREACH(const CTransaction &tx, block.vtx) {
             SyncWithWallets(tx, tip, NULL, false);
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1021,7 +1021,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
         std::map<uint256, CWalletTx>::const_iterator mit = mapWallet.find(wtxid);
         if (mit != mapWallet.end()) {
             int depth = mit->second.GetDepthInMainChain();
-            if (depth > 0  || (depth == 0 && !mit->second.isAbandoned()))
+            if (depth > 0  || (depth == 0 && !mit->second.isAbandoned() && !mit->second.IsCoinStake()))
                 return true; // Spent
         }
     }


### PR DESCRIPTION
Prevents a bug where stake inputs are not correctly marked as spent/unspent when a stake happens/orphans requiring to restart or repair the wallet to show the correct balance.