### PR TITLE
Mnemonic Startup GUI

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,7 @@ NAVCOIN_CORE_H = \
   wallet/walletdb.h \
   mnemonic/dictionary.h \
   mnemonic/mnemonic.h \
+  mnemonic/generateseed.h \
   mnemonic/arrayslice.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
@@ -235,6 +236,7 @@ libnavcoin_wallet_a_SOURCES = \
   consensus/cfund.cpp \
   mnemonic/dictionary.cpp \
   mnemonic/mnemonic.cpp \
+  mnemonic/generateseed.cpp \
   wallet/crypter.cpp \
   wallet/db.cpp \
   wallet/navtech.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -92,6 +92,12 @@ QT_TS = \
 QT_FORMS_UI = \
 	qt/forms/addressbookpage.ui \
 	qt/forms/askpassphrasedialog.ui \
+    qt/forms/startoptionsdialog.ui \
+    qt/forms/startoptions.ui \
+    qt/forms/startoptionsrestore.ui \
+    qt/forms/startoptionssort.ui \
+    qt/forms/startoptionsrevealed.ui \
+    qt/forms/startoptionsmain.ui \
 	qt/forms/coincontroldialog.ui \
 	qt/forms/editaddressdialog.ui \
 	qt/forms/helpmessagedialog.ui \
@@ -131,6 +137,12 @@ QT_MOC_CPP = \
 	qt/moc_navcoingui.cpp \
 	qt/moc_navcoinunits.cpp \
 	qt/moc_clientmodel.cpp \
+    qt/moc_startoptionsdialog.cpp \
+    qt/moc_startoptions.cpp \
+    qt/moc_startoptionsrestore.cpp \
+    qt/moc_startoptionssort.cpp \
+    qt/moc_startoptionsrevealed.cpp \
+    qt/moc_startoptionsmain.cpp \
 	qt/moc_coincontroldialog.cpp \
 	qt/moc_coincontroltreewidget.cpp \
 	qt/moc_coldstakingwizard.cpp \
@@ -223,6 +235,12 @@ NAVCOIN_QT_H = \
 	qt/navcoingui.h \
 	qt/navcoinunits.h \
 	qt/clientmodel.h \
+    qt/startoptionsdialog.h \
+    qt/startoptions.h \
+    qt/startoptionsrestore.h \
+    qt/startoptionssort.h \
+    qt/startoptionsrevealed.h \
+    qt/startoptionsmain.h \
 	qt/coincontroldialog.h \
 	qt/coincontroltreewidget.h \
 	qt/coldstakingwizard.h \
@@ -394,6 +412,12 @@ NAVCOIN_QT_CPP = \
 	qt/skinize.cpp \
 	qt/splashscreen.cpp \
 	qt/trafficgraphwidget.cpp \
+    qt/startoptionsdialog.cpp \
+    qt/startoptions.cpp \
+    qt/startoptionsrestore.cpp \
+    qt/startoptionssort.cpp \
+    qt/startoptionsrevealed.cpp \
+    qt/startoptionsmain.cpp \
 	qt/utilitydialog.cpp
 
 if TARGET_WINDOWS

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -970,7 +970,7 @@ void DownloadBlockchain(std::string url)
 /** Initialize navcoin.
  *  @pre Parameters should be parsed and config file should be read.
  */
-bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
+bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std::string& wordlist)
 {
     // ********************************************************* Step 0: download bootstrap
     std::string sBootstrap = GetArg("-bootstrap","");
@@ -1770,7 +1770,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         pwalletMain = nullptr;
         LogPrintf("Wallet disabled!\n");
     } else {
-        CWallet::InitLoadWallet();
+        CWallet::InitLoadWallet(wordlist);
         if (!pwalletMain)
             return false;
     }

--- a/src/init.h
+++ b/src/init.h
@@ -25,7 +25,7 @@ void Shutdown();
 void InitLogging();
 //!Parameter interaction: change current parameters depending on various rules
 void InitParameterInteraction();
-bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler);
+bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std::string& wordlist);
 
 /** The help message mode determines what help message to show */
 enum HelpMessageMode {

--- a/src/mnemonic/generateseed.cpp
+++ b/src/mnemonic/generateseed.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 The VEIL developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <mnemonic/generateseed.h>
+#include <key.h>
+#include <mnemonic/mnemonic.h>
+
+namespace navcoin {
+
+uint512 GenerateNewMnemonicSeed(std::string& mnemonic, const std::string& strLanguage)
+{
+    CKey key;
+    key.MakeNewKey(true);
+
+    std::vector<unsigned char, secure_allocator<unsigned char>> keyData;
+    const unsigned char* ptrKeyData = key.begin();
+    for (int i = 0; ptrKeyData != key.end(); i++) {
+        unsigned char byte = *ptrKeyData;
+        keyData.push_back(byte);
+        ptrKeyData++;
+    }
+
+    word_list mnemonic_words = create_mnemonic(keyData, string_to_lexicon(strLanguage));
+    for (auto it = mnemonic_words.begin(); it != mnemonic_words.end();) {
+        const auto word = *it;
+        mnemonic += word;
+        ++it;
+        if (it == mnemonic_words.end())
+            break;
+        mnemonic += " ";
+    }
+
+    auto blob_512 = decode_mnemonic(mnemonic_words);
+    uint512 seed512;
+    memcpy(seed512.begin(), blob_512.begin(), blob_512.size());
+
+    return seed512;
+}
+
+}

--- a/src/mnemonic/generateseed.h
+++ b/src/mnemonic/generateseed.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The VEIL developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NAVCOIN_GENERATESEED_H
+#define NAVCOIN_GENERATESEED_H
+
+#include <uint256.h>
+
+namespace navcoin {
+uint512 GenerateNewMnemonicSeed(std::string& mnemonic, const std::string& strLanguage);
+}
+
+#endif //NAVCOIN_GENERATESEED_H

--- a/src/navcoind.cpp
+++ b/src/navcoind.cpp
@@ -160,7 +160,8 @@ bool AppInit(int argc, char* argv[])
         // Set this early so that parameter interactions go to console
         InitLogging();
         InitParameterInteraction();
-        fRet = AppInit2(threadGroup, scheduler);
+        std::string wordlist;
+        fRet = AppInit2(threadGroup, scheduler, wordlist);
     }
     catch (const std::exception& e) {
         PrintExceptionContinue(&e, "AppInit()");

--- a/src/qt/forms/startoptions.ui
+++ b/src/qt/forms/startoptions.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptions</class>
+ <widget class="QWidget" name="StartOptions">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>420</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptions Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="welcomeLabel2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/startoptionsdialog.ui
+++ b/src/qt/forms/startoptionsdialog.ui
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptionsDialog</class>
+ <widget class="QDialog" name="StartOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>222</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>100</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptions Error</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="ErrorLable">
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>StartOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>StartOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/startoptionsmain.ui
+++ b/src/qt/forms/startoptionsmain.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptionsMain</class>
+ <widget class="QDialog" name="StartOptionsMain">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>220</width>
+    <height>100</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>420</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptionsMain Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QStackedWidget" name="QStackTutorialContainer">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <widget class="QWidget" name="page_3">
+      <property name="font">
+       <font>
+        <italic>false</italic>
+       </font>
+      </property>
+     </widget>
+     <widget class="QWidget" name="page_4"/>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="RestoreWallet">
+       <property name="text">
+        <string>Restore Wallet</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="NewWallet">
+       <property name="text">
+        <string>Create New Wallet</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout1">
+     <item>
+      <widget class="QPushButton" name="Back">
+       <property name="text">
+        <string>Back</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="Next">
+       <property name="text">
+        <string>Next</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/startoptionsrestore.ui
+++ b/src/qt/forms/startoptionsrestore.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptionsRestore</class>
+ <widget class="QWidget" name="StartOptionsRestore">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>420</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>420</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptionsRestore Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="restoreLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayoutRevealed">
+     <property name="leftMargin">
+      <number>20</number>
+     </property>
+     <property name="rightMargin">
+      <number>20</number>
+     </property>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/startoptionsrevealed.ui
+++ b/src/qt/forms/startoptionsrevealed.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptionsRevealed</class>
+ <widget class="QWidget" name="StartOptionsRevealed">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>420</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>420</height>
+   </size>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>10</pointsize>
+    <italic>true</italic>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptionsRevealed Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="seedLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayoutRevealed">
+     <property name="leftMargin">
+      <number>20</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/startoptionssort.ui
+++ b/src/qt/forms/startoptionssort.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StartOptionsSort</class>
+ <widget class="QWidget" name="StartOptionsSort">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>650</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>650</width>
+    <height>480</height>
+   </size>
+  </property>
+  <property name="font">
+   <font>
+    <weight>75</weight>
+    <italic>false</italic>
+    <bold>true</bold>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>StartOptionsSort Dialog</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetNoConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="dragdropLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="dragdropLabel2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string notr="true">Placeholder text</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <layout class="QGridLayout" name="gridLayoutRevealed">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetNoConstraint</enum>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/startoptions.cpp
+++ b/src/qt/startoptions.cpp
@@ -1,0 +1,31 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+
+#include <startoptions.h>
+#include <ui_startoptions.h>
+
+
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QPushButton>
+
+StartOptions::StartOptions(QWidget *parent)
+    : QWidget(parent), ui(new Ui::StartOptions) {
+    ui->setupUi(this);
+
+    ui->welcomeLabel2->setStyleSheet(
+            "QLabel{font-size: 30px; color: #7578A2;}");
+    ui->welcomeLabel2->setText(tr(
+        "Welcome to Navcoin!"));
+
+}
+
+int StartOptions::getRows() {
+    rows = 4;
+    return rows;
+};
+
+StartOptions::~StartOptions() {
+    delete ui;
+}

--- a/src/qt/startoptions.h
+++ b/src/qt/startoptions.h
@@ -1,0 +1,25 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+#pragma once
+
+#include <QWidget>
+
+namespace Ui {
+class StartOptions;
+}
+
+/** Dialog to ask for passphrases. Used for encryption only
+ */
+class StartOptions : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StartOptions(QWidget *parent = nullptr);
+    ~StartOptions();
+    int getRows();
+
+private:
+    int rows;
+    Ui::StartOptions *ui;
+};

