### PR TITLE
[DAO] Prevent duplicated insert

### DIFF
--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -1352,6 +1352,11 @@ bool CVoteList::Get(const uint256& hash, int64_t& val)
 
 bool CVoteList::Set(const int& height, const uint256& hash, int64_t vote)
 {
+    int64_t prevVote;
+
+    if (Get(hash, prevVote) && prevVote == vote)
+        return false;
+
     if (list.count(height) == 0)
     {
         std::map<uint256, int64_t> mapVote;


### PR DESCRIPTION
This is a performance fix.

Found out that remove votes are inserted even if the last vote is already a remove vote.

```2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32693 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32694 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32695 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32696 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32697 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32698 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32699 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32700 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:24 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32701 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32702 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32703 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32704 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32705 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 210339137399a9a7b64eecdf8146934edc7b15303585f1f808f09412fdb30a9e85f2ac at height 32706 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32707 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
2020-05-19 14:31:25 ConnectBlock: Setting vote for voter 21037b9407bc0d49240cd7c7d4dc8ad3b37b182579965bdf5704df7110b864373954ac at height 32708 - hash: ba3d92eda47974199816132322a6231eddeffa869c3a0f3dbee0735930eddbfc vote: -2
```

This patch prevents that behavior. PR needs to get checked with stresser script before merging.