### PR TITLE
Fix for Payment Request reorganizations

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -165,6 +165,7 @@ testScripts = [
     'cfund-vote.py',
     'cfund-proposalvotelist.py',
     'cfund-paymentrequestvotelist.py',
+    'cfund-paymentrequest-state-reorg.py',
     'reject-version-bit.py',
     'getcoldstakingaddress.py',
     'coldstaking_staking.py',

--- a/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
@@ -91,12 +91,9 @@ class CFundPaymentRequestStateReorg(NavCoinTestFramework):
 
         node_0_best_hash = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
         node_1_best_hash = self.nodes[1].getblockhash(self.nodes[1].getblockcount())
-        node_0_chainwork = int(self.nodes[0].getblock(node_0_best_hash)["chainwork"], 16)
-        node_1_chainwork = int(self.nodes[1].getblock(node_1_best_hash)["chainwork"], 16)
 
-        # Node 0 and Node 1 have forked. Difficulty in Node 0 must be higher (hence lower nbits)
+        # Node 0 and Node 1 have forked. Difficulty in Node 0 must be higher (hence lower chainwork)
         assert(node_0_best_hash != node_1_best_hash)
-        assert(node_0_chainwork < node_1_chainwork)
 
         connect_nodes(self.nodes[0], 1)
 

--- a/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
@@ -91,12 +91,12 @@ class CFundPaymentRequestStateReorg(NavCoinTestFramework):
 
         node_0_best_hash = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
         node_1_best_hash = self.nodes[1].getblockhash(self.nodes[1].getblockcount())
-        node_0_nbits = int(self.nodes[0].getblock(node_0_best_hash)["bits"], 16)
-        node_1_nbits = int(self.nodes[1].getblock(node_1_best_hash)["bits"], 16)
+        node_0_chainwork = int(self.nodes[0].getblock(node_0_best_hash)["chainwork"], 16)
+        node_1_chainwork = int(self.nodes[1].getblock(node_1_best_hash)["chainwork"], 16)
 
         # Node 0 and Node 1 have forked. Difficulty in Node 0 must be higher (hence lower nbits)
         assert(node_0_best_hash != node_1_best_hash)
-        assert(node_0_nbits < node_1_nbits)
+        assert(node_0_chainwork < node_1_chainwork)
 
         connect_nodes(self.nodes[0], 1)
 

--- a/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
@@ -92,7 +92,7 @@ class CFundPaymentRequestStateReorg(NavCoinTestFramework):
         node_0_best_hash = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
         node_1_best_hash = self.nodes[1].getblockhash(self.nodes[1].getblockcount())
 
-        # Node 0 and Node 1 have forked. Difficulty in Node 0 must be higher (hence lower chainwork)
+        # Node 0 and Node 1 have forked.
         assert(node_0_best_hash != node_1_best_hash)
 
         connect_nodes(self.nodes[0], 1)

--- a/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
@@ -76,8 +76,8 @@ class CFundPaymentRequestStateReorg(NavCoinTestFramework):
         self.nodes[0].staking(True)
         self.nodes[1].staking(True)
 
-        # Let's wait for at least 3 blocks from Node 0
-        while self.nodes[0].getblockcount() - blockcount_0 < 3:
+        # Let's wait for at least 20 blocks from Node 0
+        while self.nodes[0].getblockcount() - blockcount_0 < 20:
             time.sleep(1)
 
         # Node 1 only has 1 output so it will only stake 1 block

--- a/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-reorg.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Navcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import NavCoinTestFramework
+from test_framework.cfund_util import *
+
+import time
+import urllib.parse
+
+
+class CFundPaymentRequestStateReorg(NavCoinTestFramework):
+    """Tests consistency of Community Fund Payment Requests state through reorgs."""
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-headerspamfiltermaxsize=1000"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-headerspamfiltermaxsize=1000"]))
+        connect_nodes(self.nodes[0], 1)
+        self.is_network_split = False
+
+    def run_test(self):
+        self.nodes[0].staking(False)
+        self.nodes[1].staking(False)
+        activate_cfund(self.nodes[0])
+        self.sync_all()
+
+        self.nodes[0].donatefund(100)
+
+        # Generate our addresses
+        node_0_address = self.nodes[0].getnewaddress()
+        node_1_address = self.nodes[1].getnewaddress()
+
+        # Split funds
+        self.nodes[0].sendtoaddress(node_1_address, 5000000)
+        proposal=self.nodes[0].createproposal(node_0_address, 100, 36000, "test")
+        proposal_id=proposal["hash"]
+
+        slow_gen(self.nodes[0], 1)
+        end_cycle(self.nodes[0])
+
+        self.sync_all()
+
+        self.nodes[0].proposalvote(proposal_id, "yes")
+
+        slow_gen(self.nodes[0], 1)
+        end_cycle(self.nodes[0])
+
+        self.sync_all()
+
+        assert(self.nodes[0].getproposal(proposal_id)["state"] == 1)
+        assert(self.nodes[0].getproposal(proposal_id)["status"] == "accepted")
+
+        assert(self.nodes[1].getproposal(proposal_id)["state"] == 1)
+        assert(self.nodes[1].getproposal(proposal_id)["status"] == "accepted")
+
+        raw_preq = self.nodes[0].createpaymentrequest(proposal_id, 100, "preq", True)
+        self.sync_all()
+
+        # Disconnect Nodes 0 and 1
+        url = urllib.parse.urlparse(self.nodes[1].url)
+        self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
+
+        self.nodes[0].forcetransactions([raw_preq])
+        self.nodes[1].forcetransactions([raw_preq])
+
+        blockcount_0 = self.nodes[0].getblockcount()
+        blockcount_1 = self.nodes[1].getblockcount()
+
+        self.nodes[0].staking(True)
+        self.nodes[1].staking(True)
+
+        # Let's wait for at least 3 blocks from Node 0
+        while self.nodes[0].getblockcount() - blockcount_0 < 3:
+            time.sleep(1)
+
+        # Node 1 only has 1 output so it will only stake 1 block
+        while self.nodes[1].getblockcount() == blockcount_1:
+            time.sleep(1)
+
+        print("nodes staked!")
+
+        self.nodes[0].staking(False)
+        self.nodes[1].staking(False)
+
+        node_0_best_hash = self.nodes[0].getblockhash(self.nodes[0].getblockcount())
+        node_1_best_hash = self.nodes[1].getblockhash(self.nodes[1].getblockcount())
+        node_0_nbits = int(self.nodes[0].getblock(node_0_best_hash)["bits"], 16)
+        node_1_nbits = int(self.nodes[1].getblock(node_1_best_hash)["bits"], 16)
+
+        # Node 0 and Node 1 have forked. Difficulty in Node 0 must be higher (hence lower nbits)
+        assert(node_0_best_hash != node_1_best_hash)
+        assert(node_0_nbits < node_1_nbits)
+
+        connect_nodes(self.nodes[0], 1)
+
+        self.sync_all()
+
+        node_1_best_hash_ = self.nodes[1].getblockhash(self.nodes[1].getblockcount())
+
+        # Node 1 must have reorg'd to Node 0 chain
+        assert(node_0_best_hash == node_1_best_hash_)
+
+if __name__ == '__main__':
+    CFundPaymentRequestStateReorg().main()

