### PR TITLE
Added a lock before we call GetTxStakeAmount()

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3215,6 +3215,9 @@ int64_t GetFirstStakeTime()
 // return int =  Number of Wallet's elements analyzed
 int GetsStakeSubTotal(vStakePeriodRange_T& aRange)
 {
+    // Lock cs_main before we try to call GetTxStakeAmount
+    LOCK(cs_main);
+
     int nElement = 0;
     int64_t nAmount = 0;
 


### PR DESCRIPTION
I experienced a crash on QT wallet while staking on devnet, this PR fixes it.

Backtrace:
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff5c5b801 in __GI_abort () at abort.c:79
#2  0x0000555555dbe322 in AssertLockHeldInternal (pszName=0x5555577612a9 "cs_main", pszFile=0x5555577611d1 "wallet/wallet.cpp", nLine=4250, cs=0x555558393e60 <cs_main>) at sync.cpp:184
#3  0x0000555555e59283 in CMerkleTx::GetDepthInMainChain (this=0x7fffd4f57040, pindexRet=@0x7fffffffc290: 0x7fffffffc2c0) at wallet/wallet.cpp:4250
#4  0x00005555559d8b10 in CMerkleTx::GetDepthInMainChain (this=0x7fffd4f57040) at ./wallet/wallet.h:211
#5  0x0000555555e5946f in CMerkleTx::GetBlocksToMaturity (this=0x7fffd4f57040) at wallet/wallet.cpp:4268
#6  0x0000555555e46beb in CWalletTx::GetCredit (this=0x7fffd4f57040, filter=@0x7fffffffc384: 4 '\004') at wallet/wallet.cpp:2066
#7  0x0000555555e1bb90 in GetTxStakeAmount (tx=0x7fffd4f57040) at wallet/rpcwallet.cpp:3182
#8  0x0000555555e1bdc9 in GetsStakeSubTotal (aRange=std::vector of length 36, capacity 64 = {...}) at wallet/rpcwallet.cpp:3239
#9  0x0000555555a5f80c in OverviewPage::updateStakeReport (this=0x5555591f0aa0, fImmediate=true) at qt/overviewpage.cpp:390
#10 0x0000555555a5fb6c in OverviewPage::updateStakeReportNow (this=0x5555591f0aa0) at qt/overviewpage.cpp:419
#11 0x0000555555a177f2 in WalletView::gotoOverviewPage (this=0x5555588463e0) at qt/walletview.cpp:188
#12 0x00005555559cda15 in WalletFrame::gotoOverviewPage (this=0x5555587806f0) at qt/walletframe.cpp:132
#13 0x000055555575f475 in NavCoinGUI::gotoOverviewPage (this=0x5555585b5380) at qt/navcoingui.cpp:1009
#14 0x0000555555a1d64e in NavCoinGUI::qt_static_metacall (_o=0x5555585b5380, _c=QMetaObject::InvokeMetaMethod, _id=8, _a=0x7fffffffc6d0) at qt/moc_navcoingui.cpp:259
#15 0x000055555678f3f1 in QMetaObject::activate(QObject*, int, int, void**) ()
#16 0x0000555556989671 in QAbstractButtonPrivate::emitClicked() ()
#17 0x000055555698aada in QAbstractButtonPrivate::click() ()
#18 0x000055555698accd in QAbstractButton::mouseReleaseEvent(QMouseEvent*) ()
#19 0x000055555691b028 in QWidget::event(QEvent*) ()
#20 0x00005555568e470c in QApplicationPrivate::notify_helper(QObject*, QEvent*) ()
#21 0x00005555568ec2c7 in QApplication::notify(QObject*, QEvent*) ()
#22 0x000055555675ce38 in QCoreApplication::notifyInternal2(QObject*, QEvent*) ()
#23 0x00005555568eb1e2 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) ()

```