### PR TITLE
Community Fund GUI date buffer increase

### DIFF
--- a/src/qt/communityfunddisplaydetailed.cpp
+++ b/src/qt/communityfunddisplaydetailed.cpp
@@ -109,7 +109,7 @@ void CommunityFundDisplayDetailed::setProposalLabels() const
         std::string expiry_title = "Rejected on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
             ss << buf;
         ui->labelExpiresInTitle->setText(QString::fromStdString(expiry_title));
@@ -120,7 +120,7 @@ void CommunityFundDisplayDetailed::setProposalLabels() const
             std::string expiry_title = "Expired on: ";
             std::time_t t = static_cast<time_t>(proptime);
             std::stringstream ss;
-            char buf[24];
+            char buf[48];
             if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
                 ss << buf;
             ui->labelExpiresInTitle->setText(QString::fromStdString(expiry_title));

--- a/src/qt/communityfunddisplaypaymentrequest.cpp
+++ b/src/qt/communityfunddisplaypaymentrequest.cpp
@@ -81,7 +81,7 @@ void CommunityFundDisplayPaymentRequest::refresh()
         std::string duration_title = "Accepted on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
             ss << buf;
         ui->labelTitleDuration->setText(QString::fromStdString(duration_title));
@@ -103,7 +103,7 @@ void CommunityFundDisplayPaymentRequest::refresh()
         std::string expiry_title = "Rejected on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
             ss << buf;
         ui->labelTitleDuration->setText(QString::fromStdString(expiry_title));
@@ -118,7 +118,7 @@ void CommunityFundDisplayPaymentRequest::refresh()
             std::string expiry_title = "Expired on: ";
             std::time_t t = static_cast<time_t>(proptime);
             std::stringstream ss;
-            char buf[24];
+            char buf[48];
             if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
                 ss << buf;
             ui->labelTitleDuration->setText(QString::fromStdString(expiry_title));

--- a/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
+++ b/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
@@ -125,7 +125,7 @@ void CommunityFundDisplayPaymentRequestDetailed::setPrequestLabels() const
         std::string duration_title = "Accepted on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
             ss << buf;
         ui->labelPrequestExpiryTitle->setText(QString::fromStdString(duration_title));
@@ -137,7 +137,7 @@ void CommunityFundDisplayPaymentRequestDetailed::setPrequestLabels() const
         std::string expiry_title = "Rejected on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
             ss << buf;
         ui->labelPrequestExpiryTitle->setText(QString::fromStdString(expiry_title));
@@ -150,7 +150,7 @@ void CommunityFundDisplayPaymentRequestDetailed::setPrequestLabels() const
             std::string expiry_title = "Expired on: ";
             std::time_t t = static_cast<time_t>(proptime);
             std::stringstream ss;
-            char buf[24];
+            char buf[48];
             if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
                 ss << buf;
             ui->labelPrequestExpiryTitle->setText(QString::fromStdString(expiry_title));


### PR DESCRIPTION
This PR includes a fix for a bug which caused a wallet to crash when loading the community fund graphical interface using the 'All' filter.