### PR TITLE
Added new attributes to the `getstakinginfo` and `getstakereport` commands

### DIFF
--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -131,9 +131,45 @@ class GetStakeReport(NavCoinTestFramework):
         avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
 
         # Check the amounts
-        assert_equal('0.85714285', avg_last7d)
-        assert_equal('0.20', avg_last30d)
-        assert_equal('0.01643835', avg_last365d)
+        assert_equal('3.00', avg_last7d)
+        assert_equal('3.00', avg_last30d)
+        assert_equal('3.00', avg_last365d)
+
+        # Time travel 8 days in the future
+        cur_time = int(time.time())
+        self.nodes[0].setmocktime(cur_time + 691200)
+        self.nodes[1].setmocktime(cur_time + 691200)
+        self.nodes[2].setmocktime(cur_time + 691200)
+
+        # Load the last 24h stake amount for the wallets/nodes
+        merged_address_last_24h = self.nodes[0].getstakereport()['Last 24H']
+        spending_address_last_24h = self.nodes[1].getstakereport()['Last 24H']
+        staking_address_last_24h = self.nodes[2].getstakereport()['Last 24H']
+
+        # Check the amounts
+        assert_equal('0.00', merged_address_last_24h)
+        assert_equal('0.00', spending_address_last_24h)
+        assert_equal('0.00', staking_address_last_24h)
+
+        # Load the last 7 days stake amount for the wallets/nodes
+        merged_address_last_7d = self.nodes[0].getstakereport()['Last 7 Days']
+        spending_address_last_7d = self.nodes[1].getstakereport()['Last 7 Days']
+        staking_address_last_7d = self.nodes[2].getstakereport()['Last 7 Days']
+
+        # Check the amounts
+        assert_equal('2.00', merged_address_last_7d)
+        assert_equal('2.00', spending_address_last_7d)
+        assert_equal('2.00', staking_address_last_7d)
+
+        # Load the averages for stake amounts 
+        avg_last7d   = self.nodes[0].getstakereport()['Last 7 Days Avg']
+        avg_last30d  = self.nodes[0].getstakereport()['Last 30 Days Avg']
+        avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
+
+        # Check the amounts
+        assert_equal('0.28571428', avg_last7d)
+        assert_equal('0.75',       avg_last30d)
+        assert_equal('0.75',       avg_last365d)
 
     def stake_block(self, node):
         # Get the current block count to check against while we wait for a stake

--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -171,6 +171,42 @@ class GetStakeReport(NavCoinTestFramework):
         assert_equal('0.75',       avg_last30d)
         assert_equal('0.75',       avg_last365d)
 
+        # Time travel 31 days in the future
+        cur_time = int(time.time())
+        self.nodes[0].setmocktime(cur_time + 2678400)
+        self.nodes[1].setmocktime(cur_time + 2678400)
+        self.nodes[2].setmocktime(cur_time + 2678400)
+
+        # Load the last 24h stake amount for the wallets/nodes
+        merged_address_last_24h = self.nodes[0].getstakereport()['Last 24H']
+        spending_address_last_24h = self.nodes[1].getstakereport()['Last 24H']
+        staking_address_last_24h = self.nodes[2].getstakereport()['Last 24H']
+
+        # Check the amounts
+        assert_equal('0.00', merged_address_last_24h)
+        assert_equal('0.00', spending_address_last_24h)
+        assert_equal('0.00', staking_address_last_24h)
+
+        # Load the last 7 days stake amount for the wallets/nodes
+        merged_address_last_7d = self.nodes[0].getstakereport()['Last 7 Days']
+        spending_address_last_7d = self.nodes[1].getstakereport()['Last 7 Days']
+        staking_address_last_7d = self.nodes[2].getstakereport()['Last 7 Days']
+
+        # Check the amounts
+        assert_equal('0.00', merged_address_last_7d)
+        assert_equal('0.00', spending_address_last_7d)
+        assert_equal('0.00', staking_address_last_7d)
+
+        # Load the averages for stake amounts 
+        avg_last7d   = self.nodes[0].getstakereport()['Last 7 Days Avg']
+        avg_last30d  = self.nodes[0].getstakereport()['Last 30 Days Avg']
+        avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
+
+        # Check the amounts
+        assert_equal('0.00',       avg_last7d)
+        assert_equal('0.06666666', avg_last30d)
+        assert_equal('0.19354838', avg_last365d)
+
     def stake_block(self, node):
         # Get the current block count to check against while we wait for a stake
         blockcount = node.getblockcount()

--- a/qa/rpc-tests/getstakinginfo.py
+++ b/qa/rpc-tests/getstakinginfo.py
@@ -40,7 +40,10 @@ class GetStakingInfo(NavCoinTestFramework):
 
         # Check for staking after we have matured coins
         assert(self.nodes[0].getstakinginfo()['enabled'])
