### PR TITLE
Updated qa/rpc-tests/cfunddb-statehash.py to use connect_nodes_bi

### DIFF
--- a/qa/rpc-tests/cfunddb-statehash.py
+++ b/qa/rpc-tests/cfunddb-statehash.py
@@ -61,8 +61,7 @@ class CFundDBStateHash(NavCoinTestFramework):
         assert(self.nodes[0].getbestblockhash() != self.nodes[1].getbestblockhash())
         assert(self.nodes[0].getcfunddbstatehash() != self.nodes[1].getcfunddbstatehash())
 
-
-        connect_nodes(self.nodes[0], 1)
+        connect_nodes_bi(self.nodes, 0, 1)
 
         self.sync_all()
 


### PR DESCRIPTION
I noticed this test would sometimes fail.

I debugging locally it seems that it would fail to reconnect the nodes after disconnecting them.

So I updated the test to use connect_nodes_bi instead of the one way connection command, seems to have fixed it.