--- a/qa/rpc-tests/cfund-rawtx-paymentrequest-create.py
+++ b/qa/rpc-tests/cfund-rawtx-paymentrequest-create.py
@@ -111,8 +111,16 @@ class CommunityFundCreatePaymentrequestRawTX(NavCoinTestFramework):
 
         # Create multiple payment requests
         self.send_raw_paymentrequest(6, self.goodAddress, self.goodProposalHash, "sum_to_too_large_amount0")
-        self.send_raw_paymentrequest(6, self.goodAddress, self.goodProposalHash, "sum_to_too_large_amount1")
-        self.send_raw_paymentrequest(6, self.goodAddress, self.goodProposalHash, "sum_to_too_large_amount2")
+        try:
+            self.send_raw_paymentrequest(6, self.goodAddress, self.goodProposalHash, "sum_to_too_large_amount1")
+            raise ValueError("Error should be thrown for invalid rawtx (prequest)")
+        except JSONRPCException as e:
+            assert("bad-cfund-payment-request" in e.error['message'])
+        try:
+            self.send_raw_paymentrequest(6, self.goodAddress, self.goodProposalHash, "sum_to_too_large_amount2")
+            raise ValueError("Error should be thrown for invalid rawtx (prequest)")
+        except JSONRPCException as e:
+            assert("bad-cfund-payment-request" in e.error['message'])
 
         slow_gen(self.nodes[0], 1)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -491,7 +491,7 @@ public:
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
 
-	// Deployment of BIP68, BIP112, and BIP113.
+        // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1651363200; // May 1st, 2022

--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -468,6 +468,8 @@ std::string CFund::CProposal::GetState(uint32_t currentTime) const {
 }
 
 void CFund::CProposal::ToJson(UniValue& ret) const {
+    AssertLockHeld(cs_main);
+
     ret.push_back(Pair("version", nVersion));
     ret.push_back(Pair("hash", hash.ToString()));
     ret.push_back(Pair("blockHash", txblockhash.ToString()));

--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -260,7 +260,7 @@ bool CFund::IsValidPaymentRequest(CTransaction tx, int nMaxVersion)
 
     if(nAmount > proposal.GetAvailable(true))
         return error("%s: Invalid requested amount for payment request %s (%d vs %d available)",
-                     __func__, tx.GetHash().ToString(), nAmount, proposal.GetAvailable());
+                     __func__, tx.GetHash().ToString(), nAmount, proposal.GetAvailable(true));
     
     bool ret = (nVersion <= nMaxVersion);
 
@@ -416,6 +416,29 @@ bool CFund::CProposal::IsExpired(uint32_t currentTime) const {
 
 bool CFund::CProposal::ExceededMaxVotingCycles() const {
     return nVotingCycle > Params().GetConsensus().nCyclesProposalVoting;
+}
+
+CAmount CFund::CProposal::GetAvailable(bool fIncludeRequests) const
+{
+    AssertLockHeld(cs_main);
+
+    CAmount initial = nAmount;
+    for (unsigned int i = 0; i < vPayments.size(); i++)
+    {
+        CFund::CPaymentRequest prequest;
+        if(FindPaymentRequest(vPayments[i], prequest))
+        {
+            CBlockIndex* pindex;
+            if(prequest.txblockhash == uint256() || !mapBlockIndex.count(prequest.txblockhash))
+                continue;
+            pindex = mapBlockIndex[prequest.txblockhash];
+            if(!chainActive.Contains(pindex))
+                continue;
+            if((fIncludeRequests && prequest.fState != REJECTED && prequest.fState != EXPIRED) || (!fIncludeRequests && prequest.fState == ACCEPTED))
+                initial -= prequest.nAmount;
+        }
+    }
+    return initial;
 }
 
 std::string CFund::CProposal::GetState(uint32_t currentTime) const {

--- a/src/consensus/cfund.h
+++ b/src/consensus/cfund.h
@@ -257,18 +257,7 @@ public:
         return false;
     }
 
-    CAmount GetAvailable(bool fIncludeRequests = false) const
-    {
-        CAmount initial = nAmount;
-        for (unsigned int i = 0; i < vPayments.size(); i++)
-        {
-            CFund::CPaymentRequest prequest;
-            if(FindPaymentRequest(vPayments[i], prequest))
-                if((fIncludeRequests && prequest.fState != REJECTED) || (!fIncludeRequests && prequest.fState == ACCEPTED))
-                    initial -= prequest.nAmount;
-        }
-        return initial;
-    }
+    CAmount GetAvailable(bool fIncludeRequests = false) const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3934,6 +3934,8 @@ std::map<uint256, std::pair<int, int>> vCachePaymentRequestToUpdate;
 
 void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo, CCoinsViewCache& coins)
 {
+    AssertLockHeld(cs_main);
+
     int64_t nTimeStart = GetTimeMicros();
     CFund::CPaymentRequest prequest; CFund::CProposal proposal;
 
@@ -4034,6 +4036,9 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo, CCo
             bool fUpdate = false;
             prequest = vecPaymentRequest[i];
 
+            if (prequest.txblockhash == uint256())
+                continue;
+
             if (mapBlockIndex.count(prequest.txblockhash) == 0){
                 LogPrintf("%s: Can't find block %s of payment request %s\n",
                           __func__, prequest.txblockhash.ToString(), prequest.hash.ToString());
@@ -4127,6 +4132,9 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo, CCo
         for(unsigned int i = 0; i < vecProposal.size(); i++) {
             bool fUpdate = false;
             proposal = vecProposal[i];
+
+            if (proposal.txblockhash == uint256())
+                continue;
 
             if (mapBlockIndex.count(proposal.txblockhash) == 0) {
                 LogPrintf("%s: Can't find block %s of proposal %s\n",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1248,20 +1248,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if (IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus()) && tx.nVersion < CTransaction::TXDZEEL_VERSION_V2)
       return state.DoS(100, false, REJECT_INVALID, "old-version");
 
-    if (IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus())) {
-        bool fReducedQuorum = IsReducedCFundQuorumEnabled(chainActive.Tip(), Params().GetConsensus());
-        int nMaxVersionProposal = fReducedQuorum ? Params().GetConsensus().nProposalMaxVersion : 2;
-        int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
-
-        if(tx.nVersion == CTransaction::PROPOSAL_VERSION) // Community Fund Proposal
-            if(!CFund::IsValidProposal(tx, nMaxVersionProposal))
-                return state.DoS(10, false, REJECT_INVALID, "bad-cfund-proposal");
-
-        if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION) // Community Fund Payment Request
-            if(!CFund::IsValidPaymentRequest(tx, nMaxVersionPaymentRequest))
-                return state.DoS(10, false, REJECT_INVALID, "bad-cfund-payment-request");
-    }
-
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
         return state.DoS(100, false, REJECT_INVALID, "coinbase");
@@ -1346,6 +1332,20 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         LOCK(pool.cs);
         CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
         view.SetBackend(viewMemPool);
+
+        if (IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus())) {
+            bool fReducedQuorum = IsReducedCFundQuorumEnabled(chainActive.Tip(), Params().GetConsensus());
+            int nMaxVersionProposal = fReducedQuorum ? Params().GetConsensus().nProposalMaxVersion : 2;
+            int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
+
+            if(tx.nVersion == CTransaction::PROPOSAL_VERSION) // Community Fund Proposal
+                if(!CFund::IsValidProposal(tx, nMaxVersionProposal))
+                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-proposal");
+
+            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION) // Community Fund Payment Request
+                if(!CFund::IsValidPaymentRequest(tx, view, nMaxVersionPaymentRequest))
+                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-payment-request");
+        }
 
         // do we already have it?
         bool fHadTxInCache = pcoinsTip->HaveCoinsInCache(hash);
