### PR TITLE
This PR is a combined fix for issues #445 and #446

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -167,6 +167,7 @@ testScripts = [
     'cfund-paymentrequestvotelist.py',
     'reject-version-bit.py',
     'getcoldstakingaddress.py',
+    'getstakereport.py',
     'coldstaking_staking.py',
     'coldstaking_spending.py',
     'staticr-staking-amount.py',

--- a/qa/rpc-tests/coldstaking_spending.py
+++ b/qa/rpc-tests/coldstaking_spending.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-# copyright (c) 2018 the navcoin core developers
-# distributed under the mit software license, see the accompanying
-# file copying or http://www.opensource.org/licenses/mit-license.php.
+# Copyright (c) 2018 The Navcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 import decimal
 from test_framework.test_framework import NavCoinTestFramework
-from test_framework.util import *
+from test_framework.staticr_util import *
+
 class ColdStakingSpending(NavCoinTestFramework):
     """Tests spending and staking to/from a spending wallet."""
     # set up num of nodes
@@ -20,23 +22,12 @@ class ColdStakingSpending(NavCoinTestFramework):
     def run_test(self):
         self.nodes[0].staking(False)
 
-        """generate first 300 blocks to lock in softfork, verify coldstaking is active"""
-
-        slow_gen(self.nodes[0], 100)     
-        # verify that cold staking has started
-        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["coldstaking"]["status"] == "started")
-        slow_gen(self.nodes[0], 100)
-        # verify that cold staking is locked_in
-        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["coldstaking"]["status"] == "locked_in")
-        slow_gen(self.nodes[0], 100)
-        # verify that cold staking is active
-        assert(self.nodes[0].getblockchaininfo()["bip9_softforks"]["coldstaking"]["status"] == "active")
-
-        """set up transaction-related constants and addresses"""
+        # Make it to the static rewards fork!
+        activate_staticr(self.nodes[0])
 
         # declare transaction-related constants
         SENDING_FEE= 0.00010000
-        MIN_COLDSTAKING_SENDING_FEE = 0.0028850
+        MIN_COLDSTAKING_SENDING_FEE = 0.0033947
         BLOCK_REWARD = 50
         # generate address owned by the wallet
         spending_address_public_key = self.nodes[0].getnewaddress()
@@ -55,7 +46,7 @@ class ColdStakingSpending(NavCoinTestFramework):
         balance_before_send = self.nodes[0].getbalance()
         staking_weight_before_send = self.nodes[0].getstakinginfo()["weight"]
         # check wallet staking weight roughly equals wallet balance
-        assert(round(staking_weight_before_send / 100000000.0, -5) == round(balance_before_send, -5))
+        assert_equal(round(staking_weight_before_send / 100000000.0, -5), round(balance_before_send, -5))
 
         """send navcoin to our coldstaking address, grab balance & staking weight"""
 
@@ -70,22 +61,22 @@ class ColdStakingSpending(NavCoinTestFramework):
         assert(len(listunspent_txs) > 0)
         # asserts that the number of utxo recieved is only 1:
         assert(len(listunspent_txs) == 1)
-        # asserts if amount recieved is what it should be; ~59812449.99711600 NAV
-        assert(listunspent_txs[0]["amount"] <= Decimal('59812449.99711600'))
+        # asserts if amount recieved is what it should be; ~59814699.99660530 NAV
+        assert_equal(listunspent_txs[0]["amount"], Decimal('59814699.99660530'))
         # grabs updated wallet balance and staking weight
         balance_post_send_one = self.nodes[0].getbalance()
         staking_weight_post_send = self.nodes[0].getstakinginfo()["weight"]
 
         """check balance decreased by just the fees"""
-        
+
         # difference between balance after sending and previous balance is the same when block reward is removed
-        # values are converted to string and "00" is added to right of == operand because values must have equal num of 
+        # values are converted to string and "00" is added to right of == operand because values must have equal num of
         # decimals
         assert(str(balance_post_send_one - BLOCK_REWARD) <= (str(float(balance_before_send) - MIN_COLDSTAKING_SENDING_FEE) + "00"))
-        
+
         """check staking weight now == 0 (we don't hold the staking key)"""
-        
-        # sent ~all funds to coldstaking address where we do not own the staking key hence our 
+
+        # sent ~all funds to coldstaking address where we do not own the staking key hence our
         # staking weight will be 0 as our recieved BLOCK_REWARD navcoin isn't mature enough to count towards
         # our staking weight
         assert((staking_weight_post_send / 100000000.0) - BLOCK_REWARD <= 1)
