### PR TITLE
Staking reward setup GUI

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -158,8 +158,9 @@ QT_MOC_CPP = \
 	qt/moc_communityfundcreatepaymentrequestdialog.cpp \
 	qt/moc_peertablemodel.cpp \
 	qt/moc_paymentserver.cpp \
-	qt/moc_qvalidatedlineedit.cpp \
-	qt/moc_qvalidatedplaintextedit.cpp \
+  qt/moc_qjsonmodel.cpp \
+  qt/moc_qvalidatedlineedit.cpp \
+  qt/moc_qvalidatedplaintextedit.cpp \
 	qt/moc_qvalidatedspinbox.cpp \
 	qt/moc_qvaluecombobox.cpp \
 	qt/moc_receivecoinsdialog.cpp \
@@ -171,6 +172,7 @@ QT_MOC_CPP = \
 	qt/moc_sendcommunityfunddialog.cpp \
 	qt/moc_communityfundsuccessdialog.cpp \
 	qt/moc_signverifymessagedialog.cpp \
+  qt/moc_splitrewards.cpp \
 	qt/moc_splashscreen.cpp \
 	qt/moc_trafficgraphwidget.cpp \
 	qt/moc_transactiondesc.cpp \
@@ -229,6 +231,8 @@ NAVCOIN_QT_H = \
 	qt/guiconstants.h \
 	qt/guiutil.h \
 	qt/intro.h \
+  qt/qjsonitem.h \
+  qt/qjsonmodel.h \
 	qt/listview.h \
 	qt/macdockiconhandler.h \
 	qt/macnotificationhandler.h \
@@ -268,6 +272,7 @@ NAVCOIN_QT_H = \
 	qt/communityfundsuccessdialog.h \
 	qt/signverifymessagedialog.h \
 	qt/skinize.h \
+  qt/splitrewards.h \
 	qt/splashscreen.h \
 	qt/trafficgraphwidget.h \
 	qt/transactiondesc.h \
@@ -414,6 +419,8 @@ NAVCOIN_QT_CPP += \
 	qt/communityfunddisplaydetailed.cpp \
 	qt/communityfundcreateproposaldialog.cpp \
 	qt/communityfundcreatepaymentrequestdialog.cpp \
+  qt/qjsonitem.cpp \
+  qt/qjsonmodel.cpp \
 	qt/paymentrequestplus.cpp \
 	qt/paymentserver.cpp \
 	qt/receivecoinsdialog.cpp \
@@ -424,6 +431,7 @@ NAVCOIN_QT_CPP += \
 	qt/sendcommunityfunddialog.cpp \
 	qt/communityfundsuccessdialog.cpp \
 	qt/signverifymessagedialog.cpp \
+  qt/splitrewards.cpp \
 	qt/transactiondesc.cpp \
 	qt/transactiondescdialog.cpp \
 	qt/transactionfilterproxy.cpp \

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -1053,7 +1053,7 @@
         </widget>
        </item>
        <item alignment="Qt::AlignLeft">
-        <widget class="QPushButton" name="pushButton">
+        <widget class="QPushButton" name="showStakingSetup">
          <property name="text">
           <string>Set up Staking Rewards</string>
          </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>822</width>
-    <height>690</height>
+    <height>755</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -1049,6 +1049,13 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item alignment="Qt::AlignLeft">
+        <widget class="QPushButton" name="pushButton">
+         <property name="text">
+          <string>Set up Staking Rewards</string>
          </property>
         </widget>
        </item>

--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -153,6 +153,7 @@ NavCoinGUI::NavCoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     unlockWalletAction(0),
     lockWalletAction(0),
     toggleStakingAction(0),
+    splitRewardAction(0),
     lastDialogShown(0),
     platformStyle(platformStyle),
     updatePriceAction(0),
@@ -403,6 +404,9 @@ void NavCoinGUI::createActions()
     toggleStakingAction = new QAction(tr("Toggle &Staking"), this);
     toggleStakingAction->setStatusTip(tr("Toggle Staking"));
 
+    splitRewardAction = new QAction(tr("Set up staking rewards"), this);
+    splitRewardAction->setStatusTip(tr("Configure how to split the staking rewards"));
+
     historyAction = new QAction(platformStyle->SingleColorIcon(":/icons/history"), tr("&Transactions"), this);
     historyAction->setStatusTip(tr("Browse transaction history"));
     historyAction->setToolTip(historyAction->statusTip());
@@ -431,6 +435,7 @@ void NavCoinGUI::createActions()
     connect(historyAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
     connect(toggleStakingAction, SIGNAL(triggered()), this, SLOT(toggleStaking()));
+    connect(splitRewardAction, SIGNAL(triggered()), this, SLOT(splitRewards()));
 #endif // ENABLE_WALLET
 
     quitAction = new QAction(platformStyle->TextColorIcon(":/icons/quit"), tr("E&xit"), this);
@@ -569,6 +574,7 @@ void NavCoinGUI::createMenuBar()
         settings->addAction(changePassphraseAction);
         settings->addSeparator();
         settings->addAction(toggleStakingAction);
+        settings->addAction(splitRewardAction);
         settings->addSeparator();
         settings->addAction(updatePriceAction);
     }
@@ -1630,6 +1636,11 @@ void NavCoinGUI::toggleStaking()
 
     Q_EMIT message(tr("Staking"), GetStaking() ? tr("Staking has been enabled") : tr("Staking has been disabled"),
                    CClientUIInterface::MSG_INFORMATION);
+}
+
+void NavCoinGUI::splitRewards()
+{
+    walletFrame->splitRewards();
 }
 
 #ifdef ENABLE_WALLET

--- a/src/qt/navcoingui.h
+++ b/src/qt/navcoingui.h
@@ -136,6 +136,7 @@ private:
     QAction *unlockWalletAction;
     QAction *lockWalletAction;
     QAction *toggleStakingAction;
+    QAction *splitRewardAction;
     QPushButton *topMenu1; // Home
     QPushButton *topMenu2; // Send
     QPushButton *topMenu3; // Recieve
@@ -275,6 +276,7 @@ private Q_SLOTS:
     void updateDisplayUnit(int unit);
     /** Toggle Staking **/
     void toggleStaking();
+    void splitRewards();
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -419,7 +419,7 @@ void OverviewPage::updateStakeReportNow()
     updateStakeReport(true);
 }
 
