### PR TITLE
TX_POOL missing in switch condition in the IsMine function

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -52,6 +52,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey)
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
+    case TX_POOL:
     case TX_CONTRIBUTION:
     case TX_PROPOSALNOVOTE:
     case TX_PROPOSALYESVOTE:


### PR DESCRIPTION
When TX_POOL was added I missed including it in the switch when considering IsMine()

It triggers a build warning which this PR resolves