### PR TITLE
Disable CFund client functionality

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -511,7 +511,7 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
-        consensus.fDaoClientActivated = false;
+        consensus.fDaoClientActivated = true;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -126,6 +126,7 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 2722100;
         consensus.nHeightv452Fork = 2882875;
+        consensus.fDaoClientActivated = false;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -328,6 +329,7 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 100000;
         consensus.nHeightv452Fork = 100000;
+        consensus.fDaoClientActivated = true;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -509,6 +511,7 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
+        consensus.fDaoClientActivated = false;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;
@@ -700,6 +703,7 @@ public:
         consensus.nStaticReward = 2 * COIN;
         consensus.nHeightv451Fork = 1000;
         consensus.nHeightv452Fork = 1000;
+        consensus.fDaoClientActivated = true;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -108,6 +108,8 @@ struct Params {
     int nHeightv451Fork;
     int nHeightv452Fork;
 
+    bool fDaoClientActivated;
+
     /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
     int nCoinbaseMaturity;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -208,7 +208,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bo
 
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
-    if(IsCommunityFundEnabled(pindexPrev, chainparams.GetConsensus()) && Params().GetConsensus().fDaoClientActivated)
+    if(IsCommunityFundEnabled(pindexPrev, chainparams.GetConsensus()))
     {
         std::map<uint256, bool> votes;
         for (unsigned int i = 0; i < vAddedProposalVotes.size(); i++)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -205,8 +205,10 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bo
         coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
         coinbaseTx.vout[0].nValue = GetBlockSubsidy(nHeight, chainparams.GetConsensus());
     }
+
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
-    if(IsCommunityFundEnabled(pindexPrev, chainparams.GetConsensus()))
+
+    if(IsCommunityFundEnabled(pindexPrev, chainparams.GetConsensus()) && Params().GetConsensus().fDaoClientActivated)
     {
         std::map<uint256, bool> votes;
         for (unsigned int i = 0; i < vAddedProposalVotes.size(); i++)

--- a/src/qt/communityfundpage.cpp
+++ b/src/qt/communityfundpage.cpp
@@ -392,6 +392,17 @@ void CommunityFundPage::click_radioButtonExpired()
 
 void CommunityFundPage::click_pushButtonCreateProposal()
 {
+    if (!Params().GetConsensus().fDaoClientActivated)
+    {
+        QMessageBox msgBox(this);
+        QString str = tr("This function is temporarily disabled");
+        msgBox.setText(str);
+        msgBox.addButton(tr("Ok"), QMessageBox::AcceptRole);
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setWindowTitle(str);
+        msgBox.exec();
+        return;
+    }
     CommunityFundCreateProposalDialog dlg(this);
     dlg.setModel(walletModel);
     dlg.exec();
@@ -400,6 +411,17 @@ void CommunityFundPage::click_pushButtonCreateProposal()
 
 void CommunityFundPage::click_pushButtonCreatePaymentRequest()
 {
+    if (!Params().GetConsensus().fDaoClientActivated)
+    {
+        QMessageBox msgBox(this);
+        QString str = tr("This function is temporarily disabled");
+        msgBox.setText(str);
+        msgBox.addButton(tr("Ok"), QMessageBox::AcceptRole);
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setWindowTitle(str);
+        msgBox.exec();
+        return;
+    }
     CommunityFundCreatePaymentRequestDialog dlg(this);
     dlg.setModel(walletModel);
     dlg.exec();

--- a/src/qt/communityfundpage.h
+++ b/src/qt/communityfundpage.h
@@ -5,6 +5,7 @@
 #include <consensus/cfund.h>
 #include <wallet/wallet.h>
 
+#include <QMessageBox>
 #include <QWidget>
 #include <QPushButton>
 #include <QListView>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -596,6 +596,9 @@ UniValue createproposal(const UniValue& params, bool fHelp)
             + HelpExampleCli("createproposal", "\"NQFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ\" 12000 3600 \"Promotional stickers for everyone\" 100")
         );
 
+    if (!Params().GetConsensus().fDaoClientActivated)
+        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     CNavCoinAddress address("NQFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ"); // Dummy address
@@ -690,6 +693,9 @@ UniValue createpaymentrequest(const UniValue& params, bool fHelp)
             "\nExamples:\n"
             + HelpExampleCli("createpaymentrequest", "\"196a4c2115d3c1c1dce1156eb2404ad77f3c5e9f668882c60cb98d638313dbd3\" 1000 \"Invoice March 2017\"")
         );
+
+    if (!Params().GetConsensus().fDaoClientActivated)
+        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -3533,6 +3539,9 @@ UniValue proposalvote(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
+    if (!Params().GetConsensus().fDaoClientActivated)
+        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
+
     string strHash = params[0].get_str();
     bool duplicate = false;
 
@@ -3654,6 +3663,9 @@ UniValue paymentrequestvote(const UniValue& params, bool fHelp)
             "2. \"command\"       (string, required) 'yes' to vote yes, 'no' to vote no,\n"
             "                      'remove' to remove a proposal from the list\n"
         );
+
+    if (!Params().GetConsensus().fDaoClientActivated)
+        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
 
     LOCK(cs_main);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3539,9 +3539,6 @@ UniValue proposalvote(const UniValue& params, bool fHelp)
 
     LOCK(cs_main);
 
-    if (!Params().GetConsensus().fDaoClientActivated)
-        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
-
     string strHash = params[0].get_str();
     bool duplicate = false;
 
@@ -3663,9 +3660,6 @@ UniValue paymentrequestvote(const UniValue& params, bool fHelp)
             "2. \"command\"       (string, required) 'yes' to vote yes, 'no' to vote no,\n"
             "                      'remove' to remove a proposal from the list\n"
         );
-
-    if (!Params().GetConsensus().fDaoClientActivated)
-        throw JSONRPCError(RPC_WALLET_ERROR, "This command is temporarily disabled");
 
     LOCK(cs_main);
 


### PR DESCRIPTION
This Pull Request disables on the client the creation of proposals and payment requests in mainnet. Other networks or network validation are not affected.

Disabled RPC commands:
`createpaymentrequest`
`createproposal`

Disabled GUI functionality:
`Proposal creation`
`Payment Request creation`