### PR TITLE
Adds proposalHash to the RPC getpaymentrequest

### DIFF
--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -559,6 +559,7 @@ void CFund::CPaymentRequest::ToJson(UniValue& ret) const {
     ret.pushKV("version", nVersion);
     ret.pushKV("hash", hash.ToString());
     ret.pushKV("blockHash", txblockhash.ToString());
+    ret.pushKV("proposalHash", proposalhash.ToString());
     ret.pushKV("description", strDZeel);
     ret.pushKV("requestedAmount", FormatMoney(nAmount));
     ret.pushKV("votesYes", nVotesYes);

--- a/src/consensus/cfund.cpp
+++ b/src/consensus/cfund.cpp
@@ -547,7 +547,7 @@ void CFund::CProposal::ToJson(UniValue& ret, CCoinsViewCache& coins) const {
             if (prequest.proposalhash != hash)
                 continue;
 
-            prequest.ToJson(preq);
+            prequest.ToJson(preq, false);
             arr.push_back(preq);
         }
 
@@ -555,11 +555,13 @@ void CFund::CProposal::ToJson(UniValue& ret, CCoinsViewCache& coins) const {
     }
 }
 
-void CFund::CPaymentRequest::ToJson(UniValue& ret) const {
+void CFund::CPaymentRequest::ToJson(UniValue& ret, bool root) const {
     ret.pushKV("version", nVersion);
     ret.pushKV("hash", hash.ToString());
     ret.pushKV("blockHash", txblockhash.ToString());
-    ret.pushKV("proposalHash", proposalhash.ToString());
+    if (root) {
+        ret.pushKV("proposalHash", proposalhash.ToString());
+    }
     ret.pushKV("description", strDZeel);
     ret.pushKV("requestedAmount", FormatMoney(nAmount));
     ret.pushKV("votesYes", nVotesYes);

--- a/src/consensus/cfund.h
+++ b/src/consensus/cfund.h
@@ -172,7 +172,7 @@ public:
                          paymenthash.ToString().substr(0,10), strDZeel);
     }
 
-    void ToJson(UniValue& ret) const;
+    void ToJson(UniValue& ret, bool root) const;
 
     bool IsAccepted() const;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1543,7 +1543,7 @@ UniValue getpaymentrequest(const UniValue& params, bool fHelp)
 
     UniValue ret(UniValue::VOBJ);
 
-    prequest.ToJson(ret);
+    prequest.ToJson(ret, true);
 
     return ret;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3625,7 +3625,7 @@ UniValue paymentrequestvotelist(const UniValue& params, bool fHelp)
             auto it = std::find_if( vAddedPaymentRequestVotes.begin(), vAddedPaymentRequestVotes.end(),
                                     [&prequest](const std::pair<std::string, bool>& element){ return element.first == prequest.hash.ToString();} );
             UniValue p(UniValue::VOBJ);
-            prequest.ToJson(p);
+            prequest.ToJson(p, false);
             if (it != vAddedPaymentRequestVotes.end()) {
                 if (it->second)
                     yesvotes.push_back(p);


### PR DESCRIPTION
The proposal hash has been added to the result of RPC getpaymentrequest.

A root flag has been added to not add the proposalHash when the payment request is not the root JSON node (when it is iterated as a child of RPC getproposal)