-void OverviewPage::on_pushButton_clicked()
+void OverviewPage::on_showStakingSetup_clicked()
 {
     SplitRewardsDialog dlg(this);
     dlg.setModel(walletModel);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -418,3 +418,10 @@ void OverviewPage::updateStakeReportNow()
 {
     updateStakeReport(true);
 }
+
+void OverviewPage::on_pushButton_clicked()
+{
+    SplitRewardsDialog dlg(this);
+    dlg.setModel(walletModel);
+    dlg.exec();
+}

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -62,7 +62,7 @@ public Q_SLOTS:
     void updateStakeReportNow();
     void updateStakeReportbalanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount);
     void setVotingStatus(QString text);
-    void on_pushButton_clicked();
+    void on_showStakingSetup_clicked();
 
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -6,6 +6,7 @@
 #define NAVCOIN_QT_OVERVIEWPAGE_H
 
 #include "amount.h"
+#include "splitrewards.h"
 
 #include <QWidget>
 #include <QPushButton>
@@ -61,11 +62,11 @@ public Q_SLOTS:
     void updateStakeReportNow();
     void updateStakeReportbalanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount);
     void setVotingStatus(QString text);
-
+    void on_pushButton_clicked();
 
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
-    void outOfSyncWarningClicked();
+    void outOfSyncWarningClicked();    
 
 private:
     Ui::OverviewPage *ui;

--- a/src/qt/qjsonitem.cpp
+++ b/src/qt/qjsonitem.cpp
@@ -1,0 +1,136 @@
+/***********************************************
+    Copyright (C) 2014  Schutz Sacha
+    This file is part of QJsonModel (https://github.com/dridk/QJsonmodel).
+
+    QJsonModel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QJsonModel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QJsonModel.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************/
+
+#include "qjsonitem.h"
+
+QJsonTreeItem::QJsonTreeItem(QJsonTreeItem *parent)
+{
+
+    mParent = parent;
+
+
+}
+
+QJsonTreeItem::~QJsonTreeItem()
+{
+    qDeleteAll(mChilds);
+
+}
+
+void QJsonTreeItem::appendChild(QJsonTreeItem *item)
+{
+    mChilds.append(item);
+}
+
+QJsonTreeItem *QJsonTreeItem::child(int row)
+{
+    return mChilds.value(row);
+}
+
+QJsonTreeItem *QJsonTreeItem::parent()
+{
+    return mParent;
+}
+
+int QJsonTreeItem::childCount() const
+{
+    return mChilds.count();
+}
+
+int QJsonTreeItem::row() const
+{
+    if (mParent)
+        return mParent->mChilds.indexOf(const_cast<QJsonTreeItem*>(this));
+
+    return 0;
+}
+
+void QJsonTreeItem::setKey(const QString &key)
+{
+    mKey = key;
+}
+
+void QJsonTreeItem::setValue(const QString &value)
+{
+    mValue = value;
+}
+
+void QJsonTreeItem::setType(const QJsonValue::Type &type)
+{
+    mType = type;
+}
+
+QString QJsonTreeItem::key() const
+{
+    return mKey;
+}
+
+QString QJsonTreeItem::value() const
+{
+    return mValue;
+}
+
+QJsonValue::Type QJsonTreeItem::type() const
+{
+    return mType;
+}
+
+QJsonTreeItem* QJsonTreeItem::load(const QJsonValue& value, QJsonTreeItem* parent)
+{
+
+
+    QJsonTreeItem * rootItem = new QJsonTreeItem(parent);
+    rootItem->setKey("root");
+
+    if ( value.isObject())
+    {
+
+        //Get all QJsonValue childs
+        for (QString key: value.toObject().keys()){
+            QJsonValue v = value.toObject().value(key);
+            QJsonTreeItem * child = load(v,rootItem);
+            child->setKey(key);
+            child->setType(v.type());
+            rootItem->appendChild(child);
+
+        }
+
+    }
+
+    else if ( value.isArray())
+    {
+        //Get all QJsonValue childs
+        int index = 0;
+        for (QJsonValue v: value.toArray()){
+
+            QJsonTreeItem * child = load(v,rootItem);
+            child->setKey(QString::number(index));
+            child->setType(v.type());
+            rootItem->appendChild(child);
+            ++index;
+        }
+    }
+    else
+    {
+        rootItem->setValue(value.toVariant().toString());
+        rootItem->setType(value.type());
+    }
+
+    return rootItem;
+}

--- a/src/qt/qjsonitem.h
+++ b/src/qt/qjsonitem.h
@@ -1,0 +1,43 @@
+#ifndef JSONITEM_H
+#define JSONITEM_H
+
+#include <QtCore>
+#include <QJsonValue>
+#include <QJsonArray>
+#include <QJsonObject>
+
+class QJsonTreeItem
+{
+public:
+    QJsonTreeItem(QJsonTreeItem * parent = 0);
+    ~QJsonTreeItem();
+    void appendChild(QJsonTreeItem * item);
+    QJsonTreeItem *child(int row);
+    QJsonTreeItem *parent();
+    int childCount() const;
+    int row() const;
+    void setKey(const QString& key);
+    void setValue(const QString& value);
+    void setType(const QJsonValue::Type& type);
+    QString key() const;
+    QString value() const;
+    QJsonValue::Type type() const;
+
+
+    static QJsonTreeItem* load(const QJsonValue& value, QJsonTreeItem * parent = 0);
+
+protected:
+
+
+private:
+    QString mKey;
+    QString mValue;
+    QJsonValue::Type mType;
+
+    QList<QJsonTreeItem*> mChilds;
+    QJsonTreeItem * mParent;
+
+
+};
+
+#endif // JSONITEM_H

