### PR TITLE
Fixed freezing GUI on reindex

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -302,7 +302,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
         clientmodel->cachedBestHeaderTime = blockTime;
     }
     // if we are in-sync or if we notify a header update, update the UI regardless of last update time
-    if (fHeader || !initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
+    if ((fHeader && !fReindex) || !initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
         //pass an async signal to the UI thread
         QMetaObject::invokeMethod(clientmodel, "numBlocksChanged", Qt::QueuedConnection,
                                   Q_ARG(int, height),


### PR DESCRIPTION
## Issue
Looks like the freezing GUI when reindexing was caused by a change I ported from upstream BTC repo

Link: https://github.com/bitcoin/bitcoin/blob/v0.19.0.1/src/qt/clientmodel.cpp#L246

This PR fixes the freezing GUI on reindex

## Test
* Run a fully indexed node with GUI (navcoin-qt) with `-reindex=1`
* GUI wallet should not freeze when starting reindex.