### PR TITLE
Rescan when importing mnemonic

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1000,6 +1000,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
 
     }
 
+    if(!wordlist.empty())
+    {
+        SoftSetBoolArg("-rescan", true);
+    }
+
     // ********************************************************* Step 1: setup
 #ifdef _MSC_VER
     // Turn off Microsoft heap dump noise

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1695,7 +1695,7 @@ CPubKey CWallet::ImportMnemonic(word_list mnemonic, dictionary lang)
 
     key.Set(vKey.begin(), vKey.end(), false);
 
-    int64_t nCreationTime = GetTime();
+    int64_t nCreationTime = GetArg("-importmnemonicfromtime", chainActive.Genesis()->GetBlockTime());
     CKeyMetadata metadata(nCreationTime);
 
     // calculate the pubkey
@@ -1711,6 +1711,9 @@ CPubKey CWallet::ImportMnemonic(word_list mnemonic, dictionary lang)
 
         // mem store the metadata
         mapKeyMetadata[pubkey.GetID()] = metadata;
+
+        if (!nTimeFirstKey || nCreationTime < nTimeFirstKey)
+            nTimeFirstKey = nCreationTime;
 
         // write the key&metadata to the database
         if (!AddKeyPubKey(key, pubkey))


### PR DESCRIPTION
This PR fixes a bug which prevented a wallet to scan an already existing chain for old transactions when importing a mnemonic.

By default, the wallet will look for all the transactions from the Genesis block. This can be changed using `importmnemonicfromtime=<timestamp>` in order to save scanning time and to look for transactions in a concrete period.

### What to test

Importing a mnemonic from a wallet with transactions existing prior to the import time should show the complete transaction list and right balance.