--- a/src/qt/qjsonmodel.cpp
+++ b/src/qt/qjsonmodel.cpp
@@ -1,0 +1,175 @@
+/***********************************************
+    Copyright (C) 2014  Schutz Sacha
+    This file is part of QJsonModel (https://github.com/dridk/QJsonmodel).
+
+    QJsonModel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QJsonModel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QJsonModel.  If not, see <http://www.gnu.org/licenses/>.
+
+**********************************************/
+
+#include "qjsonmodel.h"
+#include <QFile>
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QIcon>
+#include <QFont>
+
+QJsonModel::QJsonModel(QObject *parent) :
+    QAbstractItemModel(parent)
+{
+    mRootItem = new QJsonTreeItem;
+    mHeaders.append("key");
+    mHeaders.append("value");
+}
+
+QJsonModel::QJsonModel(QString h1, QString h2) :
+    QAbstractItemModel(0)
+{
+    mRootItem = new QJsonTreeItem;
+    mHeaders.append(h1);
+    mHeaders.append(h2);
+}
+
+bool QJsonModel::load(const QString &fileName)
+{
+    QFile file(fileName);
+    bool success = false;
+    if (file.open(QIODevice::ReadOnly)) {
+        success = load(&file);
+        file.close();
+    }
+    else success = false;
+
+    return success;
+}
+
+bool QJsonModel::load(QIODevice *device)
+{
+    return loadJson(device->readAll());
+}
+
+bool QJsonModel::loadJson(const QByteArray &json)
+{
+    mDocument = QJsonDocument::fromJson(json);
+
+    if (!mDocument.isNull())
+    {
+        beginResetModel();
+        if (mDocument.isArray()) {
+            mRootItem = QJsonTreeItem::load(QJsonValue(mDocument.array()));
+        } else {
+            mRootItem = QJsonTreeItem::load(QJsonValue(mDocument.object()));
+        }
+        endResetModel();
+        return true;
+    }
+    return false;
+}
+
+
+QVariant QJsonModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    QJsonTreeItem *item = static_cast<QJsonTreeItem*>(index.internalPointer());
+
+    if ((role == Qt::DecorationRole) && (index.column() == 0))
+    {
+        return mTypeIcons.value(item->type());
+    }
+
+
+    if (role == Qt::DisplayRole)
+    {
+        if (index.column() == 0)
+            return QString("%1").arg(item->key());
+
+        if (index.column() == 1)
+            return QString("%1").arg(item->value());
+    }
+
+    return QVariant();
+}
+
+QVariant QJsonModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation == Qt::Horizontal)
+    {
+        return mHeaders.value(section);
+    }
+    else
+        return QVariant();
+}
+
+QModelIndex QJsonModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (!hasIndex(row, column, parent))
+        return QModelIndex();
+
+    QJsonTreeItem *parentItem;
+
+    if (!parent.isValid())
+        parentItem = mRootItem;
+    else
+        parentItem = static_cast<QJsonTreeItem*>(parent.internalPointer());
+
+    QJsonTreeItem *childItem = parentItem->child(row);
+    if (childItem)
+        return createIndex(row, column, childItem);
+    else
+        return QModelIndex();
+}
+
+QModelIndex QJsonModel::parent(const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return QModelIndex();
+
+    QJsonTreeItem *childItem = static_cast<QJsonTreeItem*>(index.internalPointer());
+    QJsonTreeItem *parentItem = childItem->parent();
+
+    if (parentItem == mRootItem)
+        return QModelIndex();
+
+    return createIndex(parentItem->row(), 0, parentItem);
+}
+
+int QJsonModel::rowCount(const QModelIndex &parent) const
+{
+    QJsonTreeItem *parentItem;
+    if (parent.column() > 0)
+        return 0;
+
+    if (!parent.isValid())
+        parentItem = mRootItem;
+    else
+        parentItem = static_cast<QJsonTreeItem*>(parent.internalPointer());
+
+    return parentItem->childCount();
+}
+
+int QJsonModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return 2;
+}
+
+void QJsonModel::setIcon(const QJsonValue::Type &type, const QIcon &icon)
+{
+    mTypeIcons.insert(type,icon);
+}