@@ -98,10 +89,10 @@ class ColdStakingSpending(NavCoinTestFramework):
         to_be_sent = round(float(balance_post_send_one) * float(0.5) - SENDING_FEE, 8)
         self.nodes[0].sendtoaddress(address_Y_public_key, (to_be_sent))
         # put transaction in new block & update blockchain
-        slow_gen(self.nodes[0], 1)  
+        slow_gen(self.nodes[0], 1)
         # wallet balance after sending
         balance_post_send_two = self.nodes[0].getbalance()
-        #check balance will not be less than ~half our balance before sending - this 
+        #check balance will not be less than ~half our balance before sending - this
         # will occurs if we send to an address we do not own
         assert(balance_post_send_two - BLOCK_REWARD >= (float(balance_post_send_one) * float(0.5) - SENDING_FEE))
 
@@ -111,7 +102,7 @@ class ColdStakingSpending(NavCoinTestFramework):
         self.nodes[0].sendtoaddress(coldstaking_address_spending, round(float(balance_post_send_two) - SENDING_FEE, 8))
         slow_gen(self.nodes[0], 1)
         listunspent_txs = [n for n in self.nodes[0].listunspent() if n["address"] == coldstaking_address_spending]
-        # send funds to a third party address using a signed raw transaction    
+        # send funds to a third party address using a signed raw transaction
         # get unspent tx inputs
         self.send_raw_transaction(decoded_raw_transaction = listunspent_txs[0], \
         to_address = address_Y_public_key, \
@@ -120,7 +111,7 @@ class ColdStakingSpending(NavCoinTestFramework):
         )
         # put transaction in new block & update blockchain
         slow_gen(self.nodes[0], 1)
-        # get new balance  
+        # get new balance
         balance_post_send_three = self.nodes[0].getbalance()
         # we expect our balance to be zero
         assert(balance_post_send_three - (BLOCK_REWARD * 2) == 0)
@@ -138,13 +129,13 @@ class ColdStakingSpending(NavCoinTestFramework):
             self.nodes[0].sendtoaddress(spending_address_public_key, float(current_balance) * 0.5 - 1)
             slow_gen(self.nodes[0], 1)
             # our balance should be the same minus fees, as we own the address we sent to
-            assert(self.nodes[0].getbalance() >= current_balance - 1 + BLOCK_REWARD) 
+            assert(self.nodes[0].getbalance() >= current_balance - 1 + BLOCK_REWARD)
             send_worked = True
         except Exception as e:
             print(e)
 
         assert(send_worked == True)
-        
+
         slow_gen(self.nodes[0], 1)
 
         # send to our staking address
@@ -155,11 +146,11 @@ class ColdStakingSpending(NavCoinTestFramework):
             self.nodes[0].sendtoaddress(staking_address_public_key, float(self.nodes[0].getbalance()) * 0.5 - 1)
             slow_gen(self.nodes[0], 1)
             # our balance should be half minus fees, as we dont own the address we sent to
-            assert(self.nodes[0].getbalance() - BLOCK_REWARD <= float(current_balance) * 0.5 - 1 + 2) 
+            assert(self.nodes[0].getbalance() - BLOCK_REWARD <= float(current_balance) * 0.5 - 1 + 2)
             send_worked = True
         except Exception as e:
             print(e)
-            
+
         assert(send_worked == True)
 
     def send_raw_transaction(self, decoded_raw_transaction, to_address, change_address, amount):
@@ -172,7 +163,7 @@ class ColdStakingSpending(NavCoinTestFramework):
         assert(signresult["complete"])
         # send raw transaction
         return self.nodes[0].sendrawtransaction(signresult['hex'])
-        
+
 
 if __name__ == '__main__':
     ColdStakingSpending().main()

--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -31,7 +31,6 @@ class GetStakeReport(NavCoinTestFramework):
 
         # Make it to the static rewards fork!
         activate_staticr(self.nodes[0])
-        self.sync_all()
 
         # Use THE spending address
         spending_address_public_key = self.nodes[1].getnewaddress()
@@ -74,12 +73,9 @@ class GetStakeReport(NavCoinTestFramework):
         # So that means spending last 24h == 2
         # And staking last 24h == 0 We have not sent any coins yet
         # And merged will have the total of the spending + staking
-        assert('2.00' == merged_address_last_24h)
-        assert('2.00' == spending_address_last_24h)
-        assert('0.00' == staking_address_last_24h)
-
-        # Tun of staking for this node now
-        self.nodes[1].staking(False)
+        assert_equal('2.00', merged_address_last_24h)
+        assert_equal('2.00', spending_address_last_24h)
+        assert_equal('0.00', staking_address_last_24h)
 
         # Send funds to the cold staking address (leave some NAV for fees)
         self.nodes[1].sendtoaddress(coldstaking_address_staking, self.nodes[1].getbalance() - 1)