@@ -1682,6 +1682,31 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             LimitMempoolSize(pool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
             if (!pool.exists(hash))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
+        }
+
+        if(IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus())) {
+            CAmount nProposalFee = 0;
+            bool fReducedQuorum = IsReducedCFundQuorumEnabled(chainActive.Tip(), Params().GetConsensus());
+            int nMaxVersionProposal = fReducedQuorum ? Params().GetConsensus().nProposalMaxVersion : 2;
+            int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
+
+            BOOST_FOREACH(const CTxOut& vout, tx.vout)
+            {
+              if(vout.IsCommunityFundContribution())
+              {
+                nProposalFee += vout.nValue;
+              }
+            }
+
+            if(nProposalFee > 0 && tx.nVersion == CTransaction::PROPOSAL_VERSION && CFund::IsValidProposal(tx, nMaxVersionProposal)){
+                if (!NewProposal(tx, uint256(), nProposalFee, state))
+                    return false;
+            }
+
+            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION && CFund::IsValidPaymentRequest(tx, view, nMaxVersionPaymentRequest)){
+                if (!NewPaymentRequest(tx, uint256(), state))
+                    return false;
+            }
         }
     }
 
@@ -2393,7 +2418,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                 }
             }
 
-            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION && CFund::IsValidPaymentRequest(tx, nMaxVersionPaymentRequest)) {
+            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION && CFund::IsValidPaymentRequest(tx, view, nMaxVersionPaymentRequest)) {
                 std::vector<std::pair<uint256, CFund::CProposal> > proposalIndex;
                 std::vector<std::pair<uint256, CFund::CPaymentRequest> > paymentRequestIndex;
                 paymentRequestIndex.push_back(make_pair(hash,CFund::CPaymentRequest()));
@@ -2691,6 +2716,110 @@ public:
     }
 };
 
+bool NewProposal(const CTransaction& tx, const uint256& blockhash, const CAmount& nProposalFee, CValidationState& state)
+{
+    std::vector<std::pair<uint256, CFund::CProposal> > proposalIndex;
+
+    UniValue metadata(UniValue::VOBJ);
+    try {
+        UniValue valRequest;
+        if (!valRequest.read(tx.strDZeel))
+            return error("%s: Could not read strDZeel of Proposal\n", __func__);
+
+        if (valRequest.isObject())
+            metadata = valRequest.get_obj();
+        else
+            return error("%s: Could not read strDZeel of Proposal\n", __func__);
+
+    } catch (const UniValue& objError) {
+        error("%s: Could not read strDZeel of Proposal\n", __func__);
+    } catch (const std::exception& e) {
+        return error("%s: Could not read strDZeel of Proposal: %s\n", __func__, e.what());
+    }
+
+    CFund::CProposal proposal;
+
+    proposal.nAmount = find_value(metadata, "n").get_int64();
+    proposal.Address = find_value(metadata, "a").get_str();
+    proposal.nDeadline = find_value(metadata, "d").get_int64();
+    proposal.strDZeel = find_value(metadata, "s").get_str();
+    proposal.nVersion = find_value(metadata, "v").isNum() ? find_value(metadata, "v").get_int() : 1;
+    proposal.nFee = nProposalFee;
+    proposal.hash = tx.GetHash();
+    proposal.txblockhash = blockhash;
+
+    proposalIndex.push_back(make_pair(tx.GetHash(),proposal));
+
+    if(proposal.nAmount < 0) {
+        return error("%s: Proposal cannot have an amount less than 0\n", __func__);
+    }
+
+    if (!pblocktree->UpdateProposalIndex(proposalIndex))
+        return AbortNode(state, "Failed to write proposal index");
+
+    LogPrint("cfund","New proposal %s\n",tx.GetHash().ToString());
+
+    return true;
+}
+
+bool NewPaymentRequest(const CTransaction& tx, const uint256& blockhash, CValidationState& state)
+{
+    std::vector<std::pair<uint256, CFund::CProposal> > proposalIndex;
+    std::vector<std::pair<uint256, CFund::CPaymentRequest> > paymentRequestIndex;
+
+    UniValue metadata(UniValue::VOBJ);
+    try {
+        UniValue valRequest;
+        if (!valRequest.read(tx.strDZeel))
+            return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+
+        if (valRequest.isObject())
+            metadata = valRequest.get_obj();
+        else
+            return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+
+    } catch (const UniValue& objError) {
+        return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+    } catch (const std::exception& e) {
+        return error("ConnectBlock(): Could not read strDZeel of Payment Request: %s\n", e.what());
+    }  // May not return ever false, as transactions were already chcked.
+
+    CFund::CPaymentRequest prequest;
+
+    prequest.hash = tx.GetHash();
+    prequest.nAmount = find_value(metadata, "n").get_int64();
+    prequest.proposalhash = uint256S("0x" + find_value(metadata, "h").get_str());
+    prequest.strDZeel = find_value(metadata, "i").get_str();
+    prequest.nVersion = find_value(metadata, "v").isNum() ? find_value(metadata, "v").get_int() : 1;
+    prequest.txblockhash = blockhash;
+
+    if(prequest.nAmount < 0) {
+        return error("ConnectBlock(): Payment request cannot have an amount less than 0\n");
+    }
+
+    CFund::CProposal proposal;
+    if(!CFund::FindProposal(prequest.proposalhash, proposal))
+        return error("ConnectBlock(): Could not find parent proposal of Payment Request: %s\n",
+                     proposal.hash.ToString(), prequest.proposalhash.ToString());
+
+    std::vector<uint256>::iterator position = std::find(proposal.vPayments.begin(), proposal.vPayments.end(), tx.hash);
+    if (position == proposal.vPayments.end())
+        proposal.vPayments.push_back(tx.hash);
+
+    proposalIndex.push_back(make_pair(prequest.proposalhash, proposal));
+    paymentRequestIndex.push_back(make_pair(tx.GetHash(), prequest));
+
+    if (!pblocktree->UpdateProposalIndex(proposalIndex))
+        return AbortNode(state, "Failed to write proposal index");
+
+    if (!pblocktree->UpdatePaymentRequestIndex(paymentRequestIndex))
+        return AbortNode(state, "Failed to write payment request index");
+
+    LogPrint("cfund","New payment request %s\n",tx.GetHash().ToString());
+
+    return true;
+}
+
 // Protected by cs_main
 static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS];
 