--- a/src/qt/qjsonmodel.h
+++ b/src/qt/qjsonmodel.h
@@ -1,0 +1,38 @@
+#ifndef QJSONMODEL_H
+#define QJSONMODEL_H
+
+#include "qjsonitem.h"
+
+#include <QAbstractItemModel>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QIcon>
+
+class QJsonModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+    QJsonModel(QObject *parent = 0);
+    QJsonModel(QString h1, QString h2);
+    bool load(const QString& fileName);
+    bool load(QIODevice * device);
+    bool loadJson(const QByteArray& json);
+    QVariant data(const QModelIndex &index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+    QModelIndex index(int row, int column,const QModelIndex &parent = QModelIndex()) const;
+    QModelIndex parent(const QModelIndex &index) const;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const;
+    void setIcon(const QJsonValue::Type& type, const QIcon& icon);
+
+private:
+    QJsonTreeItem * mRootItem;
+    QJsonDocument mDocument;
+    QStringList mHeaders;
+    QHash<QJsonValue::Type, QIcon> mTypeIcons;
+
+
+};
+
+#endif // QJSONMODEL_H

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -79,7 +79,11 @@ SplitRewardsDialog::SplitRewardsDialog(QWidget *parent) :
     {
         CTxDestination dest;
         if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, dest)){
-            QString strAddress = QString::fromStdString(CNavCoinAddress(dest).ToString());
+            CNavCoinAddress address(dest);
+            if (address.IsColdStakingAddress(Params()))
+                if (!address.GetStakingAddress(address))
+                    continue;
+            QString strAddress = QString::fromStdString(address.ToString());
             if (mapAddressBalance.count(strAddress) == 0)
                 mapAddressBalance[strAddress] = 0;
             mapAddressBalance[strAddress] += out.tx->vout[out.i].nValue;

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) 2019 The NavCoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "splitrewards.h"
+
+SplitRewardsDialog::SplitRewardsDialog(QWidget *parent) :
+    strDesc(new QLabel),
+    strLabel(new QLabel),
+    tree(new QTreeView)
+{
+    QVBoxLayout* layout(new QVBoxLayout);
+
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    this->setLayout(layout);
+    this->setStyleSheet(Skinize());
+
+    std::string sJson = GetArg("-stakingaddress", "") == "" ? "{\"all\":{}}" : GetArg("-stakingaddress", "");
+    QJsonDocument jsonResponse = QJsonDocument::fromJson(QString::fromStdString(sJson).toUtf8());
+    jsonObject = jsonResponse.object();
+
+    availableAmount = 100;
+
+    auto *topBox = new QFrame;
+    auto *topBoxLayout = new QHBoxLayout;
+    topBoxLayout->setContentsMargins(QMargins());
+    topBox->setLayout(topBoxLayout);
+
+    QPushButton* changeBtn = new QPushButton(tr("Change"));
+    connect(changeBtn, SIGNAL(clicked()), this, SLOT(onChange()));
+
+    topBoxLayout->addWidget(new QLabel(tr("<b>Staking Rewards Setup</b>")));
+    topBoxLayout->addStretch(1);
+    topBoxLayout->addWidget(strLabel);
+    topBoxLayout->addWidget(changeBtn);
+
+
+    auto *bottomBox = new QFrame;
+    auto *bottomBoxLayout = new QHBoxLayout;
+    bottomBoxLayout->setContentsMargins(QMargins());
+    bottomBox->setLayout(bottomBoxLayout);
+
+    QPushButton* addBtn = new QPushButton(tr("Add"));
+    connect(addBtn, SIGNAL(clicked()), this, SLOT(onAdd()));
+
+    QPushButton* editBtn = new QPushButton(tr("Edit"));
+    connect(editBtn, SIGNAL(clicked()), this, SLOT(onEdit()));
+
+    QPushButton* removeBtn = new QPushButton(tr("Remove"));
+    connect(removeBtn, SIGNAL(clicked()), this, SLOT(onRemove()));
+
+    QPushButton* saveBtn = new QPushButton(tr("Save"));
+    connect(saveBtn, SIGNAL(clicked()), this, SLOT(onSave()));
+
+    QPushButton* quitBtn = new QPushButton(tr("Cancel"));
+    connect(quitBtn, SIGNAL(clicked()), this, SLOT(onQuit()));
+
+    bottomBoxLayout->addWidget(addBtn);
+    bottomBoxLayout->addWidget(editBtn);
+    bottomBoxLayout->addWidget(removeBtn);
+    bottomBoxLayout->addStretch(1);
+    bottomBoxLayout->addWidget(saveBtn);
+    bottomBoxLayout->addWidget(quitBtn);
+
+    layout->addWidget(topBox);
+    layout->addWidget(tree);
+    layout->addWidget(strDesc);
+    layout->addWidget(bottomBox);
+
+    showFor("all");
+}
+
+void SplitRewardsDialog::showFor(QString sin)
+{
+    currentAddress = sin;
+
+    QJsonObject j;
+    QJsonObject jDup;
+
+    if (jsonObject.contains(currentAddress))
+    {
+        j  = jsonObject[currentAddress].toObject();
+    }
+
+    availableAmount = 100;
+    CAmount nCFundContribution =  Params().GetConsensus().nCommunityFundAmountV2;
+
+    QStringList descs;
+
+    for (auto &key: j.keys())
+    {
+        CNavCoinAddress address(key.toStdString());
+        double amount;
+
+        if (address.IsValid())
+        {
+            amount = j[key].toInt();
+
+            if (teamAddresses.count(key))
+            {
+                if (teamAddresses[key] == "Community Fund")
+                    nCFundContribution += PercentageToNav(amount);
+                else
+                    descs << QString::fromStdString(FormatMoney(PercentageToNav(amount))) + " to " + teamAddresses[key];
+                jDup[teamAddresses[key]] = amount;
+            }
+            else {
+                descs << QString::fromStdString(FormatMoney(PercentageToNav(amount))) + " to " + key;
+                jDup[key] = amount;
+            }
+
+            availableAmount -= amount;
+        }
+        else
+        {
+            j.erase(j.find(key));
+        }
+
+        if (availableAmount < 0)
+        {
+            j.erase(j.find(key));
+            jDup.erase(jDup.find(key));
+        }
+    }
+
+    jsonObject[currentAddress] = j;
+
+    QJsonModel* jmodel = new QJsonModel("Address", "Percentage");
+    QJsonDocument doc(jDup);
+
+    tree->setModel(jmodel);
+
+    tree->resizeColumnToContents(1);
+
+    strLabel->setText(currentAddress == "all" ? tr("Default settings") : tr("Settings for ") + currentAddress);
+
+    strDesc->setText(tr("For each block, %1 NAV will go to the Community Fund, %2 and %3 will be accumulated in your own address").arg(QString::fromStdString(FormatMoney(nCFundContribution)), descs.join(", "), QString::fromStdString(FormatMoney(PercentageToNav(availableAmount)))));
+
+    jmodel->loadJson(doc.toJson());
+}
+
+void SplitRewardsDialog::setModel(WalletModel *model)
+{
+    this->model = model;
+}
+
+void SplitRewardsDialog::onAdd()
+{
+    QString address = "";
+
+    bool ok;
+    QString item = QInputDialog::getItem(this, tr("Add a new address"),
+            tr("Choose address:"), teamAddresses.values(), 0, false, &ok);
+
+    if (ok && !item.isEmpty())
+    {
+        if (item == "Custom")
+        {
+            QString item = QInputDialog::getText(this, tr("Add a new address"),
+                    tr("Enter an address:"), QLineEdit::Normal, "", &ok);
+            if (ok && !item.isEmpty())
+            {
+                address = item;
+            }
+            else
+            {
+                return;
+            }
+
+        }
+        else
+        {
+            for (auto& key: teamAddresses.keys())
+            {
+                if (teamAddresses[key] == item)
+                {
+                    address = key;
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        return;
+    }
+
+    if (!CNavCoinAddress(address.toStdString()).IsValid())
+    {
+        QMessageBox msgBox(this);
+        msgBox.setText(tr("Invalid NavCoin Address"));
+        msgBox.addButton(tr("Ok"), QMessageBox::AcceptRole);
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setWindowTitle("Error");
+        msgBox.exec();
+        return;
+    }
+
+    int amount = QInputDialog::getInt(this, tr("Add a new address"),
+                                 tr("Percentage:"), availableAmount, 0, availableAmount, 1, &ok);
+    if (!ok)
+        return;
+
+    QJsonObject j  = jsonObject[currentAddress].toObject();
+    j[address] = amount;
+    jsonObject[currentAddress] = j;
+
+    showFor(currentAddress);
+}
+
+void SplitRewardsDialog::onRemove()
+{
+    QModelIndex index = tree->currentIndex();
+    int row = index.row();
+    QModelIndex indexrow = tree->model()->index(row, 0);
+    QVariant data = tree->model()->data(indexrow);
+    QString text = data.toString();
+    QJsonObject j  = jsonObject[currentAddress].toObject();
+    j.erase(j.find(text));
+    jsonObject[currentAddress] = j;
+    showFor(currentAddress);
+}
+
+void SplitRewardsDialog::onEdit()
+{
+    QModelIndex index = tree->currentIndex();
+    int row = index.row();
+    QModelIndex indexrow = tree->model()->index(row, 0);
+    QVariant data = tree->model()->data(indexrow);
+    QString text = data.toString();
+    QString address = text;
+    for (auto& key: teamAddresses.keys())
+    {
+        if (teamAddresses[key] == text)
+        {
+            address = key;
+            break;
+        }
+    }
+    QJsonObject j  = jsonObject[currentAddress].toObject();
+    bool ok;
+    int amount = QInputDialog::getInt(this, tr("Edit address %1").arg(text),
+                                 tr("Percentage:"), j[address].toInt(), 0, availableAmount+j[address].toInt(), 1, &ok);
+    if (!ok)
+        return;
+    j[address] = amount;
+    jsonObject[currentAddress] = j;
+    showFor(currentAddress);
+}
+
+void SplitRewardsDialog::onSave()
+{
+    QJsonDocument doc(jsonObject);
+    QString strJson(doc.toJson(QJsonDocument::Compact));
+    SoftSetArg("-stakingaddress", strJson.toStdString(), true);
+    RemoveConfigFile("stakingaddress");
+    WriteConfigFile("stakingaddress", strJson.toStdString());
+    QDialog::accept();
+}
+
+void SplitRewardsDialog::onQuit()
+{
+    QDialog::accept();
+}
+
+void SplitRewardsDialog::onChange()
+{
+    bool ok;
+    QString item = QInputDialog::getText(this, tr("Set up a concrete address"),
+            tr("Enter an address (\"all\" for default settings):"), QLineEdit::Normal, "", &ok);
+    if (ok && !item.isEmpty() && (CNavCoinAddress(item.toStdString()).IsValid() || item == "all"))
+    {
+        showFor(item);
+    }
+    else
+    {
+        return;
+    }
+}
+
+CAmount PercentageToNav(int percentage)
+{
+    return Params().GetConsensus().nStaticReward * percentage / 100;
+}

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -31,6 +31,7 @@ SplitRewardsDialog::SplitRewardsDialog(QWidget *parent) :
     topBoxLayout->addWidget(new QLabel(tr("Setup for staking address:")));
     topBoxLayout->addWidget(comboAddress);
 
+    strDesc->setWordWrap(true);
 
     auto *bottomBox = new QFrame;
     auto *bottomBoxLayout = new QHBoxLayout;

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -178,7 +178,7 @@ void SplitRewardsDialog::onAdd()
     if (availableAmount <= 0)
     {
         QMessageBox msgBox(this);
-        msgBox.setText(tr("You are already contributing the 100% of your staking rewards."));
+        msgBox.setText(tr("You are already contributing 100% of your staking rewards."));
         msgBox.addButton(tr("Ok"), QMessageBox::AcceptRole);
         msgBox.setIcon(QMessageBox::Warning);
         msgBox.setWindowTitle("Error");

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -175,6 +175,17 @@ void SplitRewardsDialog::setModel(WalletModel *model)
 
 void SplitRewardsDialog::onAdd()
 {
+    if (availableAmount <= 0)
+    {
+        QMessageBox msgBox(this);
+        msgBox.setText(tr("You are already contributing the 100% of your staking rewards."));
+        msgBox.addButton(tr("Ok"), QMessageBox::AcceptRole);
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setWindowTitle("Error");
+        msgBox.exec();
+        return;
+    }
+
     QString address = "";
 
     bool ok;

--- a/src/qt/splitrewards.cpp
+++ b/src/qt/splitrewards.cpp
@@ -71,7 +71,7 @@ SplitRewardsDialog::SplitRewardsDialog(QWidget *parent) :
     std::map<QString, CAmount> mapAddressBalance;
 
     std::vector<COutput> vCoins;
-    pwalletMain->AvailableCoins(vCoins);
+    pwalletMain->AvailableCoinsForStaking(vCoins, GetTime());
 
     comboAddress->clear();
     comboAddress->insertItem(0, "Default", "all");

--- a/src/qt/splitrewards.h
+++ b/src/qt/splitrewards.h
@@ -11,6 +11,7 @@
 #include "utilmoneystr.h"
 #include "walletmodel.h"
 
+#include <QComboBox>
 #include <QDialog>
 #include <QInputDialog>
 #include <QJsonObject>
@@ -43,15 +44,14 @@ private:
     QJsonObject jsonObject;
     QString currentAddress;
     QLabel *strDesc;
-    QLabel *strLabel;
     QTreeView *tree;
+    QComboBox *comboAddress;
 
     int availableAmount;
 
 private Q_SLOTS:
     void onAdd();
     void onRemove();
-    void onChange();
     void onSave();
     void onEdit();
     void onQuit();

--- a/src/qt/splitrewards.h
+++ b/src/qt/splitrewards.h
@@ -24,6 +24,7 @@
 #include <QVBoxLayout>
 
 static QMap<QString, QString> teamAddresses = {{"NN5QSSMAdtRU35BffLZUw9vChnhHKKMeuL", "Alex aguycalled - Core Dev"},
+                                               {"NRXfZ1egFxMSUsc4Ufpi4Lm7DdXStYmeBG", "mxaddict - Core Dev"},
                                                {"3HnzbJ4TR9", "Community Fund"},
                                                {"XVPMwBdNU9ou3a3TnwaVgAgEecbdsEVZHbVmeY4TMAHbY6BdtY8xW6m1Q1rkb", "Core Dev Bounty"},
                                                {"XAznGHuQ35hvgSGsVWi5Nu2Y6n3rT4cycE3yfZWCfnNjycCGdGAEnta2G24Mi", "Web Dev Bounty"},

--- a/src/qt/splitrewards.h
+++ b/src/qt/splitrewards.h
@@ -24,6 +24,7 @@
 #include <QVBoxLayout>
 
 static QMap<QString, QString> teamAddresses = {{"NN5QSSMAdtRU35BffLZUw9vChnhHKKMeuL", "Alex aguycalled - Core Dev"},
+                                               {"NPAxaKnCb7ukrUvFmntSyZWcZgbrGHUeC4", "Craig proletesseract - Core Dev"},
                                                {"NRXfZ1egFxMSUsc4Ufpi4Lm7DdXStYmeBG", "mxaddict - Core Dev"},
                                                {"3HnzbJ4TR9", "Community Fund"},
                                                {"XVPMwBdNU9ou3a3TnwaVgAgEecbdsEVZHbVmeY4TMAHbY6BdtY8xW6m1Q1rkb", "Core Dev Bounty"},

--- a/src/qt/splitrewards.h
+++ b/src/qt/splitrewards.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 The NavCoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SPLITREWARDS_H
+#define SPLITREWARDS_H
+
+#include "skinize.h"
+#include "util.h"
+#include "qjsonmodel.h"
+#include "utilmoneystr.h"
+#include "walletmodel.h"
+
+#include <QDialog>
+#include <QInputDialog>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStringList>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+static QMap<QString, QString> teamAddresses = {{"NN5QSSMAdtRU35BffLZUw9vChnhHKKMeuL", "Alex aguycalled - Core Dev"},
+                                               {"3HnzbJ4TR9", "Community Fund"},
+                                               {"XVPMwBdNU9ou3a3TnwaVgAgEecbdsEVZHbVmeY4TMAHbY6BdtY8xW6m1Q1rkb", "Core Dev Bounty"},
+                                               {"XAznGHuQ35hvgSGsVWi5Nu2Y6n3rT4cycE3yfZWCfnNjycCGdGAEnta2G24Mi", "Web Dev Bounty"},
+                                               {"", "Custom"}};
+
+class SplitRewardsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    SplitRewardsDialog(QWidget *parent);
+
+    void setModel(WalletModel *model);
+    void showFor(QString address);
+
+private:
+    WalletModel *model;
+    QJsonObject jsonObject;
+    QString currentAddress;
+    QLabel *strDesc;
+    QLabel *strLabel;
+    QTreeView *tree;
+
+    int availableAmount;
+
+private Q_SLOTS:
+    void onAdd();
+    void onRemove();
+    void onChange();
+    void onSave();
+    void onEdit();
+    void onQuit();
+};
+
+CAmount PercentageToNav(int percentage);
+
+#endif // SPLITREWARDS_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -60,13 +60,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         if (wtx.IsCoinStake())
         {
             for (unsigned int j = 0; j < wtx.vout.size(); j++)
-            {
                 if (wtx.vout[j].scriptPubKey != wtx.vout[1].scriptPubKey && wallet->IsMine(wtx.vout[j]))
-                {
                     nExternalReward += wtx.vout[j].nValue;
-                    break;
-                }
-            }
         }
 
         bool fAddedReward = false;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -56,12 +56,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         // Credit
         //
         unsigned int i = 0;
-        CAmount nExternalReward = 0;
+        CAmount nReward = -nDebit;
         if (wtx.IsCoinStake())
         {
             for (unsigned int j = 0; j < wtx.vout.size(); j++)
-                if (wtx.vout[j].scriptPubKey != wtx.vout[1].scriptPubKey && wallet->IsMine(wtx.vout[j]))
-                    nExternalReward += wtx.vout[j].nValue;
+                if (wtx.vout[j].scriptPubKey == wtx.vout[1].scriptPubKey)
+                    nReward += wtx.vout[j].nValue;
         }
 
         bool fAddedReward = false;
@@ -111,7 +111,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                             fAddedReward = true;
 
                             sub.type = TransactionRecord::Staked;
-                            sub.credit = nNet - nExternalReward;
+                            sub.credit = nReward;
                         }
                     }
                     else

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -214,6 +214,13 @@ void WalletFrame::setVotingStatus(QString text)
         i.value()->setVotingStatus(text);
 }
 
+void WalletFrame::splitRewards()
+{
+    QMap<QString, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->splitRewards();
+}
+
 void WalletFrame::gotoHistoryPage()
 {
     QMap<QString, WalletView*>::const_iterator i;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -112,6 +112,8 @@ public Q_SLOTS:
 
     void setVotingStatus(QString text);
 
+    void splitRewards();
+
     /** Show used sending addresses */
     void usedSendingAddresses();
     /** Show used receiving addresses */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -352,6 +352,13 @@ void WalletView::unlockWallet()
     }
 }
 
+void WalletView::splitRewards()
+{
+    SplitRewardsDialog dlg(this);
+    dlg.setModel(walletModel);
+    dlg.exec();
+}
+
 void WalletView::exportMasterPrivateKeyAction()
 {
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -6,6 +6,7 @@
 #define NAVCOIN_QT_WALLETVIEW_H
 
 #include "amount.h"
+#include "splitrewards.h"
 
 #include <QStackedWidget>
 #include <QPushButton>
@@ -110,6 +111,8 @@ public Q_SLOTS:
     void lockWallet();
     void importPrivateKey();
     void exportMasterPrivateKeyAction();
+
+    void splitRewards();
 
     /** Show used sending addresses */
     void usedSendingAddresses();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1868,11 +1868,8 @@ void GetReceived(const COutputEntry& r, const CWalletTx& wtx, const string& strA
         {
             entry.pushKV("category", "receive");
         }
-        if (!wtx.IsCoinStake())
-            entry.pushKV("amount", ValueFromAmount(r.amount));
-        else {
-            entry.pushKV("amount", ValueFromAmount(-nFee));
-        }
+        entry.pushKV("amount", ValueFromAmount(r.amount));
+
         entry.pushKV("canStake", (::IsMine(*pwalletMain, r.destination) & ISMINE_STAKABLE ||
                                           (::IsMine(*pwalletMain, r.destination) & ISMINE_SPENDABLE &&
                                            !CNavCoinAddress(r.destination).IsColdStakingAddress(Params()))) ? true : false);
@@ -1930,20 +1927,9 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
     // Received
     if (listReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
     {
-        if (!wtx.IsCoinStake())
+        BOOST_FOREACH(const COutputEntry& r, listReceived)
         {
-            BOOST_FOREACH(const COutputEntry& r, listReceived)
-            {
-                 GetReceived(r, wtx, strAccount, fLong, ret, nFee, fAllAccounts, involvesWatchonly);
-            }
-        }
-        else
-        {
-            // only get the coinstake reward output
-            if (wtx.GetValueOutCFund() == 0)
-                GetReceived(listReceived.back(), wtx, strAccount, fLong, ret, nFee, fAllAccounts, involvesWatchonly);
-            else
-                GetReceived(*std::prev(listReceived.end(),1), wtx, strAccount, fLong, ret, nFee, fAllAccounts, involvesWatchonly);
+            GetReceived(r, wtx, strAccount, fLong, ret, nFee, fAllAccounts, involvesWatchonly);
         }
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -537,7 +537,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 }
                 else if(find_value(addressMap, lookForKey).isObject())
                 {
-                    find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).getObjMap(splitObject);
+                    find_value(addressMap, lookForKey).getObjMap(splitObject);
 
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -535,8 +535,10 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);
-                        if (!address.IsValid() || nAccumulatedFee+pair.second.get_real() > 100.0)
-                            return error("%s: -stakingaddress includes a wrong address or tries to contribute more than 100%");
+                        if (!address.IsValid())
+                            continue;
+                        if (nAccumulatedFee+pair.second.get_real() > 100.0)
+                            return error("%s: -stakingaddress tries to contribute more than 100%");
 
                         nAccumulatedFee += pair.second.get_real();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -517,7 +517,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
                 if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
                 {
-                    find_value(addressMap, lookForKey).getObjMap(splitObject);
+                    find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).getObjMap(splitObject);
                     if (splitObject.size() > 0)
                         lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -518,7 +518,6 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
                 {
                     find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).getObjMap(splitObject);
-                    LogPrintf("%s %d\n", __func__, splitObject.size());
                     if (splitObject.size() > 0)
                         lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
                 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -518,6 +518,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
                 {
                     find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).getObjMap(splitObject);
+                    LogPrintf("%s %d\n", __func__, splitObject.size());
                     if (splitObject.size() > 0)
                         lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
                 }
@@ -537,6 +538,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 }
                 else if(find_value(addressMap, lookForKey).isObject())
                 {
+                    find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).getObjMap(splitObject);
+
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);
                         if (!address.IsValid() || pair.second.get_real() <= 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -512,9 +512,15 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
                 std::string lookForKey = "all";
 
-                if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isStr()
-                 || find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
+                if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isStr())
                     lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