--- a/src/qt/startoptionsdialog.cpp
+++ b/src/qt/startoptionsdialog.cpp
@@ -1,0 +1,30 @@
+#if defined(HAVE_CONFIG_H)
+#include <config/navcoin-config.h>
+#endif
+
+#include <startoptionsdialog.h>
+#include <ui_startoptionsdialog.h>
+
+#include <guiconstants.h>
+
+#include <support/allocators/secure.h>
+
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QPushButton>
+
+StartOptionsDialog::StartOptionsDialog(const QString error_words,
+                                       QWidget *parent)
+    : QDialog(parent), ui(new Ui::StartOptionsDialog) {
+    ui->setupUi(this);
+
+    ui->ErrorLable->setText(error_words);
+}
+
+StartOptionsDialog::~StartOptionsDialog() {
+    delete ui;
+}
+
+void StartOptionsDialog::accept() {
+    close();
+}

--- a/src/qt/startoptionsdialog.h
+++ b/src/qt/startoptionsdialog.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include <QDialog>
+#include <support/allocators/secure.h>
+
+class CWallet;
+
+namespace Ui {
+class StartOptionsDialog;
+}
+
+/** Dialog to ask for passphrases. Used for encryption only
+ */
+class StartOptionsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit StartOptionsDialog(const QString error_words, QWidget *parent);
+    ~StartOptionsDialog();
+
+    void accept() override;
+
+private:
+    Ui::StartOptionsDialog *ui;
+};