@@ -2927,13 +3056,27 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                             if(pblockindex == NULL)
                                 continue;
                             if((proposal.CanRequestPayments() || proposal.fState == CFund::PENDING_VOTING_PREQ)
-                                    && prequest.CanVote()
+                                    && prequest.CanVote(view)
                                     && pindex->nHeight - pblockindex->nHeight > Params().GetConsensus().nCommunityFundMinAge)
                                 pindex->vPaymentRequestVotes.push_back(make_pair(hash, vote));
                         }
                     }
                 }
             }
+        }
+
+        if(IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus())) {
+            bool fReducedQuorum = IsReducedCFundQuorumEnabled(chainActive.Tip(), Params().GetConsensus());
+            int nMaxVersionProposal = fReducedQuorum ? Params().GetConsensus().nProposalMaxVersion : 2;
+            int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
+
+            if(tx.nVersion == CTransaction::PROPOSAL_VERSION) // Community Fund Proposal
+                if(!CFund::IsValidProposal(tx, nMaxVersionProposal))
+                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-proposal");
+
+            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION) // Community Fund Payment Request
+                if(!CFund::IsValidPaymentRequest(tx, view, nMaxVersionPaymentRequest))
+                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-payment-request");
         }
 
         if (!tx.IsCoinBase())
@@ -3151,102 +3294,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
 
             if(fContribution && tx.nVersion == CTransaction::PROPOSAL_VERSION && CFund::IsValidProposal(tx, nMaxVersionProposal)){
-                std::vector<std::pair<uint256, CFund::CProposal> > proposalIndex;
-
-                UniValue metadata(UniValue::VOBJ);
-                try {
-                    UniValue valRequest;
-                    if (!valRequest.read(tx.strDZeel))
-                        return error("ConnectBlock(): Could not read strDZeel of Proposal\n");
-
-                    if (valRequest.isObject())
-                        metadata = valRequest.get_obj();
-                    else
-                        return error("ConnectBlock(): Could not read strDZeel of Proposal\n");
-
-                } catch (const UniValue& objError) {
-                    error("ConnectBlock(): Could not read strDZeel of Proposal\n");
-                } catch (const std::exception& e) {
-                    return error("ConnectBlock(): Could not read strDZeel of Proposal: %s\n", e.what());
-                }
-
-                CFund::CProposal proposal;
-
-                proposal.nAmount = find_value(metadata, "n").get_int64();
-                proposal.Address = find_value(metadata, "a").get_str();
-                proposal.nDeadline = find_value(metadata, "d").get_int64();
-                proposal.strDZeel = find_value(metadata, "s").get_str();
-                proposal.nVersion = find_value(metadata, "v").isNum() ? find_value(metadata, "v").get_int() : 1;
-                proposal.nFee = nProposalFee;
-                proposal.hash = tx.GetHash();
-                proposal.txblockhash = block.GetHash();
-
-                proposalIndex.push_back(make_pair(tx.GetHash(),proposal));
-
-                if(proposal.nAmount < 0) {
-                    return error("ConnectBlock(): Proposal cannot have an amount less than 0\n");
-                }
-
-                if (!pblocktree->UpdateProposalIndex(proposalIndex))
-                    return AbortNode(state, "Failed to write proposal index");
-
-                LogPrint("cfund","New proposal %s\n",tx.GetHash().ToString());
-
+                if (!NewProposal(tx, block.GetHash(), nProposalFee, state))
+                    return false;
             }
 
-            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION && CFund::IsValidPaymentRequest(tx, nMaxVersionPaymentRequest)){
-                std::vector<std::pair<uint256, CFund::CProposal> > proposalIndex;
-                std::vector<std::pair<uint256, CFund::CPaymentRequest> > paymentRequestIndex;
-
-                UniValue metadata(UniValue::VOBJ);
-                try {
-                    UniValue valRequest;
-                    if (!valRequest.read(tx.strDZeel))
-                        return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
-
-                    if (valRequest.isObject())
-                        metadata = valRequest.get_obj();
-                    else
-                        return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
-
-                } catch (const UniValue& objError) {
-                    return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
-                } catch (const std::exception& e) {
-                    return error("ConnectBlock(): Could not read strDZeel of Payment Request: %s\n", e.what());
-                }  // May not return ever false, as transactions were already chcked.
-
-                CFund::CPaymentRequest prequest;
-
-                prequest.hash = tx.GetHash();
-                prequest.nAmount = find_value(metadata, "n").get_int64();
-                prequest.proposalhash = uint256S("0x" + find_value(metadata, "h").get_str());
-                prequest.strDZeel = find_value(metadata, "i").get_str();
-                prequest.nVersion = find_value(metadata, "v").isNum() ? find_value(metadata, "v").get_int() : 1;
-                prequest.txblockhash = block.GetHash();
-
-                if(prequest.nAmount < 0) {
-                    return error("ConnectBlock(): Payment request cannot have an amount less than 0\n");
-                }
-
-                CFund::CProposal proposal;
-                if(!CFund::FindProposal(prequest.proposalhash, proposal))
-                    return error("ConnectBlock(): Could not find parent proposal of Payment Request: %s\n",
-                                 proposal.hash.ToString(), prequest.proposalhash.ToString());
-
-                std::vector<uint256>::iterator position = std::find(proposal.vPayments.begin(), proposal.vPayments.end(), tx.hash);
-                if (position == proposal.vPayments.end())
-                    proposal.vPayments.push_back(tx.hash);
-
-                proposalIndex.push_back(make_pair(prequest.proposalhash, proposal));
-                paymentRequestIndex.push_back(make_pair(tx.GetHash(), prequest));
-
-                if (!pblocktree->UpdateProposalIndex(proposalIndex))
-                    return AbortNode(state, "Failed to write proposal index");
-
-                if (!pblocktree->UpdatePaymentRequestIndex(paymentRequestIndex))
-                    return AbortNode(state, "Failed to write payment request index");
-
-                LogPrint("cfund","New payment request %s\n",tx.GetHash().ToString());
+            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION && CFund::IsValidPaymentRequest(tx, view, nMaxVersionPaymentRequest)){
+                if (!NewPaymentRequest(tx, block.GetHash(), state))
+                    return false;
             }
         }
 
@@ -3795,7 +3849,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         AbortNode(state, "Failed to write proposal index");
     }
 
-    CountVotes(state, pindexDelete->pprev, true);
+    CountVotes(state, pindexDelete->pprev, true, *pcoinsTip);
 
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
@@ -3858,7 +3912,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     mempool.removeForBlock(pblock->vtx, pindexNew->nHeight, txConflicted, !IsInitialBlockDownload());
     // Update chainActive & related variables.
     UpdateTip(pindexNew, chainparams);
