### PR TITLE
Add second dns seeder

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -227,8 +227,8 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x88)(0xB2)(0x1E).convert_to_container<std::vector<unsigned char> >();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
 
-        vSeeds.push_back(CDNSSeedData("nav.community", "seed.nav.community"));
-        vSeeds.push_back(CDNSSeedData("navcoin.org", "seed.navcoin.org"));
+        vSeeds.push_back(CDNSSeedData("seed 1 nav.community", "seed.nav.community"));
+        vSeeds.push_back(CDNSSeedData("seed 2 nav.community", "seed2.nav.community"));
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 


### PR DESCRIPTION
Adds a second dns seeder `seed2.nav.community`

```$ dig -t A seed2.nav.community  

; <<>> DiG 9.10.6 <<>> -t A seed2.nav.community
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 29564
;; flags: qr rd ra; QUERY: 1, ANSWER: 25, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;seed2.nav.community.		IN	A

;; ANSWER SECTION:
seed2.nav.community.	3598	IN	A	212.180.171.44
seed2.nav.community.	3598	IN	A	5.189.144.187
seed2.nav.community.	3598	IN	A	195.201.142.253
seed2.nav.community.	3598	IN	A	195.141.177.67
seed2.nav.community.	3598	IN	A	51.154.136.60
seed2.nav.community.	3598	IN	A	172.105.61.38
seed2.nav.community.	3598	IN	A	68.183.231.64
seed2.nav.community.	3598	IN	A	76.185.126.1
seed2.nav.community.	3598	IN	A	77.161.80.160
seed2.nav.community.	3598	IN	A	109.86.81.235
seed2.nav.community.	3598	IN	A	81.132.120.2
seed2.nav.community.	3598	IN	A	159.203.18.161
seed2.nav.community.	3598	IN	A	45.89.140.182
seed2.nav.community.	3598	IN	A	79.137.80.216
seed2.nav.community.	3598	IN	A	110.20.86.208
seed2.nav.community.	3598	IN	A	167.99.84.110
seed2.nav.community.	3598	IN	A	148.251.129.229
seed2.nav.community.	3598	IN	A	82.15.107.207
seed2.nav.community.	3598	IN	A	167.86.94.2
seed2.nav.community.	3598	IN	A	116.203.183.1
seed2.nav.community.	3598	IN	A	62.210.247.39
seed2.nav.community.	3598	IN	A	178.33.106.211
seed2.nav.community.	3598	IN	A	98.251.0.228
seed2.nav.community.	3598	IN	A	45.89.140.119
seed2.nav.community.	3598	IN	A	2.87.179.231

;; Query time: 34 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon Nov 18 12:53:33 CET 2019
;; MSG SIZE  rcvd: 448
```

### What to test

Nodes should quickly find nodes without needing a previous list of known servers (this is achieved starting with a completely empty data folder).