-        assert(not self.nodes[0].getstakinginfo()['staking'])
+        # Wait for the node to start staking
+        while not self.nodes[0].getstakinginfo()['staking']:
+            time.sleep(0.5)
+        assert(self.nodes[0].getstakinginfo()['staking'])
         assert_equal("", self.nodes[0].getstakinginfo()['errors'])
 
         # Get the current block count to check against while we wait for a stake
@@ -61,6 +64,9 @@ class GetStakingInfo(NavCoinTestFramework):
         assert(self.nodes[0].getstakinginfo()['enabled'])
         assert(self.nodes[0].getstakinginfo()['staking'])
         assert_equal("", self.nodes[0].getstakinginfo()['errors'])
+
+        # Check expecteddailyreward
+        assert_equal(86400 / (self.nodes[0].getstakinginfo()['expectedtime'] + 1) * 2, self.nodes[0].getstakinginfo()['expecteddailyreward'])
 
         # LOCK the wallet
         self.nodes[0].encryptwallet("password")

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -644,6 +644,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     uint64_t nNetworkWeight = GetPoSKernelPS();
     bool staking = nLastCoinStakeSearchInterval && nWeight;
     uint64_t nExpectedTime = staking ? (GetTargetSpacing(pindexBestHeader->nHeight) * nNetworkWeight / nWeight) : 0;
+    CAmount nExpectedDailyReward = staking ? ((double) 86400 / (nExpectedTime + 1)) * Params().GetConsensus().nStaticReward : 0.0;
 
     UniValue obj(UniValue::VOBJ);
 
@@ -661,6 +662,7 @@ UniValue getstakinginfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("netstakeweight", (uint64_t)nNetworkWeight));
 
     obj.push_back(Pair("expectedtime", nExpectedTime));
+    obj.push_back(Pair("expecteddailyreward", (double) nExpectedDailyReward / COIN));
 
     return obj;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3258,7 +3258,7 @@ vStakePeriodRange_T PrepareRangeForStakeReport()
     }
 
     // prepare subtotal range of last 24H, 1 week, 30 days, 1 years
-    int GroupDays[5][2] = { {1 ,0}, {7 ,0 }, {30, 0}, {365, 0}, {99999999, 0}};
+    int GroupDays[5][2] = { {1, 0}, {7, 0}, {30, 0}, {365, 0}, {99999999, 0}};
     std::string sGroupName[] = {"24H", "7 Days", "30 Days", "365 Days", "All" };
 
     nToday = GetTime();
@@ -3301,10 +3301,29 @@ UniValue getstakereport(const UniValue& params, bool fHelp)
 
     vStakePeriodRange_T::iterator vIt;
 
+    // Span of days to compute average over
+    int nDays = 0;
+
     // report it
     for(vIt = aRange.begin(); vIt != aRange.end(); vIt++)
     {
+        // Add it to results
         result.push_back(Pair(vIt->Name, FormatMoney(vIt->Total).c_str()));
+
+        // Get the nDays value
+        nDays = 0;
+        if (vIt->Name == "Last 7 Days")
+            nDays = 7;
+        else if (vIt->Name == "Last 30 Days")
+            nDays = 30;
+        else if (vIt->Name == "Last 365 Days")
+            nDays = 365;
+
+        // Check if we need to add the average
+        if (nDays > 0) {
+            // Add the Average
+            result.push_back(Pair(vIt->Name + " Avg", FormatMoney(vIt->Total / nDays).c_str()));
+        }
     }
 
     vIt--;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3186,9 +3186,9 @@ int64_t GetFirstStakeTime()
     const CWalletTx* tx;
 
     // scan the entire wallet transactions
-    for (auto it = pwalletMain->mapWallet.end(); it != pwalletMain->mapWallet.begin(); --it)
+    for (auto it = pwalletMain->wtxOrdered.begin(); it != pwalletMain->wtxOrdered.end(); ++it)
     {
-        tx = &(*it).second;
+        tx = (*it).second.first;
 
         // Check if we have a useable tx
         if (IsTxCountedAsStaked(tx))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -34,6 +34,7 @@
 using namespace std;
 
 int64_t nWalletUnlockTime;
+int64_t nWalletFirstStakeTime = -1;
 static CCriticalSection cs_nWalletUnlockTime;
 Navtech navtech;
 
@@ -3182,6 +3183,10 @@ CAmount GetTxStakeAmount(const CWalletTx* tx)
 // Returns -1 (Zero) if has not staked yet
 int64_t GetFirstStakeTime()
 {
+    // Check if we already know when
+    if (nWalletFirstStakeTime > 0)
+        return nWalletFirstStakeTime;
+
     // Need a pointer for the tx
     const CWalletTx* tx;
 
@@ -3191,12 +3196,14 @@ int64_t GetFirstStakeTime()
         tx = (*it).second.first;
 
         // Check if we have a useable tx
-        if (IsTxCountedAsStaked(tx))
-            return tx->nTime;
+        if (IsTxCountedAsStaked(tx)) {
+            nWalletFirstStakeTime = tx->nTime; // Save it for later use
+            return nWalletFirstStakeTime;
+        }
     }
 
     // Did not find the first stake
-    return -1;
+    return nWalletFirstStakeTime;
 }
 
 // **em52: Get total coins staked on given period

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3191,7 +3191,7 @@ int64_t GetFirstStakeTime()
     const CWalletTx* tx;
 
     // scan the entire wallet transactions