@@ -107,9 +103,9 @@ class GetStakeReport(NavCoinTestFramework):
         # So that means spending last 24h == 4
         # And staking last 24h == 2 We stake 2 NAV via COLD already
         # And merged will have the total of the spending + staking
-        assert('4.00' == merged_address_last_24h)
-        assert('4.00' == spending_address_last_24h)
-        assert('2.00' == staking_address_last_24h)
+        assert_equal('4.00', merged_address_last_24h)
+        assert_equal('4.00', spending_address_last_24h)
+        assert_equal('2.00', staking_address_last_24h)
 
     def stake_block(self, node):
         # Get the current block count to check against while we wait for a stake

--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -31,6 +31,7 @@ class GetStakeReport(NavCoinTestFramework):
 
         # Make it to the static rewards fork!
         activate_staticr(self.nodes[0])
+        self.sync_all()
 
         # Use THE spending address
         spending_address_public_key = self.nodes[1].getnewaddress()
@@ -120,7 +121,7 @@ class GetStakeReport(NavCoinTestFramework):
         # print("found a new block...")
 
         # Make sure the blocks are mature before we check the report
-        slow_gen(self.nodes[0], 5, 0.5)
+        slow_gen(node, 5, 0.5)
         self.sync_all()
 
 

--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Navcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import NavCoinTestFramework
+from test_framework.staticr_util import *
+
+#import time
+
+class GetStakeReport(NavCoinTestFramework):
+    """Tests getstakereport accounting."""
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def setup_network(self, split=False):
+        self.nodes = self.setup_nodes()
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[2], 0)
+        self.is_network_split = False
+
+    def run_test(self):
+        # No staking for the main node (Bad Boy)
+        self.nodes[0].staking(False)
+
+        # Make it to the static rewards fork!
+        activate_staticr(self.nodes[0])
+        self.sync_all()
+
+        # Use THE spending address
+        spending_address_public_key = self.nodes[1].getnewaddress()
+        spending_address_private_key = self.nodes[1].dumpprivkey(spending_address_public_key)
+
+        # Create a staking address
+        staking_address_public_key = self.nodes[2].getnewaddress()
+        staking_address_private_key = self.nodes[2].dumpprivkey(staking_address_public_key)
+
+        # Import the 2 keys into a third wallet
+        self.nodes[0].importprivkey(spending_address_private_key)
+        self.nodes[0].importprivkey(staking_address_private_key)
+
+        # Create the cold address
+        coldstaking_address_staking = self.nodes[1].getcoldstakingaddress(staking_address_public_key, spending_address_public_key)
+
+        # Send funds to the spending address (leave some NAV for fees)
+        self.nodes[0].sendtoaddress(spending_address_public_key, self.nodes[0].getbalance() - 1)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Stake a block
+        self.stake_block(self.nodes[1])
+
+        # Load the last 24h stake amount for the wallets/nodes
+        spending_address_last_24h = self.nodes[1].getstakereport()['Last 24H']
+        staking_address_last_24h = self.nodes[2].getstakereport()['Last 24H']
+        merged_address_last_24h = self.nodes[0].getstakereport()['Last 24H']
+        # print('spending', spending_address_last_24h)
+        # print('staking', staking_address_last_24h)
+        # print('merged', merged_address_last_24h)
+
+        # Make sure we have staked 2 NAV to the spending address
+        # So that means spending last 24h == 2
+        # And staking last 24h == 0 We have not sent any coins yet
+        # And merged will have the total of the spending + staking
+        assert('2.00' == spending_address_last_24h)
+        assert('0.00' == staking_address_last_24h)
+        assert('2.00' == merged_address_last_24h)
+
+        # Send funds to the cold staking address (leave some NAV for fees)
+        self.nodes[1].sendtoaddress(coldstaking_address_staking, self.nodes[1].getbalance() - 1)
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        # Stake a block
+        self.stake_block(self.nodes[2])
+
+        # Load the last 24h stake amount for the wallets/nodes
+        spending_address_last_24h = self.nodes[1].getstakereport()['Last 24H']
+        staking_address_last_24h = self.nodes[2].getstakereport()['Last 24H']
+        merged_address_last_24h = self.nodes[0].getstakereport()['Last 24H']
+        # print('spending', spending_address_last_24h)
+        # print('staking', staking_address_last_24h)
+        # print('merged', merged_address_last_24h)
+
+        # Make sure we staked 4 NAV in spending address (2 NAV via COLD Stake)
+        # So that means spending last 24h == 4
+        # And staking last 24h == 2 We stake 2 NAV via COLD already
+        # And merged will have the total of the spending + staking
+        assert('4.00' == spending_address_last_24h)
+        assert('2.00' == staking_address_last_24h)
+        assert('4.00' == merged_address_last_24h)
+
+    def stake_block(self, node):
+        # Get the current block count to check against while we wait for a stake
+        blockcount = node.getblockcount()
+
+        # wait for a new block to be mined
+        while node.getblockcount() == blockcount:
+            # print("waiting for a new block...")
+            time.sleep(1)
+
+        # We got one
+        # print("found a new block...")
+
+        # Make sure the blocks are mature before we check the report
+        slow_gen(self.nodes[0], 50)
+        self.sync_all()
+
+
+if __name__ == '__main__':
+    GetStakeReport().main()

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -32,33 +32,33 @@ class MempoolSpendCoinbaseTest(NavCoinTestFramework):
         self.is_network_split = False
 
     def run_test(self):