-    CountVotes(state, pindexNew, false);
+    CountVotes(state, pindexNew, false, *pcoinsTip);
     // Tell wallet about transactions that went from mempool
     // to conflicted:
     BOOST_FOREACH(const CTransaction &tx, txConflicted) {
@@ -3878,7 +3932,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 std::map<uint256, std::pair<int, int>> vCacheProposalsToUpdate;
 std::map<uint256, std::pair<int, int>> vCachePaymentRequestToUpdate;
 
-void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
+void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo, CCoinsViewCache& coins)
 {
     int64_t nTimeStart = GetTimeMicros();
     CFund::CPaymentRequest prequest; CFund::CProposal proposal;
@@ -4031,7 +4085,7 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                     }
                 } else if(prequest.fState == CFund::NIL){
                     if((proposal.fState == CFund::ACCEPTED || proposal.fState == CFund::PENDING_VOTING_PREQ) && prequest.IsAccepted()) {
-                        if(prequest.nAmount <= pindexNew->nCFLocked && prequest.nAmount <= proposal.GetAvailable()) {
+                        if(prequest.nAmount <= pindexNew->nCFLocked && prequest.nAmount <= proposal.GetAvailable(coins)) {
                             pindexNew->nCFLocked -= prequest.nAmount;
                             prequest.fState = CFund::ACCEPTED;
                             prequest.blockhash = pindexNew->GetBlockHash();
@@ -4110,13 +4164,13 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
 
                 if(proposal.IsExpired(pindexNew->GetBlockTime())){
                     if (proposal.fState != CFund::EXPIRED) {
-                        if (proposal.HasPendingPaymentRequests()) {
+                        if (proposal.HasPendingPaymentRequests(coins)) {
                             proposal.fState = CFund::PENDING_VOTING_PREQ;
                             fUpdate = true;
                         } else {
                             if(proposal.fState == CFund::ACCEPTED || proposal.fState == CFund::PENDING_VOTING_PREQ) {
-                                pindexNew->nCFSupply += proposal.GetAvailable();
-                                pindexNew->nCFLocked -= proposal.GetAvailable();
+                                pindexNew->nCFSupply += proposal.GetAvailable(coins);
+                                pindexNew->nCFLocked -= proposal.GetAvailable(coins);
                             }
                             proposal.fState = CFund::EXPIRED;
                             proposal.blockhash = pindexNew->GetBlockHash();
@@ -4131,9 +4185,9 @@ void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo)
                     }
                 } else if(proposal.IsAccepted()){
                     if((proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_FUNDS)) {
-                        if(pindexNew->nCFSupply >= proposal.GetAvailable()) {
-                            pindexNew->nCFSupply -= proposal.GetAvailable();
-                            pindexNew->nCFLocked += proposal.GetAvailable();
+                        if(pindexNew->nCFSupply >= proposal.GetAvailable(coins)) {
+                            pindexNew->nCFSupply -= proposal.GetAvailable(coins);
+                            pindexNew->nCFLocked += proposal.GetAvailable(coins);
                             proposal.fState = CFund::ACCEPTED;
                             proposal.blockhash = pindexNew->GetBlockHash();
                             fUpdate = true;
@@ -5057,19 +5111,6 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     BOOST_FOREACH(const CTransaction& tx, block.vtx) {
         if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
-        }
-        if(IsCommunityFundEnabled(chainActive.Tip(), Params().GetConsensus())) {
-            bool fReducedQuorum = IsReducedCFundQuorumEnabled(chainActive.Tip(), Params().GetConsensus());
-            int nMaxVersionProposal = fReducedQuorum ? Params().GetConsensus().nProposalMaxVersion : 2;
-            int nMaxVersionPaymentRequest = fReducedQuorum ? Params().GetConsensus().nPaymentRequestMaxVersion : 2;
-
-            if(tx.nVersion == CTransaction::PROPOSAL_VERSION) // Community Fund Proposal
-                if(!CFund::IsValidProposal(tx, nMaxVersionProposal))
-                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-proposal");
-
-            if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION) // Community Fund Payment Request
-                if(!CFund::IsValidPaymentRequest(tx, nMaxVersionPaymentRequest))
-                    return state.DoS(10, false, REJECT_INVALID, "bad-cfund-payment-request");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3246,7 +3246,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 } else if (out.scriptPubKey.IsPayToPublicKey() || out.scriptPubKey.IsColdStaking()) {
                     uint160 hashBytes;
                     int type = 0;
-		    CTxDestination destination;
+                    CTxDestination destination;
                     ExtractDestination(out.scriptPubKey, destination);
                     CNavCoinAddress address(destination);
                     if (out.scriptPubKey.IsColdStaking())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2771,17 +2771,17 @@ bool NewPaymentRequest(const CTransaction& tx, const uint256& blockhash, CValida
     try {
         UniValue valRequest;
         if (!valRequest.read(tx.strDZeel))
-            return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+            return error("%s: Could not read strDZeel of Payment Request\n", __func__);
 
         if (valRequest.isObject())
             metadata = valRequest.get_obj();
         else
-            return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+            return error("%s: Could not read strDZeel of Payment Request\n", __func__);
 
     } catch (const UniValue& objError) {
-        return error("ConnectBlock(): Could not read strDZeel of Payment Request\n");
+        return error("%s: Could not read strDZeel of Payment Request\n", __func__);
     } catch (const std::exception& e) {
-        return error("ConnectBlock(): Could not read strDZeel of Payment Request: %s\n", e.what());
+        return error("%s: Could not read strDZeel of Payment Request: %s\n", __func__, e.what());
     }  // May not return ever false, as transactions were already chcked.
 
     CFund::CPaymentRequest prequest;
@@ -2794,12 +2794,12 @@ bool NewPaymentRequest(const CTransaction& tx, const uint256& blockhash, CValida
     prequest.txblockhash = blockhash;
 
     if(prequest.nAmount < 0) {
-        return error("ConnectBlock(): Payment request cannot have an amount less than 0\n");
+        return error("%s: Payment request cannot have an amount less than 0\n", __func__);
     }
 
     CFund::CProposal proposal;
     if(!CFund::FindProposal(prequest.proposalhash, proposal))
-        return error("ConnectBlock(): Could not find parent proposal of Payment Request: %s\n",
+        return error("%s: Could not find parent proposal of Payment Request: %s\n", __func__,
                      proposal.hash.ToString(), prequest.proposalhash.ToString());
 
     std::vector<uint256>::iterator position = std::find(proposal.vPayments.begin(), proposal.vPayments.end(), tx.hash);

--- a/src/main.h
+++ b/src/main.h
@@ -638,8 +638,11 @@ static const unsigned int MAX_STANDARD_TX_SIZE = MAX_BLOCK_SIZE_GEN/5;
 
 const CBlockIndex* GetLastBlockIndex(const CBlockIndex* pindex, bool fProofOfStake);
 
-void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo);
+void CountVotes(CValidationState& state, CBlockIndex *pindexNew, bool fUndo, CCoinsViewCache& coins);
 
 bool IsSigHFEnabled(const Consensus::Params &consensus, const CBlockIndex *pindexPrev);
+
+bool NewProposal(const CTransaction& tx, const uint256& blockhash, const CAmount& nProposalFee, CValidationState& state);
+bool NewPaymentRequest(const CTransaction& tx, const uint256& blockhash, CValidationState& state);
 
 #endif // NAVCOIN_MAIN_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -240,7 +240,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bo
                 if(pblockindex == NULL)
                     continue;
                 if((proposal.CanRequestPayments() || proposal.fState == CFund::PENDING_VOTING_PREQ)
-                        && prequest.CanVote() && votes.count(prequest.hash) == 0 &&
+                        && prequest.CanVote(*pcoinsTip) && votes.count(prequest.hash) == 0 &&
                         pindexPrev->nHeight - pblockindex->nHeight > Params().GetConsensus().nCommunityFundMinAge)
                 {
                     coinbaseTx.vout.resize(coinbaseTx.vout.size()+1);

--- a/src/qt/communityfundcreatepaymentrequestdialog.cpp
+++ b/src/qt/communityfundcreatepaymentrequestdialog.cpp
@@ -196,7 +196,7 @@ void CommunityFundCreatePaymentRequestDialog::click_pushButtonSubmitPaymentReque
         std::string Signature = EncodeBase64(&vchSig[0], vchSig.size());
 
         // Validate requested amount
-        if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(pcoinsTip, true)) {
+        if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(*pcoinsTip, true)) {
             QMessageBox msgBox(this);
             std::string str = "Cannot create a Payment Request for the requested amount\n";
             msgBox.setText(tr(str.c_str()));

--- a/src/qt/communityfundcreatepaymentrequestdialog.cpp
+++ b/src/qt/communityfundcreatepaymentrequestdialog.cpp
@@ -196,7 +196,7 @@ void CommunityFundCreatePaymentRequestDialog::click_pushButtonSubmitPaymentReque
         std::string Signature = EncodeBase64(&vchSig[0], vchSig.size());
 
         // Validate requested amount
-        if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(true)) {
+        if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(pcoinsTip, true)) {
             QMessageBox msgBox(this);
             std::string str = "Cannot create a Payment Request for the requested amount\n";
             msgBox.setText(tr(str.c_str()));

--- a/src/qt/communityfunddisplay.cpp
+++ b/src/qt/communityfunddisplay.cpp
@@ -44,7 +44,7 @@ CommunityFundDisplay::CommunityFundDisplay(QWidget *parent, CFund::CProposal pro
 }
 
 void CommunityFundDisplay::refresh()
-{
+{    
     // Set labels from community fund
     ui->title->setText(QString::fromStdString(proposal.strDZeel));
     ui->labelStatus->setText(QString::fromStdString(proposal.GetState(pindexBestHeader->GetBlockTime())));
@@ -162,9 +162,12 @@ void CommunityFundDisplay::refresh()
         ui->labelDuration->setText(QString::fromStdString("After payment request voting"));
     }
 
-    //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote())
-        ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
+    {
+        LOCK(cs_main);
+        //hide ui voting elements on proposals which are not allowed vote states
+        if(!proposal.CanVote())
+            ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
+    }
 
     // Prevent overflow of title
     std::string title_string = proposal.strDZeel;

--- a/src/qt/communityfunddisplay.cpp
+++ b/src/qt/communityfunddisplay.cpp
@@ -163,7 +163,7 @@ void CommunityFundDisplay::refresh()
     }
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote(pcoinsTip))
+    if(!proposal.CanVote())
         ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
 
     // Prevent overflow of title

--- a/src/qt/communityfunddisplay.cpp
+++ b/src/qt/communityfunddisplay.cpp
@@ -163,7 +163,7 @@ void CommunityFundDisplay::refresh()
     }
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote())
+    if(!proposal.CanVote(pcoinsTip))
         ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
 
     // Prevent overflow of title

--- a/src/qt/communityfunddisplaydetailed.cpp
+++ b/src/qt/communityfunddisplaydetailed.cpp
@@ -52,10 +52,13 @@ CommunityFundDisplayDetailed::CommunityFundDisplayDetailed(QWidget *parent, CFun
     }
 
 
-    //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote())
     {
-        ui->buttonBoxYesNoVote->setStandardButtons(QDialogButtonBox::NoButton);
+        LOCK(cs_main);
+        //hide ui voting elements on proposals which are not allowed vote states
+        if(!proposal.CanVote())
+        {
+            ui->buttonBoxYesNoVote->setStandardButtons(QDialogButtonBox::NoButton);
+        }
     }
 
     // Hide ability to vote is the status is expired

--- a/src/qt/communityfunddisplaydetailed.cpp
+++ b/src/qt/communityfunddisplaydetailed.cpp
@@ -53,7 +53,7 @@ CommunityFundDisplayDetailed::CommunityFundDisplayDetailed(QWidget *parent, CFun
 
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote(pcoinsTip))
+    if(!proposal.CanVote())
     {
         ui->buttonBoxYesNoVote->setStandardButtons(QDialogButtonBox::NoButton);
     }

--- a/src/qt/communityfunddisplaydetailed.cpp
+++ b/src/qt/communityfunddisplaydetailed.cpp
@@ -53,7 +53,7 @@ CommunityFundDisplayDetailed::CommunityFundDisplayDetailed(QWidget *parent, CFun
 
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!proposal.CanVote())
+    if(!proposal.CanVote(pcoinsTip))
     {
         ui->buttonBoxYesNoVote->setStandardButtons(QDialogButtonBox::NoButton);
     }

--- a/src/qt/communityfunddisplaypaymentrequest.cpp
+++ b/src/qt/communityfunddisplaypaymentrequest.cpp
@@ -169,7 +169,7 @@ void CommunityFundDisplayPaymentRequest::refresh()
     }
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!prequest.CanVote())
+    if(!prequest.CanVote(pcoinsTip))
         ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
 
     std::string title_string = prequest.strDZeel;

--- a/src/qt/communityfunddisplaypaymentrequest.cpp
+++ b/src/qt/communityfunddisplaypaymentrequest.cpp
@@ -168,9 +168,12 @@ void CommunityFundDisplayPaymentRequest::refresh()
         }
     }
 
-    //hide ui voting elements on proposals which are not allowed vote states
-    if(!prequest.CanVote(*pcoinsTip))
-        ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
+    {
+        LOCK(cs_main);
+        //hide ui voting elements on proposals which are not allowed vote states
+        if(!prequest.CanVote(*pcoinsTip))
+            ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
+    }
 
     std::string title_string = prequest.strDZeel;
     std::replace( title_string.begin(), title_string.end(), '\n', ' ');
@@ -183,6 +186,8 @@ void CommunityFundDisplayPaymentRequest::refresh()
 
 void CommunityFundDisplayPaymentRequest::click_buttonBoxVote(QAbstractButton *button)
 {
+    LOCK(cs_main);
+
     //cast the vote
     bool duplicate = false;
 

--- a/src/qt/communityfunddisplaypaymentrequest.cpp
+++ b/src/qt/communityfunddisplaypaymentrequest.cpp
@@ -169,7 +169,7 @@ void CommunityFundDisplayPaymentRequest::refresh()
     }
 
     //hide ui voting elements on proposals which are not allowed vote states
-    if(!prequest.CanVote(pcoinsTip))
+    if(!prequest.CanVote(*pcoinsTip))
         ui->buttonBoxVote->setStandardButtons(QDialogButtonBox::NoButton);
 
     std::string title_string = prequest.strDZeel;

--- a/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
+++ b/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
@@ -51,7 +51,7 @@ CommunityFundDisplayPaymentRequestDetailed::CommunityFundDisplayPaymentRequestDe
     }
 
     //hide ui voting elements on prequests which are not allowed vote states
-    if(!prequest.CanVote())
+    if(!prequest.CanVote(pcoinsTip))
     {
         ui->buttonBoxYesNoVote_2->setStandardButtons(QDialogButtonBox::NoButton);
     }

--- a/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
+++ b/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
@@ -50,10 +50,13 @@ CommunityFundDisplayPaymentRequestDetailed::CommunityFundDisplayPaymentRequestDe
         }
     }
 
-    //hide ui voting elements on prequests which are not allowed vote states
-    if(!prequest.CanVote(*pcoinsTip))
     {
-        ui->buttonBoxYesNoVote_2->setStandardButtons(QDialogButtonBox::NoButton);
+        LOCK(cs_main);
+        //hide ui voting elements on prequests which are not allowed vote states
+        if(!prequest.CanVote(*pcoinsTip))
+        {
+            ui->buttonBoxYesNoVote_2->setStandardButtons(QDialogButtonBox::NoButton);
+        }
     }
 }
 
@@ -188,6 +191,8 @@ void CommunityFundDisplayPaymentRequestDetailed::setPrequestLabels() const
 
 void CommunityFundDisplayPaymentRequestDetailed::click_buttonBoxYesNoVote(QAbstractButton *button)
 {
+    LOCK(cs_main);
+
     // Cast the vote
     bool duplicate = false;
 

--- a/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
+++ b/src/qt/communityfunddisplaypaymentrequestdetailed.cpp
@@ -51,7 +51,7 @@ CommunityFundDisplayPaymentRequestDetailed::CommunityFundDisplayPaymentRequestDe
     }
 
     //hide ui voting elements on prequests which are not allowed vote states
-    if(!prequest.CanVote(pcoinsTip))
+    if(!prequest.CanVote(*pcoinsTip))
     {
         ui->buttonBoxYesNoVote_2->setStandardButtons(QDialogButtonBox::NoButton);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -894,18 +894,19 @@ UniValue gettxoutsetinfo(const UniValue& params, bool fHelp)
 
 UniValue listproposals(const UniValue& params, bool fHelp)
 {
-
-     if (fHelp)
+    if (fHelp)
         throw runtime_error(
-            "listproposals \"filter\"\n"
-            "\nList the proposals and all the relating data including payment requests and status.\n"
-            "\nNote passing no argument returns all proposals regardless of state.\n"
-            "\nArguments:\n"
-            "\n1. \"filter\" (string, optional)   \"accepted\" | \"rejected\" | \"expired\" | \"pending\"\n"
-            "\nExamples:\n"
-            + HelpExampleCli("listproposal", "accepted")
-            + HelpExampleRpc("listproposal", "")
-        );
+                "listproposals \"filter\"\n"
+                "\nList the proposals and all the relating data including payment requests and status.\n"
+                "\nNote passing no argument returns all proposals regardless of state.\n"
+                "\nArguments:\n"
+                "\n1. \"filter\" (string, optional)   \"accepted\" | \"rejected\" | \"expired\" | \"pending\"\n"
+                "\nExamples:\n"
+                + HelpExampleCli("listproposal", "accepted")
+                + HelpExampleRpc("listproposal", "")
+                );
+
+    LOCK(cs_main);
 
     UniValue ret(UniValue::VARR);
 
@@ -940,11 +941,11 @@ UniValue listproposals(const UniValue& params, bool fHelp)
             if((showAll && (!proposal.IsExpired(pindexBestHeader->GetBlockTime())
                             || proposal.fState == CFund::PENDING_VOTING_PREQ
                             || proposal.fState == CFund::PENDING_FUNDS))
-               || (showPending  && (proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_VOTING_PREQ
-                                    || proposal.fState == CFund::PENDING_FUNDS))
-               || (showAccepted && (proposal.fState == CFund::ACCEPTED || proposal.IsAccepted()))
-               || (showRejected && (proposal.fState == CFund::REJECTED || proposal.IsRejected()))
-               || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime()))) {
+                    || (showPending  && (proposal.fState == CFund::NIL || proposal.fState == CFund::PENDING_VOTING_PREQ
+                                         || proposal.fState == CFund::PENDING_FUNDS))
+                    || (showAccepted && (proposal.fState == CFund::ACCEPTED || proposal.IsAccepted()))
+                    || (showRejected && (proposal.fState == CFund::REJECTED || proposal.IsRejected()))
+                    || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime()))) {
                 UniValue o(UniValue::VOBJ);
                 proposal.ToJson(o);
                 ret.push_back(o);
@@ -1501,6 +1502,8 @@ UniValue getproposal(const UniValue& params, bool fHelp)
             "\nArguments:\n"
             "1. hash   (string, required) the hash of the proposal\n"
         );