-    for (auto it = pwalletMain->wtxOrdered.begin(); it != pwalletMain->wtxOrdered.end(); ++it)
+    for(auto& it: pwalletMain->wtxOrdered)
     {
         tx = (*it).second.first;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3171,7 +3171,7 @@ CAmount GetTxStakeAmount(const CWalletTx* tx)
     // use the cached amount if available
     if ((tx->fCreditCached || tx->fColdStakingCreditCached) && (tx->fDebitCached || tx->fColdStakingDebitCached))
         return tx->nCreditCached + tx->nColdStakingCreditCached - tx->nDebitCached - tx->nColdStakingDebitCached;
-    // Check for cold staking 
+    // Check for cold staking
     else if (tx->vout[1].scriptPubKey.IsColdStaking())
         return tx->GetCredit(pwalletMain->IsMine(tx->vout[1])) - tx->GetDebit(pwalletMain->IsMine(tx->vout[1]));
 
@@ -3212,7 +3212,6 @@ int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
 
     vStakePeriodRange_T::iterator vIt;
 
-    LOCK(cs_main);
     // scan the entire wallet transactions
     for (map<uint256, CWalletTx>::const_iterator it = pwalletMain->mapWallet.begin();
          it != pwalletMain->mapWallet.end();
@@ -3322,6 +3321,8 @@ UniValue getstakereport(const UniValue& params, bool fHelp)
             "List last single 30 day stake subtotal and last 24h, 7, 30, 365 day subtotal.\n");
 
     vStakePeriodRange_T aRange = PrepareRangeForStakeReport();
+
+    LOCK(cs_main);
 
     // get subtotal calc
     int64_t nTook = GetTimeMillis();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3193,7 +3193,7 @@ int64_t GetFirstStakeTime()
     // scan the entire wallet transactions
     for(auto& it: pwalletMain->wtxOrdered)
     {
-        tx = (*it).second.first;
+        tx = it.second.first;
 
         // Check if we have a useable tx
         if (IsTxCountedAsStaked(tx)) {


### PR DESCRIPTION
Added new attributes to the `getstakinginfo` and `getstakereport` commands

`getstakinginfo` now has `expecteddailyreward`

`getstakereport` now has `Last 7 Days Avg`, `Last 30 Days Avg` and `Last 365 Days Avg`

reports looks like these:
```json
{
  "enabled": true,
  "staking": true,
  "errors": "",
  "currentblocksize": 1000,
  "currentblocktx": 0,
  "difficulty": 537692.0995617752,
  "search-interval": 16,
  "weight": 1198583732549,
  "netstakeweight": 1339930863008790,
  "expectedtime": 33537,
  "expecteddailyreward": 5.15236448
}
```

```json
{
  "2019-05-15 16:00:00": "2.00",
  "2019-05-14 16:00:00": "2.00",
  "2019-05-13 16:00:00": "2.00",
  "2019-05-12 16:00:00": "2.00",
  "2019-05-11 16:00:00": "2.00",
  "2019-05-10 16:00:00": "6.0001",
  "2019-05-09 16:00:00": "4.00",
  "2019-05-08 16:00:00": "4.00",
  "2019-05-07 16:00:00": "6.00",
  "2019-05-06 16:00:00": "4.00",
  "2019-05-05 16:00:00": "2.00",
  "2019-05-04 16:00:00": "4.00",
  "2019-05-03 16:00:00": "8.00",
  "2019-05-02 16:00:00": "4.00",
  "2019-05-01 16:00:00": "6.00",
  "2019-04-30 16:00:00": "2.00",
  "2019-04-29 16:00:00": "0.00",
  "2019-04-28 16:00:00": "4.00",
  "2019-04-27 16:00:00": "4.00",
  "2019-04-26 16:00:00": "2.00",
  "2019-04-25 16:00:00": "4.00",
  "2019-04-24 16:00:00": "4.00",
  "2019-04-23 16:00:00": "0.00",
  "2019-04-22 16:00:00": "2.00",
  "2019-04-21 16:00:00": "2.00",
  "2019-04-20 16:00:00": "2.00",
  "2019-04-19 16:00:00": "4.00",
  "2019-04-18 16:00:00": "2.00",
  "2019-04-17 16:00:00": "2.00",
  "2019-04-16 16:00:00": "4.00",
  "Last 24H": "2.00",
  "Last 7 Days": "22.0001",
  "Last 7 Days Avg": "3.14287142",
  "Last 30 Days": "98.0001",
  "Last 30 Days Avg": "3.26667",
  "Last 365 Days": "425.2213209",
  "Last 365 Days Avg": "1.16498992",
  "Last All": "438.03126175",
  "Latest Stake": "2.00",
  "Latest Time": "2019-05-15 20:53:04",
  "Stake counted": 274,
  "time took (ms)": 1
}
```