-        slow_gen(self.nodes[0], 200)
+        slow_gen(self.nodes[0], 10)
         chain_height = self.nodes[0].getblockcount()
-        assert_equal(chain_height, 200)
+        assert_equal(chain_height, 10)
         node0_address = self.nodes[0].getnewaddress()
 
-        # Coinbase at height chain_height-150+1 ok in mempool, should
-        # get mined. Coinbase at height chain_height-150+2 is
+        # Coinbase at height chain_height-5+1 ok in mempool, should
+        # get mined. Coinbase at height chain_height-5+2 is
         # is too immature to spend.
-        b = [ self.nodes[0].getblockhash(n) for n in range(151, 153) ]
+        b = [ self.nodes[0].getblockhash(n) for n in range(6, 8) ]
         coinbase_txids = [ self.nodes[0].getblock(h)['tx'][0] for h in b ]
         spends_raw = [ create_tx(self.nodes[0], txid, node0_address, 49.99) for txid in coinbase_txids ]
 
-        spend_151_id = self.nodes[0].sendrawtransaction(spends_raw[0])
+        spend_6_id = self.nodes[0].sendrawtransaction(spends_raw[0])
 
-        # coinbase at height 152 should be too immature to spend
+        # coinbase at height 7 should be too immature to spend
         assert_raises(JSONRPCException, self.nodes[0].sendrawtransaction, spends_raw[1])
 
-        # mempool should have just spend_151:
-        assert_equal(self.nodes[0].getrawmempool(), [ spend_151_id ])
+        # mempool should have just spend_6:
+        assert_equal(self.nodes[0].getrawmempool(), [ spend_6_id ])
 
         # mine a block, spend_151 should get confirmed
         slow_gen(self.nodes[0], 1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
-        # ... and now height 152 can be spent:
-        spend_152_id = self.nodes[0].sendrawtransaction(spends_raw[1])
-        assert_equal(self.nodes[0].getrawmempool(), [ spend_152_id ])
+        # ... and now height 7 can be spent:
+        spend_7_id = self.nodes[0].sendrawtransaction(spends_raw[1])
+        assert_equal(self.nodes[0].getrawmempool(), [ spend_7_id ])
 
 if __name__ == '__main__':
     MempoolSpendCoinbaseTest().main()

--- a/qa/rpc-tests/sendtoaddress.py
+++ b/qa/rpc-tests/sendtoaddress.py
@@ -35,13 +35,13 @@ class SendToAddressTest (NavCoinTestFramework):
         slow_gen(self.nodes[0], 1)
         time.sleep(2)
         self.sync_all()
-        slow_gen(self.nodes[1], 75)
+        slow_gen(self.nodes[1], 30)
         self.sync_all()
-        
+
         # Assert correct amount of NAV generated
         assert_equal(self.nodes[0].getbalance(), 59800000)
         assert_equal(self.nodes[1].getbalance(), 1250)
-        
+
         # Make transactions to valid addresses
         txid0 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 60)
         txid1 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10.0"))

--- a/qa/rpc-tests/stakeimmaturebalance.py
+++ b/qa/rpc-tests/stakeimmaturebalance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from test_framework.test_framework import NavCoinTestFramework
-from test_framework.util import *
+from test_framework.staticr_util import *
 import logging
 
 '''
@@ -10,7 +10,7 @@ node0 has both confirmed and immature balance, it sends away its confirmed balan
 node0 checks that immature balance does not affect stake weight
 '''
 
-SENDING_FEE= 0.003
+SENDING_FEE= 0.003393
 BLOCK_REWARD = 50
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
@@ -28,7 +28,7 @@ class StakeImmatureBalance(NavCoinTestFramework):
 
     def run_test(self):
         addr = self.nodes[1].getnewaddress()