+
+    LOCK(cs_main);
 
     CFund::CProposal proposal;
     if(!CFund::FindProposal(params[0].get_str(), proposal))

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -947,7 +947,7 @@ UniValue listproposals(const UniValue& params, bool fHelp)
                     || (showRejected && (proposal.fState == CFund::REJECTED || proposal.IsRejected()))
                     || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime()))) {
                 UniValue o(UniValue::VOBJ);
-                proposal.ToJson(o);
+                proposal.ToJson(o, *pcoinsTip);
                 ret.push_back(o);
             }
         }
@@ -1511,7 +1511,7 @@ UniValue getproposal(const UniValue& params, bool fHelp)
 
     UniValue ret(UniValue::VOBJ);
 
-    proposal.ToJson(ret);
+    proposal.ToJson(ret, *pcoinsTip);
 
     return ret;
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -71,6 +71,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createmultisig", 0 },
     { "createmultisig", 1 },
     { "createproposal", 2 },
+    { "createproposal", 5 },
+    { "createpaymentrequest", 3 },
     { "listunspent", 0 },
     { "listunspent", 1 },
     { "listunspent", 2 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -391,7 +391,7 @@ UniValue getaddressesbyaccount(const UniValue& params, bool fHelp)
     return ret;
 }
 
-static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew, std::string strDZeel = "", bool donate = false)
+static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, CWalletTx& wtxNew, std::string strDZeel = "", bool donate = false, bool fDoNotSend = false)
 {
     CAmount curBalance = pwalletMain->GetBalance();
 
@@ -423,7 +423,7 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
         throw JSONRPCError(RPC_WALLET_ERROR, strError);
     }
