### PR TITLE
Only count stakes in main chain

### DIFF
--- a/qa/rpc-tests/getstakereport.py
+++ b/qa/rpc-tests/getstakereport.py
@@ -125,7 +125,7 @@ class GetStakeReport(NavCoinTestFramework):
         assert_equal('6.00', spending_address_last_7d)
         assert_equal('4.00', staking_address_last_7d)
 
-        # Load the averages for stake amounts 
+        # Load the averages for stake amounts
         avg_last7d   = self.nodes[0].getstakereport()['Last 7 Days Avg']
         avg_last30d  = self.nodes[0].getstakereport()['Last 30 Days Avg']
         avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
@@ -161,7 +161,7 @@ class GetStakeReport(NavCoinTestFramework):
         assert_equal('2.00', spending_address_last_7d)
         assert_equal('2.00', staking_address_last_7d)
 
-        # Load the averages for stake amounts 
+        # Load the averages for stake amounts
         avg_last7d   = self.nodes[0].getstakereport()['Last 7 Days Avg']
         avg_last30d  = self.nodes[0].getstakereport()['Last 30 Days Avg']
         avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
@@ -197,7 +197,7 @@ class GetStakeReport(NavCoinTestFramework):
         assert_equal('0.00', spending_address_last_7d)
         assert_equal('0.00', staking_address_last_7d)
 
-        # Load the averages for stake amounts 
+        # Load the averages for stake amounts
         avg_last7d   = self.nodes[0].getstakereport()['Last 7 Days Avg']
         avg_last30d  = self.nodes[0].getstakereport()['Last 30 Days Avg']
         avg_last365d = self.nodes[0].getstakereport()['Last 365 Days Avg']
@@ -207,7 +207,34 @@ class GetStakeReport(NavCoinTestFramework):
         assert_equal('0.06666666', avg_last30d)
         assert_equal('0.19354838', avg_last365d)
 
-    def stake_block(self, node):
+        # Disconnect the nodes
+        for node in self.nodes[0].getpeerinfo():
+            self.nodes[0].disconnectnode(node['addr'])
+        time.sleep(2) #disconnecting a node needs a little bit of time
+        assert(self.nodes[0].getpeerinfo() == [])
+
+        # Stake a block on node 0
+        orphaned_block_hash = self.stake_block(self.nodes[0], False)
+
+        # Generate some blocks on node 1
+        self.nodes[1].generate(100)
+
+        # Reconnect the nodes
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[2], 0)
+
+        # Wait for blocks to sync
+        self.sync_all()
+
+        # Make sure the block was orphaned
+        assert(self.nodes[0].getblock(orphaned_block_hash)['confirmations'] == -1)
+
+        # Check the staked amount
+        # Should be 0 (Zero) as the last staked block is orphaned
+        assert_equal('0.00', self.nodes[0].getstakereport()['Last 7 Days'])
+
+    def stake_block(self, node, mature = True):
         # Get the current block count to check against while we wait for a stake
         blockcount = node.getblockcount()
 
@@ -225,9 +252,17 @@ class GetStakeReport(NavCoinTestFramework):
         # Turn staking off
         node.staking(False)
 
-        # Make sure the blocks are mature before we check the report
-        slow_gen(node, 5, 0.5)
-        self.sync_all()
+        # Get the staked block
+        block_hash = node.getbestblockhash()
+
+        # Only mature the blocks if we asked for it
+        if (mature):
+            # Make sure the blocks are mature before we check the report
+            slow_gen(node, 5, 0.5)
+            self.sync_all()
+
+        # return the block hash to the function caller
+        return block_hash
 
 
 if __name__ == '__main__':

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3186,7 +3186,7 @@ bool IsTxCountedAsStaked(const CWalletTx* tx)
     LOCK(cs_main);
 
     // orphan block or immature
-    if ((!tx->GetDepthInMainChain()) || (tx->GetBlocksToMaturity() > 0))
+    if ((!tx->GetDepthInMainChain()) || (tx->GetBlocksToMaturity() > 0) || !IsInMainChain())
         return false;
 
     // abandoned transactions

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3186,7 +3186,7 @@ bool IsTxCountedAsStaked(const CWalletTx* tx)
     LOCK(cs_main);
 
     // orphan block or immature
-    if ((!tx->GetDepthInMainChain()) || (tx->GetBlocksToMaturity() > 0) || !IsInMainChain())
+    if ((!tx->GetDepthInMainChain()) || (tx->GetBlocksToMaturity() > 0) || !tx->IsInMainChain())
         return false;
 
     // abandoned transactions


### PR DESCRIPTION
This pull request fixes the count of stakes in the Staking tab of the GUI and the `getstakereport` RPC command.

### What to test

Stake count still shows the correct number even if there are orphans or blocks are invalidated.