### PR TITLE
Add support for raw script addresses

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -185,6 +185,7 @@ testScripts = [
     'sendtoaddress.py',
     'stakeimmaturebalance.py',
     'rpc-help.py',
+    'createrawscriptaddress.py'
 ]
 #if ENABLE_ZMQ:
 #    testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/createrawscriptaddress.py
+++ b/qa/rpc-tests/createrawscriptaddress.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Navcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import NavCoinTestFramework
+from test_framework.util import *
+
+class CreateRawScriptAddress(NavCoinTestFramework):
+    """Tests the creation of a raw script address."""
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = self.setup_nodes()
+        self.is_network_split = split
+
+    def run_test(self):
+        assert(self.nodes[0].validateaddress("3HnzbJ4TR9")["isvalid"] == True)
+        assert(self.nodes[0].validateaddress("3HnzbJ4TR9")["scriptPubKey"] == "6ac1")
+
+        self.nodes[0].staking(False)
+        self.nodes[0].generate(100)
+        self.nodes[0].sendtoaddress("3HnzbJ4TR9", 100)
+        self.nodes[0].generate(1)
+
+        assert(self.nodes[0].getinfo()["communityfund"]["available"] == 100)
+
+if __name__ == '__main__':
+    CreateRawScriptAddress().main()

--- a/qa/rpc-tests/createrawscriptaddress.py
+++ b/qa/rpc-tests/createrawscriptaddress.py
@@ -19,6 +19,7 @@ class CreateRawScriptAddress(NavCoinTestFramework):
         self.is_network_split = split
 
     def run_test(self):
+        assert(self.nodes[0].createrawscriptaddress("6ac1") == "3HnzbJ4TR9")
         assert(self.nodes[0].validateaddress("3HnzbJ4TR9")["isvalid"] == True)
         assert(self.nodes[0].validateaddress("3HnzbJ4TR9")["scriptPubKey"] == "6ac1")
 

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -252,6 +252,12 @@ bool CNavCoinAddress::Set(const CScriptID& id)
     return true;
 }
 
+bool CNavCoinAddress::Set(const CScript& scriptIn)
+{
+    SetData(Params().Base58Prefix(CChainParams::RAW_SCRIPT_ADDRESS), &scriptIn[0], scriptIn.size());
+    return true;
+}
+
 bool CNavCoinAddress::Set(const CTxDestination& dest)
 {
     return boost::apply_visitor(CNavCoinAddressVisitor(this), dest);
@@ -286,6 +292,8 @@ bool CNavCoinAddress::IsValid(const CChainParams& params) const
 {
     if (vchVersion == params.Base58Prefix(CChainParams::COLDSTAKING_ADDRESS))
         return vchData.size() == 40;
+    if (vchVersion == params.Base58Prefix(CChainParams::RAW_SCRIPT_ADDRESS))
+        return vchData.size() > 0;
     bool fCorrectSize = vchData.size() == 20;
     bool fKnownVersion = vchVersion == params.Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
                          vchVersion == params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
@@ -311,6 +319,8 @@ CTxDestination CNavCoinAddress::Get() const
         return CKeyID(id);
     else if (vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS))
         return CScriptID(id);
+    else if (vchVersion == Params().Base58Prefix(CChainParams::RAW_SCRIPT_ADDRESS))
+        return CScript(vchData.begin(), vchData.end());
     else
         return CNoDestination();
 }
@@ -369,6 +379,11 @@ bool CNavCoinAddress::GetSpendingKeyID(CKeyID& keyID) const
 bool CNavCoinAddress::IsScript() const
 {
     return IsValid() && vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+}
+
+bool CNavCoinAddress::IsRawScript() const
+{
+    return IsValid() && vchVersion == Params().Base58Prefix(CChainParams::RAW_SCRIPT_ADDRESS);
 }
 
 void CNavCoinSecret::SetKey(const CKey& vchSecret)

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -320,7 +320,11 @@ CTxDestination CNavCoinAddress::Get() const
     else if (vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS))
         return CScriptID(id);
     else if (vchVersion == Params().Base58Prefix(CChainParams::RAW_SCRIPT_ADDRESS))
-        return CScript(vchData.begin(), vchData.end());
+    {
+        std::vector<unsigned char> vData(vchData.size());
+        memcpy(&vData[0], &vchData[0], vchData.size());
+        return CScript(vData.begin(), vData.end());
+    }
     else
         return CNoDestination();
 }

--- a/src/base58.h
+++ b/src/base58.h
@@ -109,16 +109,19 @@ public:
     bool Set(const CKeyID &id);
     bool Set(const CKeyID &id, const CKeyID &id2);
     bool Set(const CScriptID &id);
+    bool Set(const CScript &scriptIn);
     bool Set(const CTxDestination &dest);
     bool IsValid() const;
     bool IsValid(const CChainParams &params) const;
     bool IsColdStakingAddress(const CChainParams& params) const;
