### PR TITLE
Anti Header Spam v2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,52 +281,34 @@ class CNodeHeaders
 {
 public:
     CNodeHeaders():
-        maxSize(0),
-        maxAvg(0)
+        maxSize(0)
     {
-        maxSize = GetArg("-headerspamfiltermaxsize", DEFAULT_HEADER_SPAM_FILTER_MAX_SIZE);
-        maxAvg = GetArg("-headerspamfiltermaxavg", DEFAULT_HEADER_SPAM_FILTER_MAX_AVG);
+        maxSize = GetArg("-headerspamfiltermaxsize", MAX_BLOCKS_IN_TRANSIT_PER_PEER*4);
     }
 
-    bool addHeaders(int nBegin, int nEnd)
+    bool addHeaders(std::vector<uint256> hashes)
     {
-
-        if(nBegin > 0 && nEnd > 0 && maxSize && maxAvg)
-        {
-
-            for(int point = nBegin; point<= nEnd; point++)
-            {
-                addPoint(point);
-            }
-
-            return true;
-        }
-
-        return false;
+        std::copy(hashes.begin(), hashes.end(), std::inserter(points, points.end()));
     }
 
     bool updateState(CValidationState& state, bool ret)
     {
-        // No headers
-        size_t size = points.size();
-        if(size == 0)
-            return ret;
-
-        // Compute the number of the received headers
-        size_t nHeaders = 0;
-        for(auto point : points)
+        for (auto it = points.begin(); it != points.end();)
         {
-            nHeaders += point.second;
+            if (mapBlockIndex.count(*it) && mapBlockIndex[*it]->nStatus & BLOCK_VALID_SCRIPTS)
+            {
+                it = points.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
         }
 
-        // Compute the average value per height
-        double nAvgValue = (double)nHeaders / size;
+        LogPrint("headerspam", "%s: Current size: %d Max size: %d",
+                 __func__, points.size(), maxSize);
 
-        // Ban the node if try to spam
-        bool banNode = (nAvgValue >= 1.5 * maxAvg && size >= maxAvg) ||
-                (nAvgValue >= maxAvg && nHeaders >= maxSize) ||
-                (nHeaders >= maxSize * 3);
-        if(banNode)
+        if(points.size() > maxSize)
         {
             // Clear the points and ban the node
             points.clear();
@@ -336,28 +318,9 @@ public:
         return ret;
     }
 
-private:
-    void addPoint(int height)
-    {
-        // Erace the last element in the list
-        if(points.size() == maxSize)
-        {
-            points.erase(points.begin());
-        }
-
-        // Add the point to the list
-        int occurrence = 0;
-        auto mi = points.find(height);
-         if (mi != points.end())
-             occurrence = (*mi).second;
-         occurrence++;
-         points[height] = occurrence;
-     }
-
  private:
-     std::map<int,int> points;
+     std::set<uint256> points;
      size_t maxSize;
-     size_t maxAvg;
  };
 
 /**
@@ -7309,6 +7272,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         CBlockIndex *pindexLast = nullptr;
 
+        std::vector<uint256> vHeaderHashes;
+
         for(const CBlock& header: headers) {
             CValidationState state;
             if (pindexLast != NULL && header.hashPrevBlock != pindexLast->GetBlockHash()) {
@@ -7328,6 +7293,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     break;
                 }
             }
+            vHeaderHashes.push_back(pblockheader.GetHash());
             if (pindexLast) {
                 nLast = pindexLast->nHeight;
                 if (bFirst){
@@ -7343,7 +7309,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             CValidationState state;
             CNodeState *nodestate = State(pfrom->GetId());
             CNodeHeaders& headers = ServiceHeaders(nodestate->address);
-            headers.addHeaders(nFirst, nLast);
+            headers.addHeaders(vHeaderHashes);
             int nDoS;
             ret = headers.updateState(state, ret);
             if (state.IsInvalid(nDoS)) {
@@ -7443,6 +7409,27 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 
         LogPrint("net", "received block %s peer=%d\n%s\n", block.GetHash().ToString(), pfrom->id, block.ToString());
 
+        bool ret = true;
+
+        if(GetBoolArg("-headerspamfilter", DEFAULT_HEADER_SPAM_FILTER) && !IsInitialBlockDownload())
+        {
+            LOCK(cs_main);
+            CValidationState state;
+            CNodeState *nodestate = State(pfrom->GetId());
+            CNodeHeaders& headers = ServiceHeaders(nodestate->address);
+            CBlockHeader pblockheader = CBlockHeader(block);
+            headers.addHeaders({pblockheader.GetHash()});
+            int nDoS;
+            ret = headers.updateState(state, ret);
+            if (state.IsInvalid(nDoS))
+            {
+                if (nDoS > 0)
+                    Misbehaving(pfrom->GetId(), nDoS);
+
+                return error("header spam protection");
+            }
+        }
+
         CValidationState state;
         // Process all blocks from whitelisted peers, even if not requested,
         // unless we're still syncing with the network.
@@ -7460,7 +7447,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 Misbehaving(pfrom->GetId(), nDoS);
             }
         }
-
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,7 @@ public:
     CNodeHeaders():
         maxSize(0)
     {
-        maxSize = GetArg("-headerspamfiltermaxsize", MAX_BLOCKS_IN_TRANSIT_PER_PEER*4);
+        maxSize = GetArg("-headerspamfiltermaxsize", MAX_HEADERS_RESULTS*4);
     }
 
     bool addHeaders(std::vector<uint256> hashes)
@@ -365,6 +365,7 @@ struct CNodeState {
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
     int nBlocksInFlight;
+    int nHeadersInFlight;
     int nBlocksInFlightValidHeaders;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
@@ -390,6 +391,7 @@ struct CNodeState {
         nStallingSince = 0;
         nDownloadingSince = 0;
         nBlocksInFlight = 0;
+        nHeadersInFlight = 0;
         nBlocksInFlightValidHeaders = 0;
         fPreferredDownload = false;
         fPreferHeaders = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -297,7 +297,7 @@ public:
 
         for (auto it = points.begin(); it != points.end();)
         {
-            if (mapBlockIndex.count(*it) && mapBlockIndex[*it]->nStatus & BLOCK_VALID_SCRIPTS)
+            if (mapBlockIndex.count(*it) && (mapBlockIndex[*it]->nStatus & BLOCK_VALID_SCRIPTS) == BLOCK_VALID_SCRIPTS)
             {
                 it = points.erase(it);
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,7 +286,7 @@ public:
         maxSize = GetArg("-headerspamfiltermaxsize", MAX_HEADERS_RESULTS*2);
     }
 
-    bool addHeaders(std::vector<uint256> hashes)
+    void addHeaders(std::vector<uint256> hashes)
     {
         for (auto& it: hashes)
             points.insert(it);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,7 +288,8 @@ public:
 
     bool addHeaders(std::vector<uint256> hashes)
     {
-        std::copy(hashes.begin(), hashes.end(), std::inserter(points, points.end()));
+        for (auto& it: hashes)
+            points.insert(it);
     }
 
     bool updateState(CValidationState& state, bool ret)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ public:
             }
         }
 
-        LogPrint("headerspam", "%s: Current size: %d Max size: %d",
+        LogPrint("headerspam", "%s: Current size: %d Max size: %d\n",
                  __func__, points.size(), maxSize);
 
         if(points.size() > maxSize)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,7 @@ public:
     CNodeHeaders():
         maxSize(0)
     {
-        maxSize = GetArg("-headerspamfiltermaxsize", MAX_HEADERS_RESULTS*4);
+        maxSize = GetArg("-headerspamfiltermaxsize", MAX_HEADERS_RESULTS*2);
     }
 
     bool addHeaders(std::vector<uint256> hashes)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -366,7 +366,6 @@ struct CNodeState {
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
     int nBlocksInFlight;
-    int nHeadersInFlight;
     int nBlocksInFlightValidHeaders;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
@@ -392,7 +391,6 @@ struct CNodeState {
         nStallingSince = 0;
         nDownloadingSince = 0;
         nBlocksInFlight = 0;
-        nHeadersInFlight = 0;
         nBlocksInFlightValidHeaders = 0;
         fPreferredDownload = false;
         fPreferHeaders = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,6 +293,8 @@ public:
 
     bool updateState(CValidationState& state, bool ret)
     {
+        int64_t nTime1 = GetTimeMicros();
+
         for (auto it = points.begin(); it != points.end();)
         {
             if (mapBlockIndex.count(*it) && mapBlockIndex[*it]->nStatus & BLOCK_VALID_SCRIPTS)
@@ -314,6 +316,9 @@ public:
             points.clear();
             return state.DoS(100, false, REJECT_INVALID, "header-spam", false, "ban node for sending spam");
         }
+
+        int64_t nTime2 = GetTimeMicros();
+        LogPrint("bench", "%s: Anti header spam took: %.2fms\n", __func__, 0.001 * (nTime2 - nTime1));
 
         return ret;
     }

--- a/src/main.h
+++ b/src/main.h
@@ -98,7 +98,7 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 /** -par default (number of script-checking threads, 0 = auto) */
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
-static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
+static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 64;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
 static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends


### PR DESCRIPTION
This Pull Request proposes a new anti header spam system which aims to fix some of the issues of the previous implementation (including those reported by art-of-bug).

Features:

- Every time a header or block is received from another peer, its hash is added to a `points` list associated with the peer. 
- Peers are discerned by their ip address, this means peers sharing ip address will also share the same `points` list. This can be changed with `-headerspamfilterignoreport` (default: `true`).
- Before proceeding with the block or headers validation, the `points` list will be cleared removing all the hashes of blocks whose scripts have already been correctly validated.
- The peer is banned if the size of the `points` list is greater than `MAX_HEADERS_RESULTS*2` once cleared of already validated blocks.
- The maximum allowed size of the `points` list can be changed using the `-headerspamfiltermaxsize` parameter.
- The log category `headerspam` has been added, which prints to the log the current size of a peers `points` list.
- When `-debug=bench` is specified, execution time for the `updateState` function is logged.

#### Considerations

- The maximum size of the `points` list by default is 4,000. With a block time of 30 seconds, NavCoin sees an average of 2,880 blocks per day. A maximum value of 4000 is roughly one and a half times more than the count of blocks a peer needs to be behind the chain tip to be in Initial Block Download mode. When on IBD, the header spam filter is turned off. This ensures that normal synchronisation is not affected by this filter.
- An attacker would be able to exhaust 32 bytes from the hash inserted in the `points` list + 181 bytes from the `CBlockIndex` inserted in `mapBlockIndex` for every invalid header/block before being banned. The `points` list is cleared when the attacker is banned, but those headers are not removed from `mapBlockIndex` or the hard disk in the current implementation. The size of CBlockIndex has been measured with:
```c++
    CBlockIndex* pindex = new CBlockIndex();
    CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
    ss << CDiskBlockIndex(pindex);
    std::vector<unsigned char>vch(ss.begin(), ss.end());
    std::cout << to_string(vch.size()) << std::endl;
```
- The default maximum value means that a single malicious peer with a unique IP can exhaust at max `3,999*213=831 kilobytes` without being banned or `4,000*181=707 kilobytes` being banned.

### What to test

- Legit nodes are not banned during normal synchronisation, even when it is done from genesis block, or when a node is behind many hours/days from the chain tip and it resumes syncing.
- Performance is not (heavily) affected with this filter. _Benchmarking shows only 0.25ms added._
- Spam attacks are correctly banned. The code example indicated by art-of-bug in his last article is not strictly correct to use with NavCoin. A way to replicate the attack would be to apply the following patch to this branch:

```diff
diff --git a/src/miner.cpp b/src/miner.cpp
index 010f5eb9..0ca6ac28 100644
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -120,6 +120,40 @@ BlockAssembler::BlockAssembler(const CChainParams& _chainparams)
     fNeedSizeAccounting = (nBlockMaxSize < MAX_BLOCK_SERIALIZED_SIZE-1000);
 }
 
+bool SignBlockEx(std::shared_ptr<CBlock> pblock, CBlockIndex* pindexPrev, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, CKey& key)
+{
+    CMutableTransaction txCoinStake;
+    uint32_t nTimeBlock = nTime;
+    nTimeBlock &= ~STAKE_TIMESTAMP_MASK;
+
+    txCoinStake.vin.clear();
+    txCoinStake.vout.clear();
+
+    CScript scriptEmpty;
+    scriptEmpty.clear();
+    txCoinStake.vout.push_back(CTxOut(0, scriptEmpty));
+
+    static unsigned int n = 0;
+    txCoinStake.vin.push_back(CTxIn(uint256S("0x1234"), n++));
+
+    CScript scriptPubKeyOut;
+
+    scriptPubKeyOut << key.GetPubKey() << OP_CHECKSIG;
+    txCoinStake.vout.push_back(CTxOut(10000, scriptPubKeyOut));
+
+    txCoinStake.nTime = nTimeBlock;
+    pblock->vtx[0].nTime = pblock->nTime = txCoinStake.nTime;
+    txCoinStake.nVersion = CTransaction::TXDZEEL_VERSION_V2;
+
+    CTransaction txNew;
+    *static_cast<CTransaction*>(&txNew) = CTransaction(txCoinStake);
+    pblock->vtx.insert(pblock->vtx.begin() + 1, txNew);
+    pblock->vtx[0].UpdateHash();
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+
+    return true;
+}
+
 void BlockAssembler::resetBlock()
 {
     inBlock.clear();
@@ -138,7 +172,7 @@ void BlockAssembler::resetBlock()
     blockFinished = false;
 }
 
-CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake, uint64_t* pFees)
+CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake, uint64_t* pFees, CBlockIndex* pindexPrev)
 {
     resetBlock();
 
@@ -155,7 +189,6 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bo
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
     LOCK2(cs_main, mempool.cs);
-    CBlockIndex* pindexPrev = chainActive.Tip();
     nHeight = pindexPrev->nHeight + 1;
     CCoinsViewCache view(pcoinsTip);
 
@@ -810,30 +843,42 @@ void NavCoinStaker(const CChainParams& chainparams)
             //
             // Create new block
             //
-            uint64_t nFees = 0;
+            uint64_t nTotalFees = 0;
 
-            std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript, true, &nFees));
-            if (!pblocktemplate.get())
+            if (chainActive.Tip()->nHeight < 300)
             {
-                LogPrintf("Error in NavCoinStaker: Keypool ran out, please call keypoolrefill before restarting the staking thread\n");
-                return;
+                MilliSleep(10000);
+                continue;
             }
-            CBlock *pblock = &pblocktemplate->block;
 
-            //LogPrint("coinstake","Running NavCoinStaker with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
-            //     ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+            CBlockIndex* pindexPrev = chainActive.Tip()->pprev->pprev->pprev->pprev->pprev;
+
+            CKey key;
+            CPubKey pubKey;
 
-            //Trying to sign a block
-            if (SignBlock(pblock, *pwalletMain, nFees))
             {
-                LogPrint("coinstake", "PoS Block signed\n");
-                SetThreadPriority(THREAD_PRIORITY_NORMAL);
-                CheckStake(pblock, *pwalletMain, chainparams);
-                SetThreadPriority(THREAD_PRIORITY_LOWEST);
-                MilliSleep(500);
+            LOCK(pwalletMain->cs_wallet);
+            pubKey = pwalletMain->GenerateNewKey();
+            pwalletMain->GetKey(pubKey.GetID(), key);
             }
-            else
-                MilliSleep(nMinerSleep);
+
+            for (int i = 0; i < 1200000; i++) {
+                std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript, true, &nTotalFees, pindexPrev));
+                std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
+
+                if (SignBlockEx(pblock, pindexPrev, *pwalletMain, nTotalFees, GetAdjustedTime(), key)) {
+
+                    if (key.Sign(pblock->GetHash(), pblock->vchBlockSig)) {
+                        const CBlock& block = *pblock;
+
+                        for(CNode* pnode: vNodes) {
+                            pnode->PushMessage(NetMsgType::BLOCK, block);
+                        }
+                    }
+                }
+            }
+
+            MilliSleep(1000);
 
         }
     }
diff --git a/src/miner.h b/src/miner.h
index 55ddc8c0..35f34139 100644
--- a/src/miner.h
+++ b/src/miner.h
@@ -177,7 +177,7 @@ private:
 public:
     BlockAssembler(const CChainParams& chainparams);
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake, uint64_t* pFees);
+    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool fProofOfStake, uint64_t* pFees, CBlockIndex* pindexprev=nullptr);
 
 private:
     // utility functions
diff --git a/src/rpc/mining.cpp b/src/rpc/mining.cpp
index db3e9638..6ea22a34 100644
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -117,7 +117,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript,false,0));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript,false,0,chainActive.Tip()));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
```

Then build and start one node and bootstrap a devnet chain with:

```bash
./navcoind -printtoconsole -debug=headerspam -devnet -port=12345 -staking=0 -debug=bench -ntpminmeasures=0
./navcoin-cli -devnet generate 301
```

Now start the spammer node with:

```bash
mkdir /tmp/data2
./navcoind -devnet -addnode=127.0.0.1:12345 -port=12121 -rpcport=12312 -printtoconsole -datadir=/tmp/data2
```

We should be able to see in node1 log output how it tries to ban node2 after the spam:

```
2019-12-26 18:02:13 updateState: Current size: 257 Max size: 256
2019-12-26 18:02:13 Misbehaving: 127.0.01:12121 (1 -> 101) BAN THRESHOLD EXCEEDED
2019-12-26 18:02:13 ERROR: header spam protection
2019-12-26 18:02:13 ProcessMessages(block, 332 bytes) FAILED peer=3
```