### PR TITLE
[DAO] Fix for last voting cycle of proposals and payment requests

### DIFF
--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -2740,8 +2740,7 @@ std::string CProposal::GetState(uint32_t currentTime, const CStateViewCache& vie
     }
     if(currentTime > 0 && IsExpired(currentTime, view)) {
         sFlags = "expired";
-        if(fState != DAOFlags::EXPIRED && !ExceededMaxVotingCycles(view))
-            // This branch only occurs when a proposal expires due to exceeding its nDeadline during a voting cycle, not due to exceeding max voting cycles
+        if(fState != DAOFlags::EXPIRED)
             sFlags += ", waiting for end of voting period";
     }
     if(fState == DAOFlags::PENDING_VOTING_PREQ) {
@@ -2843,7 +2842,7 @@ void CProposal::ToJson(UniValue& ret, CStateViewCache& coins) const {
     ret.pushKV("votesYes", nVotesYes);
     ret.pushKV("votesAbs", nVotesAbs);
     ret.pushKV("votesNo", nVotesNo);
-    ret.pushKV("votingCycle", std::min((uint64_t)nVotingCycle, GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES, coins)));
+    ret.pushKV("votingCycle", std::min((uint64_t)nVotingCycle, GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES, coins)+1));
     // votingCycle does not return higher than nCyclesProposalVoting to avoid reader confusion, since votes are not counted anyway when votingCycle > nCyclesProposalVoting
     UniValue mapState(UniValue::VOBJ);
     for (auto&it: this->mapState)
@@ -2904,7 +2903,7 @@ void CPaymentRequest::ToJson(UniValue& ret, const CStateViewCache& view) const {
     ret.pushKV("votesYes", nVotesYes);
     ret.pushKV("votesAbs", nVotesAbs);
     ret.pushKV("votesNo", nVotesNo);
-    ret.pushKV("votingCycle", std::min((uint64_t)nVotingCycle, GetConsensusParameter(Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES, view)));
+    ret.pushKV("votingCycle", std::min((uint64_t)nVotingCycle, GetConsensusParameter(Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES, view)+1));
     // votingCycle does not return higher than nCyclesPaymentRequestVoting to avoid reader confusion, since votes are not counted anyway when votingCycle > nCyclesPaymentRequestVoting
     UniValue mapState(UniValue::VOBJ);
     for (auto&it: this->mapState)

--- a/src/consensus/dao.h
+++ b/src/consensus/dao.h
@@ -386,8 +386,11 @@ public:
             if(fState != DAOFlags::REJECTED)
                 sFlags += " waiting for end of voting period";
         }
-        if(IsExpired(view))
+        if(IsExpired(view)) {
             sFlags = "expired";
+            if(fState != DAOFlags::EXPIRED)
+                sFlags += " waiting for end of voting period";
+        }
         if (fState == PAID)
             sFlags = "paid";
         return sFlags;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1208,8 +1208,8 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
         consensus.pushKV("minSumVotesPerVotingCycleSecondHalf",GetConsensusParameter(Consensus::CONSENSUS_PARAM_VOTING_CYCLE_LENGTH, view) * Params().GetConsensus().nMinimumQuorumSecondHalf);
     }
 
-    consensus.pushKV("maxCountVotingCycleProposals",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES, view));
-    consensus.pushKV("maxCountVotingCyclePaymentRequests",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES, view));
+    consensus.pushKV("maxCountVotingCycleProposals",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES, view)+1);
+    consensus.pushKV("maxCountVotingCyclePaymentRequests",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES, view)+1);
     consensus.pushKV("votesAcceptProposalPercentage",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MIN_ACCEPT, view)/100);
     consensus.pushKV("votesRejectProposalPercentage",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PROPOSAL_MIN_REJECT, view)/100);
     consensus.pushKV("votesAcceptPaymentRequestPercentage",GetConsensusParameter(Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MIN_ACCEPT, view)/100);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -88,6 +88,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "proposeconsensuschange", 3},
     { "consultationvote", 2 },
     { "support", 1 },
+    { "proposeanswer", 1 },
     { "proposeanswer", 2 },
     { "proposeanswer", 3 },
     { "createpaymentrequest", 3 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -773,7 +773,14 @@ UniValue proposeconsensuschange(const UniValue& params, bool fHelp)
     int64_t nMin = params[0].get_int64();
     int64_t nMax = 1;
 
-    std::string sAnswer = std::to_string(params[1].get_int64());
+    int64_t nValue = params[1].get_int64();
+
+    if (nMin == Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES || nMin == Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES)
+    {
+        nValue--;
+    }
+
+    std::string sAnswer = std::to_string(nValue);
 
     if (nMin < Consensus::CONSENSUS_PARAM_VOTING_CYCLE_LENGTH || nMin >= Consensus::MAX_CONSENSUS_PARAMS)
         throw JSONRPCError(RPC_TYPE_ERROR, "Wrong parameter id");
@@ -1191,7 +1198,14 @@ UniValue proposeanswer(const UniValue& params, bool fHelp)
     if(!consultation.CanHaveNewAnswers())
         throw JSONRPCError(RPC_TYPE_ERROR, "The consultation does not admit new answers.");
 
-    std::string sAnswer = params[1].get_str();
+    int64_t nValue = params[1].get_int64();
+
+    if (consultation.nMin == Consensus::CONSENSUS_PARAM_PROPOSAL_MAX_VOTING_CYCLES || consultation.nMin == Consensus::CONSENSUS_PARAM_PAYMENT_REQUEST_MAX_VOTING_CYCLES)
+    {
+        nValue--;
+    }
+
+    std::string sAnswer = std::to_string(nValue);
 
     bool fDump = params.size() == 4 ? params[3].getBool() : false;
 


### PR DESCRIPTION
Proposals and Payment Requests run for one cycle more than the one specified by the respective consensus parameters. This is preferred to be kept like this and not fixed, to maintain backwards compatibility with the validation of old entries.

This PR fixes the max cycle count shown in gui and rpc responses and translates new proposals for consensus changes based on this logic.