### PR TITLE
Currency Change now updates staking info as well

### DIFF
--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -1697,7 +1697,6 @@ void NavCoinGUI::updateWeight()
     nWeight = pwalletMain->GetStakeWeight();
 }
 
-
 void NavCoinGUI::updatePrice()
 {
   QNetworkAccessManager *manager = new QNetworkAccessManager();

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -189,6 +189,8 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     ui->labelImmature->setText(NavCoinUnits::formatWithUnit(unit, immatureBalance, false, NavCoinUnits::separatorAlways));
     ui->labelTotal->setText(NavCoinUnits::formatWithUnit(unit, balance + unconfirmedBalance + stakingBalance, false, NavCoinUnits::separatorAlways));
 
+    updateStakeReportNow();
+
     bool showStaking = stakingBalance != 0;
 
     ui->labelStaking->setVisible(showStaking);


### PR DESCRIPTION
When updating the currency setting on bottom right corner of the GUI wallet, the staking info section is now also updated instead of having to restart the wallet to see the change.