-    if (!pwalletMain->CommitTransaction(wtxNew, reservekey))
+    if (!fDoNotSend && !pwalletMain->CommitTransaction(wtxNew, reservekey))
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of the wallet and coins were spent in the copy but not marked as spent here.");
 }
 
@@ -543,7 +543,7 @@ UniValue createproposal(const UniValue& params, bool fHelp)
 
     if (fHelp || params.size() < 4)
         throw runtime_error(
-            "createproposal \"navcoinaddress\" \"amount\" duration \"desc\" ( fee )\n"
+            "createproposal \"navcoinaddress\" \"amount\" duration \"desc\" ( fee dump_raw )\n"
             "\nCreates a proposal for the community fund. Min fee of " + std::to_string((float)Params().GetConsensus().nProposalMinimalFee/COIN) + "NAV is required.\n"
             + HelpRequiringPassphrase() +
             "\nArguments:\n"
@@ -552,6 +552,7 @@ UniValue createproposal(const UniValue& params, bool fHelp)
             "3. duration               (numeric, required) Number of seconds the proposal will exist after being accepted.\n"
             "4. \"desc\"               (string, required) Short description of the proposal.\n"
             "5. fee                    (numeric, optional) Contribution to the fund used as fee.\n"
+            "6. dump_raw               (bool, optional) Dump the raw transaction instead of sending. Default: false\n"
             "\nResult:\n"
             "\"{ hash: proposalid,\"            (string) The proposal id.\n"
             "\"  strDZeel: string }\"            (string) The attached strdzeel property.\n"
@@ -568,6 +569,8 @@ UniValue createproposal(const UniValue& params, bool fHelp)
     CAmount nAmount = params.size() == 5 ? AmountFromValue(params[4]) : Params().GetConsensus().nProposalMinimalFee;
     if (nAmount <= 0 || nAmount < Params().GetConsensus().nProposalMinimalFee)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount for fee");
+
+    bool fDump = params.size() == 6 ? params[5].getBool() : false;
 
     CWalletTx wtx;
     bool fSubtractFeeFromAmount = false;
@@ -601,15 +604,18 @@ UniValue createproposal(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_TYPE_ERROR, "String too long");
 
     EnsureWalletIsUnlocked();
+    SendMoney(address.Get(), nAmount, fSubtractFeeFromAmount, wtx, "", true, fDump);
 
-    SendMoney(address.Get(), nAmount, fSubtractFeeFromAmount, wtx, "", true);
+    if (!fDump)
+    {
+        UniValue ret(UniValue::VOBJ);
 
-    UniValue ret(UniValue::VOBJ);
-
-    ret.push_back(Pair("hash",wtx.GetHash().GetHex()));
-    ret.push_back(Pair("strDZeel",wtx.strDZeel));
-
-    return ret;
+        ret.push_back(Pair("hash",wtx.GetHash().GetHex()));
+        ret.push_back(Pair("strDZeel",wtx.strDZeel));
+        return ret;
+    }
+    else
+        return EncodeHexTx(wtx);
 }
 
 std::string random_string( size_t length )