--- a/src/qt/startoptionsmain.cpp
+++ b/src/qt/startoptionsmain.cpp
@@ -1,0 +1,238 @@
+//
+// Copyright (c) 2019 DeVault developers
+// Created by Kolby on 6/19/2019.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#include <startoptionsdialog.h>
+#include <startoptionsmain.h>
+#include <ui_startoptionsmain.h>
+
+#include <QDebug>
+#include <QFileDialog>
+#include <iostream>
+#include <qt/guiutil.h>
+#include <random.h>
+#include <utilstrencodings.h>
+
+#include <ui_interface.h>
+#include <mnemonic/mnemonic.h>
+#include <mnemonic/generateseed.h>
+
+#include <QKeyEvent>
+#include <QMessageBox>
+#include <QPushButton>
+
+inline bool is_not_space(int c) { return !std::isspace(c); }
+
+StartOptionsMain::StartOptionsMain(QWidget *parent)
+    : QDialog(parent), ui(new Ui::StartOptionsMain) {
+    ui->setupUi(this);
+
+    this->setWindowTitle(tr("Navcoin Wallet Setup"));
+
+    dictionary dic = string_to_lexicon("english");
+    for(unsigned long i=0; i< dic.size() ; i++){
+        qWordList << dic[i];
+    }
+
+    this->setContentsMargins(0, 0, 0, 0);
+    ui->QStackTutorialContainer->setContentsMargins(0, 0, 0, 10);
+    this->setStyleSheet(
+            "QWidget{background-color: #E8EBF0; color:#7578A2;}"
+             "QListView { background-color: #E8EBF0; border: 2px solid #E8EBF0;} "
+             "QListView::item { color: #7578A2; height: 36px;} "
+             "QListView::item:selected{border:1px solid #E8EBF0;background:transparent;}"
+             "QListView::item:hover{border:1px solid #f0e8eb;background:#7578A2; color:#E8EBF0;}"
+     "QGraphicsView {background-color: #E8EBF0;border: 2px solid #E8EBF0; color: #7578A2;} "
+    "QGraphicsScene {background-color: #E8EBF0;color: #7578A2;} "
+     "QRadioButton {height: 40px;text-align: center;font-size: 20px;padding: 20px;border-radius: 8px;} "
+
+     "QRadioButton:focus {background-color: #000;}"
+     "QRadioButton::indicator {display: none;opacity: 0;width: 0px;height: 0px;}"
+     "QRadioButton:checked {background-color: transparent;border: 2px solid #7578A2;} "
+     "QRadioButton:unchecked {background-color: transparent;border-width: 2px;border-color:  #777;} "
+
+     "QRadioButton::unchecked: hover {background-color:  #1f1f1f;} "
+     "QListWidget {border-color: #E8EBF0;}"
+     "QListWidget::item {border-radius: 8px;border: none;color: #7578A2;} "
+     "QListWidget::item:selected {border: 2px solid #7578A2;border-radius: 8px;padding-left: 4px;background: transparent;} "
+     "QListWidget::item:focus {border: 1px solid #1f1f1f;background:  #1f1f1f; ;border-radius: 8px;padding-left: 4px;}"
+
+     "QPushButton {background-color:#E8EBF0;padding:0.85em 2em;letter-spacing:1px;border:0;color:#7578A2;font-size:12px;font-weight:bold;border-radius:20px;}"
+     "QPushButton:hover {background-color:#7578A2;}"
+     "QPushButton:focus {border:none;outline:none;}"
+     "QPushButton:pressed {border:1px solid#333;}");
+
+    ui->Back->setVisible(false);
+    ui->Next->setVisible(false);
+    startOptions = new StartOptions(this);
+    ui->QStackTutorialContainer->addWidget(startOptions);
+    ui->QStackTutorialContainer->setCurrentWidget(startOptions);
+}
+
+StartOptionsMain::~StartOptionsMain() {
+    delete ui;
+}
+
+void StartOptionsMain::on_NewWallet_clicked() {
+    pageNum = CreateOrRestorePage;
+    ui->NewWallet->setVisible(false);
+    ui->RestoreWallet->setVisible(false);
+    ui->Back->setVisible(true);
+    ui->Next->setVisible(true);
+    rows = startOptions->getRows();
+
+   //Generate mnemonic phrase from fresh entropy
+           mnemonic = "";
+    navcoin::GenerateNewMnemonicSeed(mnemonic, "english");
+
+    std::stringstream ss(mnemonic);
+    std::istream_iterator<std::string> begin(ss);
+    std::istream_iterator<std::string> end;
+    words.clear();
+    words = std::vector<std::string>(begin, end);
+
+
+    startOptionsRevealed = new StartOptionsRevealed(words, rows, this);
+    ui->QStackTutorialContainer->addWidget(startOptionsRevealed);
+    ui->QStackTutorialContainer->setCurrentWidget(startOptionsRevealed);
+}
+
+void StartOptionsMain::on_RestoreWallet_clicked() {
+    pageNum = CheckWordsPage;
+    ui->NewWallet->setVisible(false);
+    ui->RestoreWallet->setVisible(false);
+    ui->Back->setVisible(true);
+    ui->Next->setVisible(true);
+    rows = startOptions->getRows();
+
+    startOptionsRestore = new StartOptionsRestore(qWordList, rows, this);
+    ui->QStackTutorialContainer->addWidget(startOptionsRestore);
+    ui->QStackTutorialContainer->setCurrentWidget(startOptionsRestore);
+}
+
+void StartOptionsMain::on_Back_clicked() {
+    /*  Pages
+     * Page 1 : Main page were you select the amount of words and the option
+     *      Path 1 : Create wallet
+     *          Page 2 : Shows you your words
+     *          Page 3 : Order the words
+     *      Path 2 : Restore wallet
+     *          Page 4 Enter words to restore
+     */
+    switch (pageNum) {
+        case StartPage: {
+            // does nothing as you can not click back on page one
+        }
+        case CreateOrRestorePage: {
+            pageNum = StartPage;
+            ui->NewWallet->setVisible(true);
+            ui->RestoreWallet->setVisible(true);
+            ui->Back->setVisible(false);
+            ui->Next->setVisible(false);
+            ui->QStackTutorialContainer->setCurrentWidget(startOptions);
+            break;
+        }
+        case OrderWordsPage: {
+            pageNum = CreateOrRestorePage;
+            ui->QStackTutorialContainer->addWidget(startOptionsRevealed);
+            ui->QStackTutorialContainer->setCurrentWidget(startOptionsRevealed);
+            break;
+        }
+        case CheckWordsPage: {
+            pageNum = StartPage;
+            ui->NewWallet->setVisible(true);
+            ui->RestoreWallet->setVisible(true);
+            ui->Back->setVisible(false);
+            ui->Next->setVisible(false);
+            ui->QStackTutorialContainer->setCurrentWidget(startOptions);
+            break;
+        }
+    }
+}
+
+void StartOptionsMain::on_Next_clicked() {
+    auto rtrim = [](std::string& s) { s.erase(std::find_if(s.rbegin(), s.rend(), is_not_space).base(), s.end()); };
+    /*  Pages
+     * Page 1 : Main page were you select the amount of words and the option
+     *      Path 1 : Create wallet
+     *          Page 2 : Shows you your words
+     *          Page 3 : Order the words
+     *      Path 2 : Restore wallet
+     *          Page 4 Enter words to restore
+     */
+    switch (pageNum) {
+        case StartPage: {
+            // does nothing as you can not click back on page one
+        }
+
+        case CreateOrRestorePage: {
+            pageNum = OrderWordsPage;
+            startOptionsSort = new StartOptionsSort(words, rows, this);
+            ui->QStackTutorialContainer->addWidget(startOptionsSort);
+            ui->QStackTutorialContainer->setCurrentWidget(startOptionsSort);
+            break;
+        }
+        case OrderWordsPage: {
+            words_empty_str = "";
+            std::list<QString> word_str = startOptionsSort->getOrderedStrings();
+            // reverses the lists order
+            word_str.reverse();
+            for (QString &q_word : word_str) {
+                if (words_empty_str.empty())
+                    words_empty_str = q_word.toStdString();
+                else
+                    words_empty_str += "" + q_word.toStdString();
+            }
+
+            words_mnemonic = "";
+            for (std::string &q_word : words) {
+                if (words_mnemonic.empty())
+                    words_mnemonic = q_word;
+                else
+                    words_mnemonic += "" + q_word;
+            }
+            rtrim(words_empty_str);
+            rtrim(words_mnemonic);
+            if (words_empty_str != words_mnemonic) {
+                QString error = tr("Unfortunately, your words are in the wrong "
+                                "order. Please try again.");
+                StartOptionsDialog dlg(error, this);
+                dlg.exec();
+            } else {
+                wordsDone = join(words, " ");
+                QApplication::quit();
+            }
+            break;
+        }
+        case CheckWordsPage: {
+            std::vector<std::string> word_str = startOptionsRestore->getOrderedStrings();
+
+            std::string seedphrase = "";
+            for (std::string &q_word : word_str) {
+                if (seedphrase.empty())
+                    seedphrase = q_word;
+                else
+                    seedphrase += " " + q_word;
+            }
+            // reverses the lists order
+            dictionary lexicon = string_to_lexicon("english");
+            if (validate_mnemonic(sentence_to_word_list(seedphrase), lexicon)) {
+                wordsDone = join(word_str, " ");
+                QApplication::quit();
+            } else {
+                QString error =
+                    tr("Unfortunately, your words seem to be invalid. This is "
+                    "most likely because one or more are misspelled. Please "
+                    "double check your spelling and word order. If you "
+                    "continue to have issue your words may not currently be in "
+                    "our dictionary.");
+                StartOptionsDialog dlg(error, this);
+                dlg.exec();
+            }
+
+            break;
+        }
+    }
+}

