### PR TITLE
Added an additional LOCK for cs_main in communityfunddisplay

### DIFF
--- a/src/qt/communityfunddisplay.cpp
+++ b/src/qt/communityfunddisplay.cpp
@@ -44,7 +44,7 @@ CommunityFundDisplay::CommunityFundDisplay(QWidget *parent, CFund::CProposal pro
 }
 
 void CommunityFundDisplay::refresh()
-{    
+{
     // Set labels from community fund
     ui->title->setText(QString::fromStdString(proposal.strDZeel));
     ui->labelStatus->setText(QString::fromStdString(proposal.GetState(pindexBestHeader->GetBlockTime())));
@@ -188,6 +188,9 @@ void CommunityFundDisplay::refresh()
 
 void CommunityFundDisplay::click_buttonBoxVote(QAbstractButton *button)
 {
+    // Make sure we have a lock when voting
+    LOCK(cs_main);
+
     // Cast the vote
     bool duplicate = false;
 


### PR DESCRIPTION
Found another missing lock, would sometimes crash when setting votes as cs_main lock was not help when calling `CFund::VoteProposal`