### PR TITLE
Set DEFAULT_SCRIPTCHECK_THREADS to auto

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -96,7 +96,7 @@ static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
-static const int DEFAULT_SCRIPTCHECK_THREADS = 2;
+static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
 static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */


### PR DESCRIPTION
This Pull Request introduces changes to set the value of `DEFAULT_SCRIPTCHECK_THREADS`  based on the cores count. `DEFAULT_SCRIPTCHECK_THREADS` determines how many parallel jobs are used for script verification.

### What to test

debug.log should show

```
Using n threads for script verification
```

where n is the right number of cores.