--- a/src/qt/startoptionsmain.h
+++ b/src/qt/startoptionsmain.h
@@ -1,0 +1,57 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+#pragma once
+
+#include <QDialog>
+#include <QWidget>
+
+#include "startoptions.h"
+#include <startoptionsrestore.h>
+#include <startoptionsrevealed.h>
+#include <startoptionssort.h>
+
+#include "mnemonic/mnemonic.h"
+
+class WalletModel;
+
+namespace Ui {
+class StartOptionsMain;
+}
+
+/** Dialog to ask for passphrases. Used for encryption only
+ */
+class StartOptionsMain : public QDialog {
+    Q_OBJECT
+
+public:
+    enum Pages { StartPage, CreateOrRestorePage, OrderWordsPage, CheckWordsPage };
+    explicit StartOptionsMain(QWidget *parent);
+    ~StartOptionsMain();
+
+    std::string getWords() { return wordsDone; }
+
+public Q_SLOTS:
+    void on_RestoreWallet_clicked();
+    void on_Next_clicked();
+    void on_Back_clicked();
+    void on_NewWallet_clicked();
+
+private:
+    Ui::StartOptionsMain *ui;
+    Pages pageNum = StartPage;
+    int rows;
+    QStringList qWordList;
+
+    std::string wordsDone;
+    std::vector<std::string> words;
+    std::vector<std::string> wordsList;
+    std::string mnemonic;
+
+    StartOptions *startOptions;
+    StartOptionsRevealed *startOptionsRevealed;
+    StartOptionsSort *startOptionsSort;
+    StartOptionsRestore *startOptionsRestore;
+    std::string words_empty_str;
+    std::string words_mnemonic;
+};

--- a/src/qt/startoptionsrestore.cpp
+++ b/src/qt/startoptionsrestore.cpp
@@ -1,0 +1,61 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+
+#include <QLabel>
+#include <QLineEdit>
+#include <startoptionsrestore.h>
+#include <ui_startoptionsrestore.h>
+
+QString editLineCorrectCss = "QLineEdit{; border:1px solid #7578A2;}";
+QString editLineInvalidCss = "QLineEdit{ border:1px solid red;}";
+
+StartOptionsRestore::StartOptionsRestore(QStringList _wordList, int rows,
+                                         QWidget *parent)
+    : QWidget(parent), ui(new Ui::StartOptionsRestore), wordList(_wordList) {
+    ui->setupUi(this);
+
+    for (int i = 0; i < rows; i++) {
+        for (int k = 0; k < 6; k++) {
+
+            QLineEdit *label = new QLineEdit(this);
+            label->setStyleSheet(
+                "QLabel{background-color: blue; padding:0px; margin:0px"
+                "; font-size: 18px; font-weight: thin; color: #7578A2;}");
+            label->setMinimumSize(80, 36);
+            label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            label->setContentsMargins(0, 0, 0, 0);
+            label->setAlignment(Qt::AlignCenter);
+            editList.push_back(label);
+            ui->restoreLabel->setText(
+                tr("Restore your wallet using a recovery seed phrase below. "
+                   ""));
+            connect(label, SIGNAL(textChanged(const QString &)), this,
+                    SLOT(textChanged(const QString &)));
+            ui->gridLayoutRevealed->addWidget(label, i, k, Qt::AlignCenter);
+        }
+    }
+}
+
+void StartOptionsRestore::textChanged(const QString &text) {
+
+    QObject *senderObj = sender();
+    QLineEdit* label = static_cast<QLineEdit*>(senderObj);
+    if (wordList.contains(text)) {
+        label->setStyleSheet(editLineCorrectCss);
+    } else {
+        label->setStyleSheet(editLineInvalidCss);
+    }
+}
+
+std::vector<std::string> StartOptionsRestore::getOrderedStrings() {
+    std::vector<std::string> list;
+    for (QLineEdit *label : editList) {
+        list.push_back(label->text().toStdString());
+    }
+    return list;
+}
+
+StartOptionsRestore::~StartOptionsRestore() {
+    delete ui;
+}

--- a/src/qt/startoptionsrestore.h
+++ b/src/qt/startoptionsrestore.h
@@ -1,0 +1,34 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+#pragma once
+
+#include <QLineEdit>
+#include <QString>
+#include <QWidget>
+#include <list>
+
+namespace Ui {
+class StartOptionsRestore;
+}
+
+/** Dialog to ask for passphrases. Used for encryption only
+ */
+class StartOptionsRestore : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StartOptionsRestore(QStringList wordList, int rows,
+                                 QWidget *parent = nullptr);
+    ~StartOptionsRestore();
+    std::vector<std::string> getOrderedStrings();
+
+private Q_SLOTS:
+    void textChanged(const QString &text);
+
+private:
+    Ui::StartOptionsRestore *ui;
+    std::list<QLineEdit *> editList;
+
+    QStringList wordList;
+};

