### PR TITLE
Prevent segfault on gui close

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -315,7 +315,8 @@ RPCConsole::~RPCConsole()
     GUIUtil::saveWindowGeometry("nRPCConsoleWindow", this);
     Q_EMIT stopExecutor();
     RPCUnsetTimerInterface(rpcTimerInterface);
-    errorLogFile->close();
+    if (errorLogFile)
+        errorLogFile->close();
     delete rpcTimerInterface;
     delete ui;
 }


### PR DESCRIPTION
This PR prevents a segmentation fault when the wallet graphic interface is closed.