-        slow_gen(self.nodes[0], 300) #300 for soft fork voting
+        activate_staticr(self.nodes[0])
         self.nodes[0].sendtoaddress(addr, satoshi_round(float(self.nodes[0].getbalance()) - SENDING_FEE))
         slow_gen(self.nodes[0], 1)
         logging.info('Checking stake weight')

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -676,12 +676,12 @@ def get_bip9_status(node, key):
     return info['bip9_softforks'][key]
 
 
-def slow_gen(node, count):
+def slow_gen(node, count, sleep = 0.1):
     total = count
     blocks = []
     while total > 0:
         now = min(total, 10)
         blocks.extend(node.generate(now))
         total -= now
-        time.sleep(0.1)
+        time.sleep(sleep)
     return blocks

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -6,6 +6,8 @@
 from test_framework.test_framework import NavCoinTestFramework
 from test_framework.util import *
 
+BLOCK_REWARD = 50
+
 class WalletTest (NavCoinTestFramework):
 
     def __init__(self):
@@ -213,8 +215,8 @@ class WalletTest (NavCoinTestFramework):
         slow_gen(self.nodes[1], 1) #mine a block, tx should not be in there
         self.sync_all()
 
-        # We need to adjust the balance since a new block has been confirmd
-        node_2_bal += 50
+        # We need to adjust the balance since new block/s got confirmed
+        node_2_bal += BLOCK_REWARD
 
         assert_equal(self.nodes[2].getbalance(), node_2_bal) #should not be changed because tx was not broadcasted
 
@@ -223,9 +225,9 @@ class WalletTest (NavCoinTestFramework):
         slow_gen(self.nodes[1], 1)
         self.sync_all()
 
-        # We need to adjust the balance since a new block has been confirmd
+        # We need to adjust the balance since new block/s got confirmed
         # And we sent 2 NAV to it
-        node_2_bal += 52
+        node_2_bal += BLOCK_REWARD + 2
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
 
@@ -240,14 +242,14 @@ class WalletTest (NavCoinTestFramework):
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,2,0)
-        sync_blocks(self.nodes)
 
+        self.sync_all()
         slow_gen(self.nodes[0], 1)
         self.sync_all()
 
-        # We need to adjust the balance since 2 new blocks confirmed
+        # We need to adjust the balance since new block/s got confirmed
         # And we sent 2 NAV to it
-        node_2_bal += 102
+        node_2_bal += 2 * BLOCK_REWARD + 2
 
         #tx should be added to balance because after restarting the nodes tx should be broadcastet
         assert_equal(self.nodes[2].getbalance(), node_2_bal)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -42,7 +42,7 @@ class WalletTest (NavCoinTestFramework):
         assert_equal(walletinfo['balance'], 0)
 
         self.sync_all()
-        slow_gen(self.nodes[1], 101)
+        slow_gen(self.nodes[1], 56)
 
         self.sync_all()
 
@@ -75,8 +75,8 @@ class WalletTest (NavCoinTestFramework):
         self.nodes[2].lockunspent(True, [unspent_0])
         assert_equal(len(self.nodes[2].listlockunspent()), 0)
 
-        # Have node1 generate 100 blocks (so node0 can recover the fee)
-        slow_gen(self.nodes[1], 100)
+        # Have node1 generate 10 blocks (so node0 can recover the fee)
+        slow_gen(self.nodes[1], 10)
         self.sync_all()
 
         assert_equal(self.nodes[2].getbalance(), 21)
@@ -213,13 +213,20 @@ class WalletTest (NavCoinTestFramework):
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         slow_gen(self.nodes[1], 1) #mine a block, tx should not be in there
         self.sync_all()
+
+        # We need to adjust the balance since a new block has been confirmd
+        node_2_bal += 50
+
         assert_equal(self.nodes[2].getbalance(), node_2_bal) #should not be changed because tx was not broadcasted
 
         #now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(txObjNotBroadcasted['hex'])
         slow_gen(self.nodes[1], 1)
         self.sync_all()
-        node_2_bal += 2
+
+        # We need to adjust the balance since a new block has been confirmd
+        # And we sent 2 NAV to it
+        node_2_bal += 52
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
 
@@ -238,7 +245,10 @@ class WalletTest (NavCoinTestFramework):
 
         slow_gen(self.nodes[0], 1)
         sync_blocks(self.nodes)
-        node_2_bal += 2
+
+        # We need to adjust the balance since 2 new blocks have been confirmd
+        # And we sent 2 NAV to it
+        node_2_bal += 102
 
         #tx should be added to balance because after restarting the nodes tx should be broadcastet
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -266,14 +276,14 @@ class WalletTest (NavCoinTestFramework):
         else:
             raise AssertionError("Must not parse invalid amounts")
 