--- a/src/qt/startoptionsrevealed.cpp
+++ b/src/qt/startoptionsrevealed.cpp
@@ -1,0 +1,51 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <startoptionsrevealed.h>
+#include <ui_startoptionsrevealed.h>
+
+StartOptionsRevealed::StartOptionsRevealed(std::vector<std::string> Words,
+                                           int rows, QWidget *parent)
+    : QWidget(parent), ui(new Ui::StartOptionsRevealed) {
+    ui->setupUi(this);
+
+    ui->seedLabel->setText(
+        tr("The words below are your recovery phrase (mnemonic seed). Please "
+           "write them down and/or securely save them. "));
+
+    for (int i = 0; i < rows; i++) {
+        for (int k = 0; k < 6; k++) {
+
+            QLabel *label = new QLabel(this);
+            label->setStyleSheet(
+                "QLabel{background-color:transparent;padding-left:8px;padding-"
+                "right:8px;border-radius:0px;color:#7578A2;border-bottom:2px "
+                "solid #7578A2; text-align:center; font-size:18px;}");
+            label->setMinimumSize(110, 50);
+            label->setMaximumSize(110, 50);
+            label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+            label->setContentsMargins(8, 12, 8, 12);
+            label->setAlignment(Qt::AlignCenter);
+            labelsList.push_back(label);
+            ui->gridLayoutRevealed->addWidget(label, i, k, Qt::AlignCenter);
+        }
+    }
+    int i = 0;
+    for (QLabel *label : labelsList) {
+        label->setStyleSheet(
+            "QLabel{background-color:transparent;padding-left:8px;padding-"
+            "right:8px;border-radius:0px;color:#7578A2;border-bottom:2px solid "
+            "#7578A2; text-align:center; font-size:18px;}");
+        label->setContentsMargins(8, 12, 8, 12);
+        label->setText(QString::fromStdString(Words[i]));
+        i++;
+    }
+}
+
+StartOptionsRevealed::~StartOptionsRevealed() {
+    delete ui;
+}

--- a/src/qt/startoptionsrevealed.h
+++ b/src/qt/startoptionsrevealed.h
@@ -1,0 +1,26 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+#pragma once
+
+#include <QLabel>
+#include <QWidget>
+
+namespace Ui {
+class StartOptionsRevealed;
+}
+
+/** Dialog to ask for passphrases. Used for encryption only
+ */
+class StartOptionsRevealed : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StartOptionsRevealed(std::vector<std::string> Words, int rows,
+                                  QWidget *parent = nullptr);
+    ~StartOptionsRevealed();
+
+private:
+    Ui::StartOptionsRevealed *ui;
+    std::list<QLabel *> labelsList;
+};