+    bool IsRawScript() const;
 
     CNavCoinAddress() {}
     CNavCoinAddress(const CTxDestination &dest) { Set(dest); }
     CNavCoinAddress(const CKeyID &id, const CKeyID &id2) { Set(id, id2); }
     CNavCoinAddress(const std::string& strAddress) { SetString(strAddress); }
     CNavCoinAddress(const char* pszAddress) { SetString(pszAddress); }
+    CNavCoinAddress(const CScript &scriptIn) { Set(scriptIn); }
 
     CTxDestination Get() const;
     bool GetKeyID(CKeyID &keyID) const;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -216,6 +216,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,53);
         base58Prefixes[COLDSTAKING_ADDRESS] = std::vector<unsigned char>(1,21); // cold staking addresses start with 'X'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,85);
+        base58Prefixes[RAW_SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,150);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
@@ -417,6 +418,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[COLDSTAKING_ADDRESS] = std::vector<unsigned char>(1,8); // cold staking addresses start with 'C/D'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[RAW_SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x40)(0x88)(0x2B)(0xE1).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x40)(0x88)(0xDA)(0x4E).convert_to_container<std::vector<unsigned char> >();
@@ -602,6 +604,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[COLDSTAKING_ADDRESS] = std::vector<unsigned char>(1,63); // cold staking addresses start with 'S'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[RAW_SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x40)(0x88)(0x2B)(0xE1).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x40)(0x88)(0xDA)(0x4E).convert_to_container<std::vector<unsigned char> >();
@@ -777,6 +780,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[COLDSTAKING_ADDRESS] = std::vector<unsigned char>(1,63); // cold staking addresses start with 'S'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
+        base58Prefixes[RAW_SCRIPT_ADDRESS] = std::vector<unsigned char>(1,60);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x40)(0x88)(0x2B)(0xE1).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x40)(0x88)(0xDA)(0x4E).convert_to_container<std::vector<unsigned char> >();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -47,6 +47,7 @@ public:
     enum Base58Type {
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
+        RAW_SCRIPT_ADDRESS,
         SECRET_KEY,
         EXT_PUBLIC_KEY,
         EXT_SECRET_KEY,

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -368,6 +368,12 @@ public:
         *script << OP_HASH160 << ToByteVector(scriptID) << OP_EQUAL;
         return true;
     }
+
+    bool operator()(const CScript &scriptIn) const {
+        script->clear();
+        *script += scriptIn;
+        return true;
+    }
 };
 }
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -76,7 +76,7 @@ public:
  *  * Pair of two CKeyID: TX_COLDSTAKING destination
  *  A CTxDestination is the internal data type encoded in a CNavCoinAddress
  */
-typedef boost::variant<CNoDestination, CKeyID, CScriptID, pair<CKeyID, CKeyID>> CTxDestination;
+typedef boost::variant<CNoDestination, CKeyID, CScriptID, pair<CKeyID, CKeyID>, CScript> CTxDestination;
 
 const char* GetTxnOutputType(txnouttype t);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -115,6 +115,27 @@ string AccountFromValue(const UniValue& value)
     return strAccount;
 }
 
+UniValue createrawscriptaddress(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "createrawscriptaddress \"hex script\"\n"
+            "\nReturns the NavCoin address for the specified raw hex script.\n"
+            "\nArguments:\n"
+            "1. \"hex script\"        (string) The hex script to encode in the address.\n"
+            "\nResult:\n"
+            "\"navcoinaddress\"    (string) The  navcoin address\n"
+            "\nExamples:\n"
+            + HelpExampleCli("createrawscriptaddress", "6ac4c5")
+        );
+
+    std::string data = params[0].get_str();
+
+    std::vector<unsigned char> vData = ParseHex(data);
+
+    return CNavCoinAddress(CScript(vData.begin(), vData.end())).ToString();
+}
+
 UniValue getnewaddress(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))
@@ -3697,6 +3718,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "addmultisigaddress",       &addmultisigaddress,       true  },
     { "wallet",             "addwitnessaddress",        &addwitnessaddress,        true  },
     { "wallet",             "backupwallet",             &backupwallet,             true  },
+    { "wallet",             "createrawscriptaddress",   &createrawscriptaddress,   true  },
     { "wallet",             "dumpprivkey",              &dumpprivkey,              true  },
     { "wallet",             "dumpmasterprivkey",        &dumpmasterprivkey,        true  },
     { "wallet",             "dumpmnemonic",             &dumpmnemonic,             true  },


### PR DESCRIPTION
This PR adds support for a new type of addresses which encode raw scripts.

A new rpc command has been added `createrawscriptaddress`.

Example: `createrawscriptaddress 6ac1` outputs `3HnzbJ4TR9`. Sending coins to `3HnzbJ4TR9` would send them to the DAO Fund.

This enables to easily redirect stake rewards to any special script (like the DAO fund).