+
+                if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
+                {
+                    find_value(addressMap, lookForKey).getObjMap(splitObject);
+                    if (splitObject.size() > 0)
+                        lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
+                }
 
                 if(find_value(addressMap, lookForKey).isStr())
                 {
@@ -529,7 +535,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                         return error("%s: -stakingaddress includes a wrong address %s", __func__, find_value(addressMap, lookForKey).get_str());
                     }
                 }
-                else if(find_value(addressMap, lookForKey).isObject() && find_value(addressMap, lookForKey).getObjMap(splitObject) && splitObject.size() > 0)
+                else if(find_value(addressMap, lookForKey).isObject())
                 {
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1833,14 +1833,14 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
         nFee = nDebit - nValueOut + nValueOutCFund;
     }
 
-    CAmount nExternalReward = 0;
+    CAmount nReward = -nDebit;
     if (IsCoinStake())
     {
         for (unsigned int j = 0; j < vout.size(); j++)
         {
-            if (vout[j].scriptPubKey != vout[1].scriptPubKey)
+            if (vout[j].scriptPubKey == vout[1].scriptPubKey)
             {
-                nExternalReward += vout[j].nValue;
+                nReward += vout[j].nValue;
             }
         }
     }
@@ -1897,7 +1897,7 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
             else
             {
                 fAddedReward = true;
-                output.amount = GetValueOut() - nDebit - nExternalReward;
+                output.amount = nReward;
                 listReceived.push_back(output);
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -535,7 +535,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);
-                        if (!address.IsValid())
+                        if (!address.IsValid() || second.get_real() <= 0)
                             continue;
                         if (nAccumulatedFee+pair.second.get_real() > 100.0)
                             return error("%s: -stakingaddress tries to contribute more than 100%");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -529,10 +529,8 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                         return error("%s: -stakingaddress includes a wrong address %s", __func__, find_value(addressMap, lookForKey).get_str());
                     }
                 }