--- a/src/qt/startoptionssort.cpp
+++ b/src/qt/startoptionssort.cpp
@@ -1,0 +1,188 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+
+#include <QLineEdit>
+#include <QListView>
+#include <QListWidget>
+#include <QStringListModel>
+#include <QTableWidget>
+#include <QtWidgets>
+#include <algorithm>
+#include <chrono>
+#include <random>
+#include <startoptionssort.h>
+#include <ui_startoptionssort.h>
+
+CustomRectItem::CustomRectItem(QGraphicsItem *parent)
+        : QGraphicsRectItem(parent) {
+    setAcceptDrops(true);
+    setFlags(QGraphicsItem::ItemIsSelectable);
+}
+
+void StartOptionsSort::keyPressEvent(QKeyEvent *event){
+    Q_FOREACH(QGraphicsItem *item, scene->selectedItems())
+    if(event->key() == Qt::Key_Backspace){
+
+        if(CustomRectItem *rItem = qgraphicsitem_cast<CustomRectItem*> (item)){
+            for (auto const& i : labelsList)
+            {
+                if (i->count() < 4) {
+                    i->addItem(rItem->text());
+                    rItem->setText(QString());
+                    break;
+                }
+            }
+        }
+        scene->clearSelection();
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void CustomRectItem::setText(const QString &text) {
+    this->m_text = text;
+    update();
+}
+
+void CustomRectItem::paint(QPainter *painter,
+                           const QStyleOptionGraphicsItem *option,
+                           QWidget *widget) {
+    QGraphicsRectItem::paint(painter, option, widget);
+    painter->drawText(boundingRect(), m_text, QTextOption(Qt::AlignCenter));
+}
+
+void CustomRectItem::dropEvent(QGraphicsSceneDragDropEvent *event) {
+    if (event->mimeData()->hasFormat(
+            "application/x-qabstractitemmodeldatalist")) {
+        QByteArray itemData =
+                event->mimeData()->data("application/x-qabstractitemmodeldatalist");
+        QDataStream stream(&itemData, QIODevice::ReadOnly);
+        int row, col;
+        QMap<int, QVariant> valueMap;
+        stream >> row >> col >> valueMap;
+        QString origText = m_text;
+        if (!valueMap.isEmpty()) setText(valueMap.value(0).toString());
+
+        event->setDropAction(Qt::MoveAction);
+        event->accept();
+
+        if (!origText.isEmpty()) {
+            if (QListWidget *lWidget =
+                        qobject_cast<QListWidget *>(event->source()))
+                lWidget->addItem(origText);
+        }
+    } else
+        event->ignore();
+}
+
+StartOptionsSort::StartOptionsSort(std::vector<std::string> Words, int rows,
+                                   QWidget *parent)
+        : QWidget(parent), ui(new Ui::StartOptionsSort) {
+    ui->setupUi(this);
+
+    ui->dragdropLabel->setText(
+            tr("Please <b>drag</b> and <b>drop</b> your seed words into the "
+               "correct order to confirm your recovery phrase. "));
+    ui->dragdropLabel2->setText(
+            tr("To remove words click the word then hit backspace."));
+    scene = new QGraphicsScene(this);
+    if (rows == 4) {
+        scene->setSceneRect(0, 0, 620, 229);
+        view = new QGraphicsView;
+        view->setScene(scene);
+        view->setMinimumSize(QSize(1, 250));
+        view->setContentsMargins(0, 0, 0, 2);
+    } else {
+        scene->setSceneRect(0, 0, 620, 154);
+        view = new QGraphicsView;
+        view->setScene(scene);
+        view->setMinimumSize(QSize(1, 155));
+    }
+
+    view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    QRectF rect(0, 0, 90, 70);
+    QRectF rect2(0, 0, 90, 2);
+
+    for (int i = 0; i < rows; i++) {
+        for (int k = 0; k < 6; k++) {
+            int ki;
+            if (k < 1) {
+                ki = 10;
+            } else {
+                ki = 10 + 100 * k;
+            }
+            int ii;
+            if (i < 1) {
+                ii = 1;
+            } else {
+                ii = 1 + 50 * i;
+            }
+
+            CustomRectItem *listView = new CustomRectItem;
+            scene->addItem(listView);
+            listView->setRect(rect);
+
+            CustomRectItem *listViewBorder = new CustomRectItem;
+            scene->addItem(listViewBorder);
+            listViewBorder->setRect(rect2);
+            listViewBorder->setBrush(QColor(117, 120, 162));
+            listViewBorder->setPos(ki, ii + 50);
+            listViewBorder->setPen(Qt::NoPen);
+
+            listView->setPos(ki, ii);
+            QPen myPen(QColor(117, 120, 162), 2, Qt::MPenStyle);
+            listView->setPen(myPen);
+
+            graphicsList.push_back(listView);
+            graphicsList.push_back(listViewBorder);
+        }
+    }
+
+    ui->gridLayoutRevealed->addWidget(view, 0, 0, 1, 6, Qt::AlignCenter);
+
+    // Randomizes the word list
+    std::vector<std::string> randomWords = Words;
+    unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
+    shuffle(randomWords.begin(), randomWords.end(),
+            std::default_random_engine(seed));
+
+    for (int k = 0; k < 6; k++) {
+
+        QListWidget *itemListWidget = new QListWidget;
+        QStringList itemList;
+        for (int i = 0; i < rows; i++) {
+            itemList.append(QString::fromStdString(randomWords[k * rows + i]));
+        }
+
+        itemListWidget->addItems(itemList);
+        itemListWidget->setFixedWidth(120);
+        itemListWidget->setMinimumSize(QSize(118, 180));
+        itemListWidget->setMaximumSize(QSize(118, 180));
+        itemListWidget->setDragEnabled(true);
+        itemListWidget->setFocusPolicy(Qt::NoFocus);
+        itemListWidget->setStyleSheet(
+                "QWidget{font-size:18px; font-style:bold; color:#7578A2;}");
+        itemListWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        labelsList.push_back(itemListWidget);
+        ui->gridLayoutRevealed->addWidget(itemListWidget, 2, k, Qt::AlignCenter);
+    }
+
+    setAcceptDrops(true);
+    setWindowTitle(tr("Draggable Text"));
+}
+
+std::list<QString> StartOptionsSort::getOrderedStrings() {
+    std::list<QString> list;
+    Q_FOREACH (QGraphicsItem *item, scene->items())
+    if (CustomRectItem *rItem =
+                qgraphicsitem_cast<CustomRectItem *>(item)) {
+        list.push_back(rItem->text());
+    }
+    return list;
+}
+
+StartOptionsSort::~StartOptionsSort() {
+    delete ui;
+}

--- a/src/qt/startoptionssort.h
+++ b/src/qt/startoptionssort.h
@@ -1,0 +1,57 @@
+//
+// Created by Kolby on 6/19/2019.
+//
+#pragma once
+
+#include <QGraphicsRectItem>
+#include <QGraphicsScene>
+#include <QGraphicsSceneDragDropEvent>
+#include <QGraphicsView>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QListView>
+#include <QListWidget>
+#include <QMimeData>
+#include <QPainter>
+#include <QWidget>
+
+class QDragEnterEvent;
+class QDropEvent;
+
+namespace Ui {
+    class StartOptionsSort;
+}
+
+class StartOptionsSort : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit StartOptionsSort(std::vector<std::string> Words, int rows,
+                              QWidget *parent = nullptr);
+    ~StartOptionsSort();
+    std::list<QString> getOrderedStrings();
+
+    void keyPressEvent(QKeyEvent  *);
+
+private:
+    Ui::StartOptionsSort *ui;
+    std::list<QListWidget *> labelsList;
+    std::list<QGraphicsRectItem *> graphicsList;
+    QString m_text;
+    QGraphicsView *view;
+    QGraphicsScene *scene;
+};
+
+class CustomRectItem : public QGraphicsRectItem {
+public:
+    CustomRectItem(QGraphicsItem *parent = 0);
+    void dropEvent(QGraphicsSceneDragDropEvent *event);
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+               QWidget *widget);
+    void setText(const QString &text);
+    QString text() const { return m_text; }
+
+private:
+    QString m_text;
+};

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -585,6 +585,17 @@ static boost::filesystem::path pathCached;
 static boost::filesystem::path pathCachedNetSpecific;
 static CCriticalSection csPathCached;
 
