### PR TITLE
Updated __poll_chk implementation to be not so strict

### DIFF
--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -6,7 +6,6 @@
 #include <config/navcoin-config.h>
 #endif
 
-#include <assert.h>
 #include <cstddef>
 #include <cstdint>
 #include <errno.h>
@@ -110,7 +109,8 @@ extern "C" int __wrap_glob64(const char * pattern, int flags, int (*errfunc) (co
 
 extern "C" int __poll_chk(struct pollfd *fds, nfds_t nfds, int timeout, size_t fdslen)
 {
-    assert((fdslen / sizeof(*fds)) < nfds);
+    if(fdslen / sizeof(*fds) < nfds)
+        __chk_fail();
     return poll(fds, nfds, timeout);
 }
 


### PR DESCRIPTION
This fixes a crash for navcoin-qt when libs call poll() with bad data.

Updated the `__poll_chk` to behave less aggressive (More like `__explicit_bzero_chk`)

Calls `__chk_fail()` instead of an assert which would terminate the execution of the rest of the app