-                else if(find_value(addressMap, lookForKey).isObject())
+                else if(find_value(addressMap, lookForKey).isObject() && find_value(addressMap, lookForKey).getObjMap(splitObject) && splitObject.size() > 0)
                 {
-                    find_value(addressMap, lookForKey).getObjMap(splitObject);
-
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);
                         if (!address.IsValid() || pair.second.get_real() <= 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -535,7 +535,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
 
                     for ( const auto &pair : splitObject ) {
                         address = CNavCoinAddress(pair.first);
-                        if (!address.IsValid() || second.get_real() <= 0)
+                        if (!address.IsValid() || pair.second.get_real() <= 0)
                             continue;
                         if (nAccumulatedFee+pair.second.get_real() > 100.0)
                             return error("%s: -stakingaddress tries to contribute more than 100%");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -429,9 +429,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 LogPrint("coinstake", "CreateCoinStake : added kernel type=%d\n", whichType);
                 fKernelFound = true;
                 break;
-
             }
-
         }
 
         if (fKernelFound)
@@ -484,74 +482,25 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         nCredit += nReward;
     }
 
-    if (nCredit >= Params().GetConsensus().nStakeSplitThreshold)
-        txNew.vout.push_back(CTxOut(0, txNew.vout[1].scriptPubKey)); //split stake
-
-    // Inode Payments
-    int payments = 1;
-    // start inode payments
-    bool bINodePayment = false; // note was false, set true to test
-
-
-    CScript payee;
-    bool hasPayment = false;
-    if(bINodePayment) {
-        //hub
-        // if(!inodePayments.GetBlockPayee(pindexPrev->nHeight+1, payee)){
-        //     int winningNode = GetCurrentINode(1);
-        //         if(winningNode >= 0){
-        //             payee =GetScriptForDestination(vecInodes[winningNode].pubkey.GetID());
-        //         } else {
-        //             LogPrintf("CreateCoinStake: Failed to detect inode to pay\n");
-        //             hasPayment = false;
-        //         }
-        // }
-    }
-
-    if(hasPayment){
-        payments = txNew.vout.size() + 1;
-        txNew.vout.resize(payments);
-
-        txNew.vout[payments-1].scriptPubKey = payee;
-        txNew.vout[payments-1].nValue = 0;
-
-        CTxDestination address1;
-        ExtractDestination(payee, address1);
-        CNavCoinAddress address2(address1);
-
-        LogPrintf("Inode payment to %s\n", address2.ToString().c_str());
-    }
-
     int64_t blockValue = nCredit;