+bool CheckIfWalletDatExists(bool fNetSpecific) {
+
+    namespace fs = boost::filesystem;
+
+    boost::filesystem::path path("wallet.dat");
+    if (!path.is_complete())
+        path = GetDataDir(fNetSpecific) / path;
+
+    return fs::exists(path);
+}
+
 const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 {
     namespace fs = boost::filesystem;

--- a/src/util.h
+++ b/src/util.h
@@ -145,6 +145,7 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
 bool TryCreateDirectory(const boost::filesystem::path& p);
 boost::filesystem::path GetDefaultDataDir();
+bool CheckIfWalletDatExists(bool fNetSpecific = true);
 const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 boost::filesystem::path GetConfigFile();

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -702,3 +702,16 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
     return true;
 }
 
+// Replaces boost::join
+std::string join(const std::vector<std::string>& words, const std::string &separator, const std::string &concluder) {
+
+    std::stringstream ss;
+    for (size_t i=0;i<words.size();i++) {
+        if (i>0) ss << separator;
+        ss << words[i];
+    }
+
+    ss << concluder;
+
+    return ss.str();
+}

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -144,4 +144,8 @@ bool TimingResistantEqual(const T& a, const T& b)
  */
 bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out);
 
+// Join words with separator
+std::string join(const std::vector<std::string>& words, const std::string &separator = ", ", const std::string &concluder = "");
+
+
 #endif // NAVCOIN_UTILSTRENCODINGS_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3949,7 +3949,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     return strUsage;
 }
 
-bool CWallet::InitLoadWallet()
+bool CWallet::InitLoadWallet(const std::string& wordlist)
 {
     std::string walletFile = GetArg("-wallet", DEFAULT_WALLET_DAT);
 
@@ -4021,8 +4021,13 @@ bool CWallet::InitLoadWallet()
             // generate a new master key
             CKey key;
             CPubKey masterPubKey;
-            if (GetArg("-importmnemonic","") != "") {
-                word_list words = sentence_to_word_list(GetArg("-importmnemonic",""));
+            word_list words;
+            if (GetArg("-importmnemonic","") != "" || !wordlist.empty()) {
+                if (!wordlist.empty()) {
+                    words = sentence_to_word_list(wordlist);
+                } else {
+                    words = sentence_to_word_list(GetArg("-importmnemonic",""));
+                }
                 dictionary lexicon = string_to_lexicon(GetArg("-mnemoniclanguage","english"));
                 if (!validate_mnemonic(words, lexicon)) {
                     if (validate_mnemonic(words, language::all))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -995,7 +995,7 @@ public:
     static std::string GetWalletHelpString(bool showDebug);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static bool InitLoadWallet();
+    static bool InitLoadWallet(const std::string& wordlist);
 
     /* Wallets parameter interaction */
     static bool ParameterInteraction();


### PR DESCRIPTION
This PR was for the #451 a bounty Navcoin had to add a Startup GUI which allowed for the ability to restore and create wallets with Mnemonic words. Mnemonic words are like a read readable master key for BIP32 a bitcoin proposal to make key generation derived from one key or a masterkey instead of being randomly created as before hand.

This page is the first page and it allows for the user to select Restore wallet an option to restore a wallet with your mnemonic words or Create a new wallet if you have never created a wallet that supports Mnemonic words before
![image](https://user-images.githubusercontent.com/31669092/74597500-9b6b5e00-501d-11ea-8e84-e5ee62a88d6e.png)

The restore page is where you would enter your mnemonic words if you were restoring it from the mnemonic words you kept safe. If a word is spelt incorrectly or invalid the box will have a red outline, if it is correct it will have a purple outline.
![image](https://user-images.githubusercontent.com/31669092/74597508-d4a3ce00-501d-11ea-97d0-31ba92564946.png)

The reveal page. This page is shown after the user selects Create New Wallet and shows the user his Mnemonic words that he must write down and keep safe.
![image](https://user-images.githubusercontent.com/31669092/74597519-07e65d00-501e-11ea-823d-81c1573dae4f.png)

The sort page. This page is shown after the reveal page and it is used to confirm whether the user has written down his words.
![image](https://user-images.githubusercontent.com/31669092/74597537-3feda000-501e-11ea-82d4-b276ab0a875a.png)


The address the bounty should be paid to NdTrSEe6bMMvVwNUimxs2BiWkX5Xn9MW7o



