### PR TITLE
Missing increased buffer for cfund gui

### DIFF
--- a/src/qt/communityfunddisplay.cpp
+++ b/src/qt/communityfunddisplay.cpp
@@ -93,7 +93,7 @@ void CommunityFundDisplay::refresh()
         std::string expiry_title = "Rejected on: ";
         std::time_t t = static_cast<time_t>(proptime);
         std::stringstream ss;
-        char buf[24];
+        char buf[48];
         if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
 	    ss << buf;
         ui->labelTitleDuration->setText(QString::fromStdString(expiry_title));
@@ -108,7 +108,7 @@ void CommunityFundDisplay::refresh()
             std::string expiry_title = "Expired on: ";
             std::time_t t = static_cast<time_t>(proptime);
             std::stringstream ss;
-            char buf[24];
+            char buf[48];
             if (strftime(buf, sizeof(buf), "%c %Z", std::gmtime(&t)))
 		ss << buf;
             ui->labelTitleDuration->setText(QString::fromStdString(expiry_title));


### PR DESCRIPTION
Pull request #443 was missing an increased buffer in communityfunddisplay.cpp which caused the wallet to crash when using the CFund GUI on some systems. This pull requests corrects the size.