@@ -635,13 +641,14 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
 
     if (fHelp || params.size() != 3)
         throw runtime_error(
-            "createpaymentrequest \"hash\" \"amount\" \"id\"\n"
+            "createpaymentrequest \"hash\" \"amount\" \"id\" ( dump_raw )\n"
             "\nCreates a proposal to withdraw funds from the community fund. Fee: 0.0001 NAV\n"
             + HelpRequiringPassphrase() +
             "\nArguments:\n"
             "1. \"hash\"               (string, required) The hash of the proposal from which you want to withdraw funds. It must be approved.\n"
             "2. \"amount\"             (numeric or string, required) The amount in " + CURRENCY_UNIT + " to withdraw. eg 10\n"
             "3. \"id\"                 (string, required) Unique id to identify the payment request\n"
+            "4. dump_raw               (bool, optional) Dump the raw transaction instead of sending. Default: false\n"
             "\nResult:\n"
             "\"{ hash: prequestid,\"             (string) The payment request id.\n"
             "\"  strDZeel: string }\"            (string) The attached strdzeel property.\n"
@@ -676,6 +683,9 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
 
     CAmount nReqAmount = AmountFromValue(params[1]);
     std::string id = params[2].get_str();
+
+    bool fDump = params.size() == 4 ? params[3].getBool() : false;
+
     std::string sRandom = random_string(16);
 
     std::string Secret = sRandom + "I kindly ask to withdraw " +
@@ -713,14 +723,18 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
     if(wtx.strDZeel.length() > 1024)
         throw JSONRPCError(RPC_TYPE_ERROR, "String too long");
 
-    SendMoney(address.Get(), 10000, fSubtractFeeFromAmount, wtx, "", true);
+    SendMoney(address.Get(), 10000, fSubtractFeeFromAmount, wtx, "", true, fDump);
 
-    UniValue ret(UniValue::VOBJ);
+    if (!fDump)
+    {
+        UniValue ret(UniValue::VOBJ);
 
-    ret.push_back(Pair("hash",wtx.GetHash().GetHex()));
-    ret.push_back(Pair("strDZeel",wtx.strDZeel));
-
-    return ret;
+        ret.push_back(Pair("hash",wtx.GetHash().GetHex()));
+        ret.push_back(Pair("strDZeel",wtx.strDZeel));
+        return ret;
+    }
+    else
+        return EncodeHexTx(wtx);
 }
 
 UniValue donatefund(const UniValue& params, bool fHelp)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3413,6 +3413,8 @@ UniValue proposalvote(const UniValue& params, bool fHelp)
             "                      'remove' to remove a proposal from the list\n"
         );
 
+    LOCK(cs_main);
+
     string strHash = params[0].get_str();
     bool duplicate = false;
 
@@ -3512,6 +3514,8 @@ UniValue paymentrequestvote(const UniValue& params, bool fHelp)
             "2. \"command\"       (string, required) 'yes' to vote yes, 'no' to vote no,\n"
             "                      'remove' to remove a proposal from the list\n"
         );
+
+    LOCK(cs_main);
 
     string strHash = params[0].get_str();
     bool duplicate = false;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -692,7 +692,7 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
 
     std::string Signature = EncodeBase64(&vchSig[0], vchSig.size());
 
-    if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(true))
+    if (nReqAmount <= 0 || nReqAmount > proposal.GetAvailable(*pcoinsTip, true))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount.");
 
     CWalletTx wtx;
@@ -3377,7 +3377,7 @@ UniValue proposalvotelist(const UniValue& params, bool fHelp)
              auto it = std::find_if( vAddedProposalVotes.begin(), vAddedProposalVotes.end(),
                  [&proposal](const std::pair<std::string, bool>& element){ return element.first == proposal.hash.ToString();} );
              UniValue p(UniValue::VOBJ);
-             proposal.ToJson(p);
+             proposal.ToJson(p, *pcoinsTip);
              if (it != vAddedProposalVotes.end()) {
                  if (it->second)
                      yesvotes.push_back(p);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3361,6 +3361,8 @@ UniValue proposalvotelist(const UniValue& params, bool fHelp)
                 "}\n"
         );
 
+    LOCK(cs_main);
+
     UniValue ret(UniValue::VOBJ);
     UniValue yesvotes(UniValue::VARR);
     UniValue novotes(UniValue::VARR);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -639,7 +639,7 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp))
         return NullUniValue;
 
-    if (fHelp || params.size() != 3)
+    if (fHelp || params.size() < 3)
         throw runtime_error(
             "createpaymentrequest \"hash\" \"amount\" \"id\" ( dump_raw )\n"
             "\nCreates a proposal to withdraw funds from the community fund. Fee: 0.0001 NAV\n"


### PR DESCRIPTION
This PR prevents payment requests with invalid hashes (not set yet or out of the main chain) to count for the already requested balance of a proposal.