-    int64_t inodePayment = 0; //GetInodePayment(pindexPrev->nHeight+1, nReward);
+    std::map<CNavCoinAddress, double> splitMap;
+    double nAccumulatedFee = 0.0;
 
+    CNavCoinAddress poolFeeAddress(GetArg("-pooladdress", ""));
+    double nPoolFee = GetArg("-poolfee", 0) / 100.0;
 
-    // Set output amount
-    if (!hasPayment && txNew.vout.size() == 3) // 2 stake outputs, stake was split, no inode payment
+    if (nPoolFee > 0 && poolFeeAddress.IsValid())
     {
-        txNew.vout[1].nValue = (blockValue / 2 / CENT) * CENT;
-        txNew.vout[2].nValue = blockValue - txNew.vout[1].nValue;
+        CAmount nRewardAsFee = nReward * nPoolFee;
+        blockValue -= nRewardAsFee;
+        txNew.vout.push_back(CTxOut(nRewardAsFee, GetScriptForDestination(poolFeeAddress.Get())));
     }
-    else if(hasPayment && txNew.vout.size() == 4) // 2 stake outputs, stake was split, plus a inode payment
+    else if (GetArg("-stakingaddress", "") != "")
     {
-        txNew.vout[payments-1].nValue = inodePayment;
-        blockValue -= inodePayment;
-        txNew.vout[1].nValue = (blockValue / 2 / CENT) * CENT;
-        txNew.vout[2].nValue = blockValue - txNew.vout[1].nValue;
-    }
-    else if(!hasPayment && txNew.vout.size() == 2) // only 1 stake output, was not split, no inode payment
-        txNew.vout[1].nValue = blockValue;
-    else if(hasPayment && txNew.vout.size() == 3) // only 1 stake output, was not split, plus a inode payment
-    {
-        txNew.vout[payments-1].nValue = inodePayment;
-        blockValue -= inodePayment;
-        txNew.vout[1].nValue = blockValue;
-    }
-
-    if (GetArg("-stakingaddress", "") != "" && !txNew.vout[txNew.vout.size()-1].scriptPubKey.IsColdStaking()) {
         CNavCoinAddress address;
         UniValue stakingAddress;
         UniValue addressMap(UniValue::VOBJ);
+        std::map<std::string, UniValue> splitObject;
 
         if (stakingAddress.read(GetArg("-stakingaddress", "")))
         {
@@ -561,15 +510,38 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
                 else
                     return error("%s: Failed to read JSON from -stakingaddress argument", __func__);
 
-                // Use "all" address if present
-                if(find_value(addressMap, "all").isStr())
+                std::string lookForKey = "all";
+
+                if (find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isStr()
+                 || find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isObject())
+                    lookForKey = CNavCoinAddress(key.GetPubKey().GetID()).ToString();
+
+                if(find_value(addressMap, lookForKey).isStr())
                 {
-                    address = CNavCoinAddress(find_value(addressMap, "all").get_str());
+                    address = CNavCoinAddress(find_value(addressMap, lookForKey).get_str());
+
+                    if (address.IsValid())
+                    {
+                        splitMap[address] = 100.0;
+                    }
+                    else
+                    {
+                        return error("%s: -stakingaddress includes a wrong address %s", __func__, find_value(addressMap, lookForKey).get_str());
+                    }
                 }
-                // Or use specified address if present
-                if(find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).isStr())
+                else if(find_value(addressMap, lookForKey).isObject())
                 {
-                    address = CNavCoinAddress(find_value(addressMap, CNavCoinAddress(key.GetPubKey().GetID()).ToString()).get_str());
+                    find_value(addressMap, lookForKey).getObjMap(splitObject);
+
+                    for ( const auto &pair : splitObject ) {
+                        address = CNavCoinAddress(pair.first);
+                        if (!address.IsValid() || nAccumulatedFee+pair.second.get_real() > 100.0)
+                            return error("%s: -stakingaddress includes a wrong address or tries to contribute more than 100%");
+
+                        nAccumulatedFee += pair.second.get_real();
+
+                        splitMap[address] = pair.second.get_real();
+                    }
                 }
 
             } catch (const UniValue& objError) {
@@ -581,25 +553,35 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         else
         {
             address = CNavCoinAddress(GetArg("-stakingaddress", ""));
+            if (address.IsValid()) {
+                splitMap[address] = 100;
+            }
         }
 
-        if (address.IsValid()) {
-            txNew.vout[txNew.vout.size()-1].nValue -= nReward;
-            txNew.vout.push_back(CTxOut(nReward, GetScriptForDestination(address.Get())));
+        for (const auto& entry: splitMap)
+        {
+            CAmount thisOut = nReward * entry.second/100.0;
+            blockValue -= thisOut;
+            txNew.vout.push_back(CTxOut(thisOut, GetScriptForDestination(entry.first.Get())));
         }
     }
 
-    CNavCoinAddress poolFeeAddress(GetArg("-pooladdress", ""));
-    double nPoolFee = GetArg("-poolfee", 0) / 100.0;
+    bool fSplit = false;
 
-    if (nPoolFee > 0 && poolFeeAddress.IsValid())
+    if (blockValue >= Params().GetConsensus().nStakeSplitThreshold)
     {
-        CAmount nRewardAsFee = nReward * nPoolFee;
-        txNew.vout[txNew.vout.size()-1].nValue -= nRewardAsFee;
-        if (txNew.vout[txNew.vout.size()-1].nValue == 0)
-            txNew.vout.erase(txNew.vout.begin()+txNew.vout.size()-1);
-        txNew.vout.push_back(CTxOut(nRewardAsFee, GetScriptForDestination(poolFeeAddress.Get())));
+        fSplit = true;
+        txNew.vout.insert(txNew.vout.begin()+2, CTxOut(0, txNew.vout[1].scriptPubKey)); //split stake
     }
+
+    // Set output amount
+    if (fSplit) // 2 stake outputs, stake was split
+    {
+        txNew.vout[1].nValue = (blockValue / 2 / CENT) * CENT;
+        txNew.vout[2].nValue = blockValue - txNew.vout[1].nValue;
+    }
+    else if(!fSplit) // only 1 stake output, was not split
+        txNew.vout[1].nValue = blockValue;
 
     // Adds Community Fund output if enabled
     if(IsCommunityFundAccumulationEnabled(pindexPrev, Params().GetConsensus(), false))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -638,7 +638,6 @@ private:
      */
     bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = NULL) const;
     bool SelectCoinsForStaking(int64_t nTargetValue, unsigned int nSpendTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, int64_t& nValueRet) const;