-            
-        my_function_failed = False    
+
+        my_function_failed = False
         try:
             self.nodes[0].generate("2")
             raise AssertionError("Must not accept strings as numeric")
         except JSONRPCException as e:
             my_function_failed = True
-         
+
         assert(my_function_failed)
 
         # Import address and private key to check correct behavior of spendable unspents

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -127,6 +127,9 @@ public:
         consensus.nHeightv451Fork = 2722100;
         consensus.nHeightv452Fork = 2882875;
 
+        /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+        consensus.nCoinbaseMaturity = 50;
+
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
@@ -319,6 +322,9 @@ public:
         consensus.nHeightv451Fork = 100000;
         consensus.nHeightv452Fork = 100000;
 
+        /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+        consensus.nCoinbaseMaturity = 50;
+
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
@@ -460,7 +466,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
         consensus.nStakeMinAge = 2;	// minimum for coin age: 2 seconds
-        consensus.nTargetSpacing = 30; // Blocktime: 30 secs
+        consensus.nTargetSpacing = 5; // Blocktime: 5 secs
         consensus.nStakeCombineThreshold = 1000 * COIN;
         consensus.nStakeSplitThreshold = 2 * consensus.nStakeCombineThreshold;
         consensus.nDailyBlockCount =  (24 * 60 * 60) / consensus.nTargetSpacing;
@@ -491,7 +497,10 @@ public:
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
 
-	// Deployment of BIP68, BIP112, and BIP113.
+        /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+        consensus.nCoinbaseMaturity = 5;
+
+        // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1651363200; // May 1st, 2022
@@ -672,6 +681,9 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
+
+        /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+        consensus.nCoinbaseMaturity = 50;
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -16,8 +16,6 @@ static const unsigned int MAX_BLOCK_WEIGHT = 8000000;
 static const unsigned int MAX_BLOCK_BASE_SIZE = 2000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
-/** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 50;
 
 /** Flags for nSequence and nLockTime locks */
 enum {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -107,6 +107,9 @@ struct Params {
     int nHeightv451Fork;
     int nHeightv452Fork;
 
+    /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
+    int nCoinbaseMaturity;
+
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
 };
 } // namespace Consensus

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1406,7 +1406,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         double dPriority = view.GetPriority(tx, chainActive.Height(), inChainInputValue);
 
         // Keep track of transactions that spend a coinbase, which we re-scan
