### PR TITLE
Remove Bootstrap option from GUI

### DIFF
--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -117,7 +117,6 @@ NavCoinGUI::NavCoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     usedReceivingAddressesAction(0),
     repairWalletAction(0),
     importPrivateKeyAction(0),
-    bootstrapBlockchainAction(0),
     exportMasterPrivateKeyAction(0),
     signMessageAction(0),
     verifyMessageAction(0),
@@ -459,9 +458,6 @@ void NavCoinGUI::createActions()
     importPrivateKeyAction = new QAction(tr("&Import private key"), this);
     importPrivateKeyAction->setToolTip(tr("Import private key"));
 
-    bootstrapBlockchainAction = new QAction(tr("&Bootstrap blockchain"), this);
-    bootstrapBlockchainAction->setToolTip(tr("Bootstrap blockchain"));
-
     exportMasterPrivateKeyAction = new QAction(tr("Show &master private key"), this);
     exportMasterPrivateKeyAction->setToolTip(tr("Show master private key"));
 
@@ -484,7 +480,6 @@ void NavCoinGUI::createActions()
     connect(openRPCConsoleAction, SIGNAL(triggered()), this, SLOT(showDebugWindow()));
     // prevents an open debug window from becoming stuck/unusable on client shutdown
     connect(quitAction, SIGNAL(triggered()), rpcConsole, SLOT(hide()));
-    connect(bootstrapBlockchainAction, SIGNAL(triggered()), this, SLOT(bootstrapBlockchain()));
 
 #ifdef ENABLE_WALLET
     if(walletFrame)
@@ -506,31 +501,6 @@ void NavCoinGUI::createActions()
 
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C), this, SLOT(showDebugWindowActivateConsole()));
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_D), this, SLOT(showDebugWindow()));
-}
-
-void NavCoinGUI::bootstrapBlockchain()
-{
-    bool ok = false;
-    QString defaultUrl = "https://s3.amazonaws.com/navcoin-bootstrap/bootstrap-navcoin_" +
-            QString::fromStdString(Params().NetworkIDString()) + "net.tar";
-    QString url = QInputDialog::getText(this, tr("Bootstrap blockchain"),
-                                            tr("You can use an external trusted source to download the blockchain from.<BR>The following URL points to a bootstrap copy provided by the NavCoin Core Team.<BR>Where would you like to download it from?"), QLineEdit::Normal,
-                                            defaultUrl, &ok);
-    if (ok && !url.isEmpty())
-    {
-        QMessageBox::StandardButton btnRetVal = QMessageBox::question(this, tr("Bootstrap blockchain"),
-            tr("Client restart required to initiate download.<br><br>Client will be shut down and you should manually start it again. Do you want to proceed?"),
-            QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel);
-
-        if(btnRetVal == QMessageBox::Cancel)
-            return;
-
-        RemoveConfigFile("bootstrap");
-        WriteConfigFile("bootstrap",url.toStdString());
-
-        QApplication::quit();
-    }
-
 }
 
 void NavCoinGUI::createMenuBar()
@@ -559,7 +529,6 @@ void NavCoinGUI::createMenuBar()
         file->addSeparator();
         file->addAction(importPrivateKeyAction);
         file->addAction(exportMasterPrivateKeyAction);
-        file->addAction(bootstrapBlockchainAction);
     }
     file->addAction(quitAction);
 

--- a/src/qt/navcoingui.h
+++ b/src/qt/navcoingui.h
@@ -109,7 +109,6 @@ private:
     QAction *usedReceivingAddressesAction;
     QAction *repairWalletAction;
     QAction *importPrivateKeyAction;
-    QAction *bootstrapBlockchainAction;
     QAction *exportMasterPrivateKeyAction;
     QAction *signMessageAction;
     QAction *verifyMessageAction;
@@ -268,8 +267,6 @@ private Q_SLOTS:
     void showHelpMessageClicked();
     /** Toggle Staking **/
     void toggleStaking();
-    /** Bootstrap blockchain **/
-    void bootstrapBlockchain();
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);


### PR DESCRIPTION
In order to encourage the use of trust-less full syncs, this PR removes the option to Bootstrap from the GUI.