-    void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
 
     CWalletDB *pwalletdbEncryption;
 
@@ -755,6 +754,7 @@ public:
      * populate vCoins with vector of available COutputs.
      */
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, bool fIncludeColdStaking=false) const;
+    void AvailableCoinsForStaking(std::vector<COutput>& vCoins, unsigned int nSpendTime) const;
 
     /**
      * Shuffle and select coins until nTargetValue is reached while avoiding


### PR DESCRIPTION
This PR adds a new GUI to set up different ways to split the staking rewards. Setup can be done generally for every address or individually per staking address.

Works for both hot and cold staking methods.

Includes the following hardcoded addresses:

```
{"NN5QSSMAdtRU35BffLZUw9vChnhHKKMeuL", "Alex aguycalled - Core Dev"},
{"NRXfZ1egFxMSUsc4Ufpi4Lm7DdXStYmeBG", "mxaddict - Core Dev"},
{"3HnzbJ4TR9", "Community Fund"},
{"XVPMwBdNU9ou3a3TnwaVgAgEecbdsEVZHbVmeY4TMAHbY6BdtY8xW6m1Q1rkb", "Core Dev Bounty"},
{"XAznGHuQ35hvgSGsVWi5Nu2Y6n3rT4cycE3yfZWCfnNjycCGdGAEnta2G24Mi", "Web Dev Bounty"}
```

Please comment in this pull request to add other community member addresses.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/24814046/65363162-c71f1f00-dc0a-11e9-943f-0c23c2bf8f11.png">
<img width="763" alt="image" src="https://user-images.githubusercontent.com/24814046/65363165-cc7c6980-dc0a-11e9-91ff-2510dd3aadf7.png">