-        // during reorgs to ensure COINBASE_MATURITY is still met.
+        // during reorgs to ensure Params().GetConsensus().nCoinbaseMaturity is still met.
         bool fSpendsCoinbase = false;
         BOOST_FOREACH(const CTxIn &txin, tx.vin) {
             const CCoins *coins = view.AccessCoins(txin.prevout.hash);
@@ -2133,7 +2133,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 
             // If prev is coinbase, check that it's matured
             if ((coins->IsCoinBase() || coins->IsCoinStake()) && !GetBoolArg("-testnet",false)) {
-                if (nSpendHeight - coins->nHeight < COINBASE_MATURITY && nSpendHeight - coins->nHeight > 0)
+                if (nSpendHeight - coins->nHeight < ::Params().GetConsensus().nCoinbaseMaturity && nSpendHeight - coins->nHeight > 0)
                     return state.Invalid(false,
                         REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                         strprintf("tried to spend %s at depth %d", coins->IsCoinBase() ?"coinbase":"coinstake",nSpendHeight - coins->nHeight));

--- a/src/main.h
+++ b/src/main.h
@@ -158,7 +158,7 @@ static const bool DEFAULT_FEEFILTER = true;
 /** Default for -headerspamfilter, use header spam filter */
 static const bool DEFAULT_HEADER_SPAM_FILTER = true;
 /** Default for -headerspamfiltermaxsize, maximum size of the list of indexes in the header spam filter */
-static const unsigned int DEFAULT_HEADER_SPAM_FILTER_MAX_SIZE = COINBASE_MATURITY;
+static const unsigned int DEFAULT_HEADER_SPAM_FILTER_MAX_SIZE = 50;
 /** Default for -headerspamfiltermaxavg, maximum average size of an index occurrence in the header spam filter */
 static const unsigned int DEFAULT_HEADER_SPAM_FILTER_MAX_AVG = 10;
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -265,7 +265,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
 
     if (wtx.IsCoinBase())
     {
-        quint32 numBlocksToMaturity = COINBASE_MATURITY +  1;
+        quint32 numBlocksToMaturity = Params().GetConsensus().nCoinbaseMaturity +  1;
         strHTML += "<br>" + tr("Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to \"not accepted\" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.").arg(QString::number(numBlocksToMaturity)) + "<br>";
     }
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -36,8 +36,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 {
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
-    CAmount nCredit = wtx.GetCredit(ISMINE_ALL);
-    CAmount nDebit = wtx.GetDebit((wtx.IsCoinStake() && wtx.vout[1].scriptPubKey.IsColdStaking()) ? ISMINE_STAKABLE|ISMINE_SPENDABLE_STAKABLE : ISMINE_ALL);
+    isminefilter dCFilter = (wtx.IsCoinStake() && wtx.vout[1].scriptPubKey.IsColdStaking()) ? wallet->IsMine(wtx.vout[1]) : ISMINE_ALL;
+    CAmount nCredit = wtx.GetCredit(dCFilter);
+    CAmount nDebit = wtx.GetDebit(dCFilter);
     CAmount nCFundCredit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;
     uint256 hash = wtx.GetHash();
@@ -45,9 +46,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     std::string dzeel = "";
 
     if (!wtx.fAnon)
-  	{
-  	    dzeel = wtx.strDZeel;
-  	}
+    {
+        dzeel = wtx.strDZeel;
+    }
 
     if (nNet > 0 || wtx.IsCoinBase() || wtx.IsCoinStake())
     {

--- a/src/test/test_navcoin.cpp
+++ b/src/test/test_navcoin.cpp
@@ -83,7 +83,7 @@ TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
     // Generate a 100-block chain:
     coinbaseKey.MakeNewKey(true);
     CScript scriptPubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
-    for (int i = 0; i < COINBASE_MATURITY; i++)
+    for (int i = 0; i < Params().GetConsensus().nCoinbaseMaturity; i++)
     {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -5,6 +5,7 @@
 
 #include "txmempool.h"
 
+#include "chainparams.h"
 #include "clientversion.h"
 #include "consensus/consensus.h"
 #include "consensus/validation.h"
@@ -698,7 +699,7 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
                     continue;
                 const CCoins *coins = pcoins->AccessCoins(txin.prevout.hash);
                 if (nCheckFrequency != 0) assert(coins);
-                if (!coins || ((coins->IsCoinBase() || coins->IsCoinStake()) && ((signed long)nMemPoolHeight) - coins->nHeight < COINBASE_MATURITY)) {
+                if (!coins || ((coins->IsCoinBase() || coins->IsCoinStake()) && ((signed long)nMemPoolHeight) - coins->nHeight < Params().GetConsensus().nCoinbaseMaturity)) {
                     transactionsToRemove.push_back(tx);
                     break;
                 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3159,28 +3159,29 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
         pcoin = &(*it).second;
 
         // skip orphan block or immature
-        if  ((!pcoin->GetDepthInMainChain()) || (pcoin->GetBlocksToMaturity()>0))
+        if ((!pcoin->GetDepthInMainChain()) || (pcoin->GetBlocksToMaturity()>0))
             continue;
 
         // skip abandoned transactions
-        if(pcoin->isAbandoned())
+        if (pcoin->isAbandoned())
             continue;
 
         // skip transaction other than POS block
         if (!(pcoin->IsCoinStake()))
             continue;
 
-        if(pcoin->isAbandoned())
+        if (pcoin->isAbandoned())
             continue;
 
         nElement++;
 
         // use the cached amount if available
         if ((pcoin->fCreditCached || pcoin->fColdStakingCreditCached) && (pcoin->fDebitCached || pcoin->fColdStakingDebitCached))
-            nAmount = pcoin->nCreditCached  + pcoin->nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
+            nAmount = pcoin->nCreditCached + pcoin->nColdStakingCreditCached - pcoin->nDebitCached - pcoin->nColdStakingDebitCached;
+        else if (pcoin->vout[1].scriptPubKey.IsColdStaking())
+            nAmount = pcoin->GetCredit(pwalletMain->IsMine(pcoin->vout[1])) - pcoin->GetDebit(pwalletMain->IsMine(pcoin->vout[1]));
         else
             nAmount = pcoin->GetCredit(ISMINE_SPENDABLE) + pcoin->GetCredit(ISMINE_STAKABLE) - pcoin->GetDebit(ISMINE_SPENDABLE) - pcoin->GetDebit(ISMINE_STAKABLE);
-
 
         // scan the range
         for(vIt=aRange.begin(); vIt != aRange.end(); vIt++)
@@ -3264,8 +3265,7 @@ vStakePeriodRange_T PrepareRangeForStakeReport()
     x.Name = "Latest Stake";
     aRange.push_back(x);
 
-
-return aRange;
+    return aRange;
 }
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3151,6 +3151,7 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
 
     vStakePeriodRange_T::iterator vIt;
 
+    LOCK(cs_main);
     // scan the entire wallet transactions
     for (map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin();
          it != pwalletMain->mapWallet.end();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2021,6 +2021,7 @@ CAmount CWalletTx::GetDebit(const isminefilter& filter) const
         return 0;
 
     CAmount debit = 0;
+
     if(filter & ISMINE_SPENDABLE)
     {
         if (fDebitCached)
@@ -2043,6 +2044,7 @@ CAmount CWalletTx::GetDebit(const isminefilter& filter) const
             debit += nColdStakingDebitCached;
         }
     }
+
     if(filter & ISMINE_WATCH_ONLY)
     {
         if(fWatchDebitCached)
@@ -2054,6 +2056,7 @@ CAmount CWalletTx::GetDebit(const isminefilter& filter) const
             debit += nWatchDebitCached;
         }
     }
+
     return debit;
 }
 
@@ -2063,7 +2066,8 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter) const
     if ((IsCoinBase() || IsCoinStake()) && GetBlocksToMaturity() > 0)
         return 0;
 
-    int64_t credit = 0;
+    CAmount credit = 0;
+
     if (filter & ISMINE_SPENDABLE)
     {
         // GetBalance can assume transactions in mapWallet won't change
@@ -2087,6 +2091,7 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter) const
             credit += nColdStakingCreditCached;
         }
     }
+
     if (filter & ISMINE_WATCH_ONLY)
     {
         if (fWatchCreditCached)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4265,7 +4265,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!(IsCoinBase() || IsCoinStake()) || GetBoolArg("-testnet",false))
         return 0;
-    return max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
+    return max(0, (Params().GetConsensus().nCoinbaseMaturity+1) - GetDepthInMainChain());
 }
 
 


### PR DESCRIPTION
It seems that PR#447 did not fix the issue entirely, but it did point to the right direction.

This PR has changes that fix both #445 and #446

1. With original code on 4.6.0 RC, the issue was that a wallet with only a staking address would report negative values for staking report numbers, SAMPLE BELLOW:

```
{
  "2019-04-26 16:00:00": "0.00",
  "2019-04-25 16:00:00": "-8833.93873429",
  "2019-04-24 16:00:00": "-16719.44565578",
  "2019-04-23 16:00:00": "0.00",
  "2019-04-22 16:00:00": "2.00",
  "2019-04-21 16:00:00": "2.00",
  "2019-04-20 16:00:00": "2.00",
  "2019-04-19 16:00:00": "4.00",
  "2019-04-18 16:00:00": "2.00",
  "2019-04-17 16:00:00": "2.00",
  "2019-04-16 16:00:00": "4.00",
  "2019-04-15 16:00:00": "4.00",
  "2019-04-14 16:00:00": "4.00",
  "2019-04-13 16:00:00": "6.00",
  "2019-04-12 16:00:00": "4.00",
  "2019-04-11 16:00:00": "2.00",
  "2019-04-10 16:00:00": "2.00",
  "2019-04-09 16:00:00": "2.00",
  "2019-04-08 16:00:00": "6.00",
  "2019-04-07 16:00:00": "0.00",
  "2019-04-06 16:00:00": "0.00",
  "2019-04-05 16:00:00": "0.00",
  "2019-04-04 16:00:00": "6.00",
  "2019-04-03 16:00:00": "0.00",
  "2019-04-02 16:00:00": "0.00",
  "2019-04-01 16:00:00": "2.00",
  "2019-03-31 16:00:00": "2.00",
  "2019-03-30 16:00:00": "0.00",
  "2019-03-29 16:00:00": "0.00",
  "2019-03-28 16:00:00": "4.00",
  "Last 24H": "-8833.93873429",
  "Last 7 Days": "-25543.38439007",
  "Last 30 Days": "-25487.38426307",
  "Last 365 Days": "-25202.22851166",
  "Last All": "-25193.35322832",
  "Latest Stake": "-6046.0209064",
  "Latest Time": "2019-04-26 11:57:36",
  "Stake counted": 239,
  "time took (ms)": 1
}
```

2. And a wallet with only a spending address would report the whole amount in the output as the transaction amount (Instead of only getting the staked amount) samples bellow:

![Screenshot from 2019-04-27 00-32-07](https://user-images.githubusercontent.com/1060905/56822568-0e83c800-6884-11e9-8914-5446f26abffc.png)

![Screenshot from 2019-04-27 00-32-19](https://user-images.githubusercontent.com/1060905/56822570-104d8b80-6884-11e9-979e-2a46098db46a.png)

The fix in PR #447 Fixed the balance in the wallet with only "spending" address, but caused the same bug to appear on the wallet with only "staking" address

This PR fixes the issue on 3 wallet scenarios :

* Wallet with spending address
* Wallet with staking address
* Wallet with both spending and staking address

Both the transactions list and the stakereport show the correct values based on my testing