### PR TITLE
Optimize memory use for blockindex

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -222,20 +222,11 @@ public:
     int64_t nCFSupply;
     int64_t nCFLocked;
 
-    std::vector<std::pair<uint256, int>> vProposalVotes;
-    std::vector<std::pair<uint256, int>> vPaymentRequestVotes;
-    std::map<uint256, bool> mapSupport;
-    std::map<uint256, uint64_t> mapConsultationVotes;
-
     std::string strDZeel;
 
     unsigned int nFlags;  // ppcoin: block index flags
 
     uint64_t nStakeModifier; // hash modifier for proof-of-stake
-
-    // proof-of-stake specific fields
-    COutPoint prevoutStake;
-    unsigned int nStakeTime;
 
     arith_uint256 hashProof;
 
@@ -262,17 +253,11 @@ public:
         nFlags = 0;
         nStakeModifier = 0;
         hashProof = arith_uint256();
-        prevoutStake.SetNull();
-        nStakeTime = 0;
         nVersion       = 0;
         hashMerkleRoot = uint256();
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
-        vProposalVotes.clear();
-        vPaymentRequestVotes.clear();
-        mapSupport.clear();
-        mapConsultationVotes.clear();
     }
 
     CBlockIndex()
@@ -298,13 +283,6 @@ public:
         if (block.IsProofOfStake())
         {
             SetProofOfStake();
-            prevoutStake = block.vtx[1].vin[0].prevout;
-            nStakeTime = block.vtx[1].nTime;
-        }
-        else
-        {
-            prevoutStake.SetNull();
-            nStakeTime = 0;
         }
 
         nVersion       = block.nVersion;
@@ -389,13 +367,12 @@ public:
 
     std::string ToString() const
     {
-        return strprintf("CBlockIndex(nprev=%p, nFile=%u, nHeight=%d, nMint=%s, nCFSupply=%s, nCFLocked=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016x, hashProof=%s, prevoutStake=(%s), nStakeTime=%d merkle=%s, hashBlock=%s)",
+        return strprintf("CBlockIndex(nprev=%p, nFile=%u, nHeight=%d, nMint=%s, nCFSupply=%s, nCFLocked=%s, nFlags=(%s)(%d)(%s), nStakeModifier=%016x, hashProof=%s, merkle=%s, hashBlock=%s)",
                          pprev, nFile, nHeight,
                          FormatMoney(nMint), FormatMoney(nCFSupply), FormatMoney(nCFLocked),
                          GeneratedStakeModifier() ? "MOD" : "-", GetStakeEntropyBit(), IsProofOfStake()? "PoS" : "PoW",
                          nStakeModifier,
                          hashProof.ToString(),
-                         prevoutStake.ToString(), nStakeTime,
                          hashMerkleRoot.ToString(),
                          GetBlockHash().ToString());
     }
@@ -484,10 +461,25 @@ public:
     uint256 hashPrev;
     uint256 hashNext;
 
+    std::vector<std::pair<uint256, int>> vProposalVotes;
+    std::vector<std::pair<uint256, int>> vPaymentRequestVotes;
+    std::map<uint256, bool> mapSupport;
+    std::map<uint256, uint64_t> mapConsultationVotes;
+
+    // proof-of-stake specific fields
+    COutPoint prevoutStake;
+    unsigned int nStakeTime;
+
     CDiskBlockIndex() {
         hashPrev = uint256();
         hashNext = uint256();
         blockHash = uint256();
+        prevoutStake.SetNull();
+        nStakeTime = 0;
+        vProposalVotes.clear();
+        vPaymentRequestVotes.clear();
+        mapSupport.clear();
+        mapConsultationVotes.clear();
     }
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -363,103 +363,121 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
 
         if (fCFund)
         {
-            for(unsigned int i = 0; i < pindexblock->vProposalVotes.size(); i++)
+            auto pVotes = GetProposalVotes(pindexblock->GetBlockHash());
+            if (pVotes != nullptr)
             {
-                if(mapSeen.count(pindexblock->vProposalVotes[i].first) == 0)
+                for(unsigned int i = 0; i < pVotes->size(); i++)
                 {
-                    LogPrint("daoextra", "%s: Found vote %d for proposal %s at block height %d\n", __func__,
-                             pindexblock->vProposalVotes[i].second, pindexblock->vProposalVotes[i].first.ToString(),
-                             pindexblock->nHeight);
+                    if(mapSeen.count((*pVotes)[i].first) == 0)
+                    {
+                        LogPrint("daoextra", "%s: Found vote %d for proposal %s at block height %d\n", __func__,
+                                 (*pVotes)[i].second, (*pVotes)[i].first.ToString(),
+                                 pindexblock->nHeight);
 
-                    if(mapCacheProposalsToUpdate.count(pindexblock->vProposalVotes[i].first) == 0)
-                        mapCacheProposalsToUpdate[pindexblock->vProposalVotes[i].first] = make_pair(make_pair(0, 0), 0);
+                        if(mapCacheProposalsToUpdate.count((*pVotes)[i].first) == 0)
+                            mapCacheProposalsToUpdate[(*pVotes)[i].first] = make_pair(make_pair(0, 0), 0);
 
-                    if(pindexblock->vProposalVotes[i].second == VoteFlags::VOTE_YES)
-                        mapCacheProposalsToUpdate[pindexblock->vProposalVotes[i].first].first.first += 1;
-                    else if(pindexblock->vProposalVotes[i].second == VoteFlags::VOTE_ABSTAIN)
-                        mapCacheProposalsToUpdate[pindexblock->vProposalVotes[i].first].second += 1;
-                    else if(pindexblock->vProposalVotes[i].second == VoteFlags::VOTE_NO)
-                        mapCacheProposalsToUpdate[pindexblock->vProposalVotes[i].first].first.second += 1;
+                        if((*pVotes)[i].second == VoteFlags::VOTE_YES)
+                            mapCacheProposalsToUpdate[(*pVotes)[i].first].first.first += 1;
+                        else if((*pVotes)[i].second == VoteFlags::VOTE_ABSTAIN)
+                            mapCacheProposalsToUpdate[(*pVotes)[i].first].second += 1;
+                        else if((*pVotes)[i].second == VoteFlags::VOTE_NO)
+                            mapCacheProposalsToUpdate[(*pVotes)[i].first].first.second += 1;
 
-                    mapSeen[pindexblock->vProposalVotes[i].first]=true;
+                        mapSeen[(*pVotes)[i].first]=true;
+                    }
                 }
             }
 
-            for(unsigned int i = 0; i < pindexblock->vPaymentRequestVotes.size(); i++)
+            auto prVotes = GetPaymentRequestVotes(pindexblock->GetBlockHash());
+            if (prVotes != nullptr)
             {
-                if(mapSeen.count(pindexblock->vPaymentRequestVotes[i].first) == 0)
+                for(unsigned int i = 0; i < prVotes->size(); i++)
                 {
-                    LogPrint("daoextra", "%s: Found vote %d for payment request %s at block height %d\n", __func__,
-                             pindexblock->vPaymentRequestVotes[i].second, pindexblock->vPaymentRequestVotes[i].first.ToString(),
-                             pindexblock->nHeight);
+                    if(mapSeen.count((*prVotes)[i].first) == 0)
+                    {
+                        LogPrint("daoextra", "%s: Found vote %d for payment request %s at block height %d\n", __func__,
+                                 (*prVotes)[i].second, (*prVotes)[i].first.ToString(),
+                                 pindexblock->nHeight);
 
-                    if(mapCachePaymentRequestToUpdate.count(pindexblock->vPaymentRequestVotes[i].first) == 0)
-                        mapCachePaymentRequestToUpdate[pindexblock->vPaymentRequestVotes[i].first] = make_pair(make_pair(0, 0), 0);
+                        if(mapCachePaymentRequestToUpdate.count((*prVotes)[i].first) == 0)
+                            mapCachePaymentRequestToUpdate[(*prVotes)[i].first] = make_pair(make_pair(0, 0), 0);
 
-                    if(pindexblock->vPaymentRequestVotes[i].second == VoteFlags::VOTE_YES)
-                        mapCachePaymentRequestToUpdate[pindexblock->vPaymentRequestVotes[i].first].first.first += 1;
-                    else if(pindexblock->vPaymentRequestVotes[i].second == VoteFlags::VOTE_ABSTAIN)
-                        mapCachePaymentRequestToUpdate[pindexblock->vPaymentRequestVotes[i].first].second += 1;
-                    else if(pindexblock->vPaymentRequestVotes[i].second == VoteFlags::VOTE_NO)
-                        mapCachePaymentRequestToUpdate[pindexblock->vPaymentRequestVotes[i].first].first.second += 1;
+                        if((*prVotes)[i].second == VoteFlags::VOTE_YES)
+                            mapCachePaymentRequestToUpdate[(*prVotes)[i].first].first.first += 1;
+                        else if((*prVotes)[i].second == VoteFlags::VOTE_ABSTAIN)
+                            mapCachePaymentRequestToUpdate[(*prVotes)[i].first].second += 1;
+                        else if((*prVotes)[i].second == VoteFlags::VOTE_NO)
+                            mapCachePaymentRequestToUpdate[(*prVotes)[i].first].first.second += 1;
 
-                    mapSeen[pindexblock->vPaymentRequestVotes[i].first]=true;
+                        mapSeen[(*prVotes)[i].first]=true;
+                    }
                 }
             }
         }
 
         if (fDAOConsultations)
         {
-            for (auto& it: pindexblock->mapSupport)
+            auto supp = GetSupport(pindexblock->GetBlockHash());
+
+            if (supp != nullptr)
             {
-                if (!it.second)
-                    continue;
-
-                if (!mapSeenSupport.count(it.first))
+                for (auto& it: *supp)
                 {
-                    LogPrint("daoextra", "%s: Found support vote for %s at block height %d\n", __func__,
-                             it.first.ToString(),
-                             pindexblock->nHeight);
+                    if (!it.second)
+                        continue;
 
-                    if(mapCacheSupportToUpdate.count(it.first) == 0)
-                        mapCacheSupportToUpdate[it.first] = 0;
+                    if (!mapSeenSupport.count(it.first))
+                    {
+                        LogPrint("daoextra", "%s: Found support vote for %s at block height %d\n", __func__,
+                                 it.first.ToString(),
+                                 pindexblock->nHeight);
 
-                    mapCacheSupportToUpdate[it.first] += 1;
-                    mapSeenSupport[it.first]=true;
+                        if(mapCacheSupportToUpdate.count(it.first) == 0)
+                            mapCacheSupportToUpdate[it.first] = 0;
+
+                        mapCacheSupportToUpdate[it.first] += 1;
+                        mapSeenSupport[it.first]=true;
+                    }
                 }
             }
 
-            for (auto&it: pindexblock->mapConsultationVotes)
+            auto cVotes = GetConsultationVotes(pindexblock->GetBlockHash());
+
+            if (cVotes != nullptr)
             {
-                if (mapSeen.count(it.first))
-                    continue;
-
-                if (view.HaveConsultation(it.first) || view.HaveConsultationAnswer(it.first))
+                for (auto&it: *cVotes)
                 {
+                    if (mapSeen.count(it.first))
+                        continue;
 
-                    if (it.second == VoteFlags::VOTE_ABSTAIN && view.GetConsultationAnswer(it.first, answer))
+                    if (view.HaveConsultation(it.first) || view.HaveConsultationAnswer(it.first))
                     {
-                        if(mapCacheConsultationToUpdate.count(std::make_pair(answer.parent,it.second)) == 0)
-                            mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)] = 0;
 
-                        mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)] += 1;
+                        if (it.second == VoteFlags::VOTE_ABSTAIN && view.GetConsultationAnswer(it.first, answer))
+                        {
+                            if(mapCacheConsultationToUpdate.count(std::make_pair(answer.parent,it.second)) == 0)
+                                mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)] = 0;
 
-                        mapSeen[it.first]=true;
+                            mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)] += 1;
 
-                        LogPrint("daoextra", "%s: Found consultation answer vote %d for %s at block height %d (total %d)\n", __func__,
-                                 it.second, answer.parent.ToString(), pindexblock->nHeight, mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)]);
-                    }
-                    else
-                    {
-                        if(mapCacheConsultationToUpdate.count(std::make_pair(it.first,it.second)) == 0)
-                            mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)] = 0;
+                            mapSeen[it.first]=true;
 
-                        mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)] += 1;
+                            LogPrint("daoextra", "%s: Found consultation answer vote %d for %s at block height %d (total %d)\n", __func__,
+                                     it.second, answer.parent.ToString(), pindexblock->nHeight, mapCacheConsultationToUpdate[std::make_pair(answer.parent,it.second)]);
+                        }
+                        else
+                        {
+                            if(mapCacheConsultationToUpdate.count(std::make_pair(it.first,it.second)) == 0)
+                                mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)] = 0;
 
-                        mapSeen[it.first]=true;
+                            mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)] += 1;
 
-                        LogPrint("daoextra", "%s: Found consultation vote %d for %s at block height %d (total %d)\n", __func__,
-                                 it.second, it.first.ToString(), pindexblock->nHeight, mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)]);
+                            mapSeen[it.first]=true;
+
+                            LogPrint("daoextra", "%s: Found consultation vote %d for %s at block height %d (total %d)\n", __func__,
+                                     it.second, it.first.ToString(), pindexblock->nHeight, mapCacheConsultationToUpdate[std::make_pair(it.first,it.second)]);
+                        }
                     }
                 }
             }

--- a/src/main.h
+++ b/src/main.h
@@ -186,6 +186,10 @@ extern CTxMemPool mempool;
 extern CTxMemPool stempool;
 typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
+extern std::map<uint256,std::vector<std::pair<uint256, int>>> vProposalVotes;
+extern std::map<uint256,std::vector<std::pair<uint256, int>>> vPaymentRequestVotes;
+extern std::map<uint256,std::map<uint256, bool>> mapSupport;
+extern std::map<uint256,std::map<uint256, uint64_t>> mapConsultationVotes;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
 extern uint64_t nLastBlockWeight;
@@ -672,5 +676,14 @@ uint64_t GetStakingRewardPerBlock(const CStateViewCache& view);
 
 static void RelayDandelionTransaction(const CTransaction& tx, CNode* pfrom);
 static void CheckDandelionEmbargoes();
+
+std::vector<std::pair<uint256, int>>* GetProposalVotes(const uint256& hash);
+std::vector<std::pair<uint256, int>>* GetPaymentRequestVotes(const uint256& hash);
+std::map<uint256, bool>* GetSupport(const uint256& hash);
+std::map<uint256, uint64_t>* GetConsultationVotes(const uint256& hash);
+std::vector<std::pair<uint256, int>>* InsertProposalVotes(const uint256& hash);
+std::vector<std::pair<uint256, int>>* InsertPaymentRequestVotes(const uint256& hash);
+std::map<uint256, bool>* InsertSupport(const uint256& hash);
+std::map<uint256, uint64_t>* InsertConsultationVotes(const uint256& hash);
 
 #endif // NAVCOIN_MAIN_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -66,39 +66,55 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.pushKV("modifier", strprintf("%016x", blockindex->nStakeModifier));
 
     UniValue votes(UniValue::VARR);
-    for (auto& it: blockindex->vProposalVotes)
+    auto pVotes = GetProposalVotes(blockindex->GetBlockHash());
+    if (pVotes != nullptr)
     {
-        UniValue entry(UniValue::VOBJ);
-        entry.pushKV("hash", it.first.ToString());
-        entry.pushKV("vote", it.second);
-        votes.push_back(entry);
+        for (auto& it: *pVotes)
+        {
+            UniValue entry(UniValue::VOBJ);
+            entry.pushKV("hash", it.first.ToString());
+            entry.pushKV("vote", it.second);
+            votes.push_back(entry);
+        }
     }
     result.pushKV("cfund_votes", votes);
 
     UniValue votes_pr(UniValue::VARR);
-    for (auto& it: blockindex->vPaymentRequestVotes)
+    auto prVotes = GetPaymentRequestVotes(blockindex->GetBlockHash());
+    if (prVotes != nullptr)
     {
-        UniValue entry(UniValue::VOBJ);
-        entry.pushKV("hash", it.first.ToString());
-        entry.pushKV("vote", it.second);
-        votes_pr.push_back(entry);
+        for (auto& it: *prVotes)
+        {
+            UniValue entry(UniValue::VOBJ);
+            entry.pushKV("hash", it.first.ToString());
+            entry.pushKV("vote", it.second);
+            votes_pr.push_back(entry);
+        }
     }
     result.pushKV("cfund_request_votes", votes_pr);
 
     UniValue daosupport(UniValue::VARR);
-    for (auto& it: blockindex->mapSupport)
+    auto supp = GetSupport(blockindex->GetBlockHash());
+    if (supp != nullptr)
     {
-        daosupport.push_back(it.first.ToString());
+        for (auto& it: *supp)
+        {
+            daosupport.push_back(it.first.ToString());
+        }
     }
     result.pushKV("dao_support", daosupport);
 
     UniValue daovotes(UniValue::VARR);
-    for (auto& it: blockindex->mapConsultationVotes)
+    auto cVotes = GetConsultationVotes(blockindex->GetBlockHash());
+    if (cVotes != nullptr)
     {
-        UniValue entry(UniValue::VOBJ);
-        entry.pushKV("hash", it.first.ToString());
-        entry.pushKV("vote", it.second);
-        daovotes.push_back(entry);
+        for (auto& it: *cVotes)
+        {
+            UniValue entry(UniValue::VOBJ);
+            entry.pushKV("hash", it.first.ToString());
+            entry.pushKV("vote", it.second);
+            daovotes.push_back(entry);
+        }
     }
     result.pushKV("dao_votes", daovotes);
 
@@ -316,14 +332,14 @@ UniValue getblockcount(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getblockcount\n"
-            "\nReturns the number of blocks in the longest block chain.\n"
-            "\nResult:\n"
-            "n    (numeric) The current block count\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockcount", "")
-            + HelpExampleRpc("getblockcount", "")
-        );
+                "getblockcount\n"
+                "\nReturns the number of blocks in the longest block chain.\n"
+                "\nResult:\n"
+                "n    (numeric) The current block count\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblockcount", "")
+                + HelpExampleRpc("getblockcount", "")
+                );
 
     LOCK(cs_main);
     return chainActive.Height();
@@ -333,14 +349,14 @@ UniValue getbestblockhash(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getbestblockhash\n"
-            "\nReturns the hash of the best (tip) block in the longest block chain.\n"
-            "\nResult\n"
-            "\"hex\"      (string) the block hash hex encoded\n"
-            "\nExamples\n"
-            + HelpExampleCli("getbestblockhash", "")
-            + HelpExampleRpc("getbestblockhash", "")
-        );
+                "getbestblockhash\n"
+                "\nReturns the hash of the best (tip) block in the longest block chain.\n"
+                "\nResult\n"
+                "\"hex\"      (string) the block hash hex encoded\n"
+                "\nExamples\n"
+                + HelpExampleCli("getbestblockhash", "")
+                + HelpExampleRpc("getbestblockhash", "")
+                );
 
     LOCK(cs_main);
     return chainActive.Tip()->GetBlockHash().GetHex();
@@ -350,14 +366,14 @@ UniValue getdifficulty(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getdifficulty\n"
-            "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nResult:\n"
-            "n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getdifficulty", "")
-            + HelpExampleRpc("getdifficulty", "")
-        );
+                "getdifficulty\n"
+                "\nReturns the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
+                "\nResult:\n"
+                "n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getdifficulty", "")
+                + HelpExampleRpc("getdifficulty", "")
+                );
 
     LOCK(cs_main);
     return GetDifficulty();
@@ -367,20 +383,20 @@ std::string EntryDescriptionString()
 {
     return "    \"size\" : n,             (numeric) transaction size in bytes\n"
            "    \"fee\" : n,              (numeric) transaction fee in " + CURRENCY_UNIT + "\n"
-           "    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority\n"
-           "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
-           "    \"height\" : n,           (numeric) block height when transaction entered pool\n"
-           "    \"startingpriority\" : n, (numeric) priority when transaction entered pool\n"
-           "    \"currentpriority\" : n,  (numeric) transaction priority now\n"
-           "    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n"
-           "    \"descendantsize\" : n,   (numeric) size of in-mempool descendants (including this one)\n"
-           "    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one)\n"
-           "    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n"
-           "    \"ancestorsize\" : n,     (numeric) size of in-mempool ancestors (including this one)\n"
-           "    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one)\n"
-           "    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n"
-           "        \"transactionid\",    (string) parent transaction id\n"
-           "       ... ]\n";
+                                                                                           "    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority\n"
+                                                                                           "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
+                                                                                           "    \"height\" : n,           (numeric) block height when transaction entered pool\n"
+                                                                                           "    \"startingpriority\" : n, (numeric) priority when transaction entered pool\n"
+                                                                                           "    \"currentpriority\" : n,  (numeric) transaction priority now\n"
+                                                                                           "    \"descendantcount\" : n,  (numeric) number of in-mempool descendant transactions (including this one)\n"
+                                                                                           "    \"descendantsize\" : n,   (numeric) size of in-mempool descendants (including this one)\n"
+                                                                                           "    \"descendantfees\" : n,   (numeric) modified fees (see above) of in-mempool descendants (including this one)\n"
+                                                                                           "    \"ancestorcount\" : n,    (numeric) number of in-mempool ancestor transactions (including this one)\n"
+                                                                                           "    \"ancestorsize\" : n,     (numeric) size of in-mempool ancestors (including this one)\n"
+                                                                                           "    \"ancestorfees\" : n,     (numeric) modified fees (see above) of in-mempool ancestors (including this one)\n"
+                                                                                           "    \"depends\" : [           (array) unconfirmed transactions used as inputs for this transaction\n"
+                                                                                           "        \"transactionid\",    (string) parent transaction id\n"
+                                                                                           "       ... ]\n";
 }
 
 void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
@@ -449,25 +465,25 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
         throw runtime_error(
-            "getrawmempool ( verbose )\n"
-            "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
-            "\nArguments:\n"
-            "1. verbose           (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
-            "\nResult: (for verbose = false):\n"
-            "[                     (json array of string)\n"
-            "  \"transactionid\"     (string) The transaction id\n"
-            "  ,...\n"
-            "]\n"
-            "\nResult: (for verbose = true):\n"
-            "{                           (json object)\n"
-            "  \"transactionid\" : {       (json object)\n"
-            + EntryDescriptionString()
-            + "  }, ...\n"
-            "}\n"
-            "\nExamples\n"
-            + HelpExampleCli("getrawmempool", "true")
-            + HelpExampleRpc("getrawmempool", "true")
-        );
+                "getrawmempool ( verbose )\n"
+                "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
+                "\nArguments:\n"
+                "1. verbose           (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
+                "\nResult: (for verbose = false):\n"
+                "[                     (json array of string)\n"
+                "  \"transactionid\"     (string) The transaction id\n"
+                "  ,...\n"
+                "]\n"
+                "\nResult: (for verbose = true):\n"
+                "{                           (json object)\n"
+                "  \"transactionid\" : {       (json object)\n"
+                + EntryDescriptionString()
+                + "  }, ...\n"
+                  "}\n"
+                  "\nExamples\n"
+                + HelpExampleCli("getrawmempool", "true")
+                + HelpExampleRpc("getrawmempool", "true")
+                );
 
     bool fVerbose = false;
     if (params.size() > 0)
@@ -480,26 +496,26 @@ UniValue getmempoolancestors(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2) {
         throw runtime_error(
-            "getmempoolancestors txid (verbose)\n"
-            "\nIf txid is in the mempool, returns all in-mempool ancestors.\n"
-            "\nArguments:\n"
-            "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
-            "2. verbose                  (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
-            "\nResult (for verbose=false):\n"
-            "[                       (json array of strings)\n"
-            "  \"transactionid\"           (string) The transaction id of an in-mempool ancestor transaction\n"
-            "  ,...\n"
-            "]\n"
-            "\nResult (for verbose=true):\n"
-            "{                           (json object)\n"
-            "  \"transactionid\" : {       (json object)\n"
-            + EntryDescriptionString()
-            + "  }, ...\n"
-            "}\n"
-            "\nExamples\n"
-            + HelpExampleCli("getmempoolancestors", "\"mytxid\"")
-            + HelpExampleRpc("getmempoolancestors", "\"mytxid\"")
-            );
+                    "getmempoolancestors txid (verbose)\n"
+                    "\nIf txid is in the mempool, returns all in-mempool ancestors.\n"
+                    "\nArguments:\n"
+                    "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
+                    "2. verbose                  (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
+                    "\nResult (for verbose=false):\n"
+                    "[                       (json array of strings)\n"
+                    "  \"transactionid\"           (string) The transaction id of an in-mempool ancestor transaction\n"
+                    "  ,...\n"
+                    "]\n"
+                    "\nResult (for verbose=true):\n"
+                    "{                           (json object)\n"
+                    "  \"transactionid\" : {       (json object)\n"
+                    + EntryDescriptionString()
+                    + "  }, ...\n"
+                      "}\n"
+                      "\nExamples\n"
+                    + HelpExampleCli("getmempoolancestors", "\"mytxid\"")
+                    + HelpExampleRpc("getmempoolancestors", "\"mytxid\"")
+                    );
     }
 
     bool fVerbose = false;
@@ -544,26 +560,26 @@ UniValue getmempooldescendants(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2) {
         throw runtime_error(
-            "getmempooldescendants txid (verbose)\n"
-            "\nIf txid is in the mempool, returns all in-mempool descendants.\n"
-            "\nArguments:\n"
-            "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
-            "2. verbose                  (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
-            "\nResult (for verbose=false):\n"
-            "[                       (json array of strings)\n"
-            "  \"transactionid\"           (string) The transaction id of an in-mempool descendant transaction\n"
-            "  ,...\n"
-            "]\n"
-            "\nResult (for verbose=true):\n"
-            "{                           (json object)\n"
-            "  \"transactionid\" : {       (json object)\n"
-            + EntryDescriptionString()
-            + "  }, ...\n"
-            "}\n"
-            "\nExamples\n"
-            + HelpExampleCli("getmempooldescendants", "\"mytxid\"")
-            + HelpExampleRpc("getmempooldescendants", "\"mytxid\"")
-            );
+                    "getmempooldescendants txid (verbose)\n"
+                    "\nIf txid is in the mempool, returns all in-mempool descendants.\n"
+                    "\nArguments:\n"
+                    "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
+                    "2. verbose                  (boolean, optional, default=false) true for a json object, false for array of transaction ids\n"
+                    "\nResult (for verbose=false):\n"
+                    "[                       (json array of strings)\n"
+                    "  \"transactionid\"           (string) The transaction id of an in-mempool descendant transaction\n"
+                    "  ,...\n"
+                    "]\n"
+                    "\nResult (for verbose=true):\n"
+                    "{                           (json object)\n"
+                    "  \"transactionid\" : {       (json object)\n"
+                    + EntryDescriptionString()
+                    + "  }, ...\n"
+                      "}\n"
+                      "\nExamples\n"
+                    + HelpExampleCli("getmempooldescendants", "\"mytxid\"")
+                    + HelpExampleRpc("getmempooldescendants", "\"mytxid\"")
+                    );
     }
 
     bool fVerbose = false;
@@ -608,18 +624,18 @@ UniValue getmempoolentry(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1) {
         throw runtime_error(
-            "getmempoolentry txid\n"
-            "\nReturns mempool data for given transaction\n"
-            "\nArguments:\n"
-            "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
-            "\nResult:\n"
-            "{                           (json object)\n"
-            + EntryDescriptionString()
-            + "}\n"
-            "\nExamples\n"
-            + HelpExampleCli("getmempoolentry", "\"mytxid\"")
-            + HelpExampleRpc("getmempoolentry", "\"mytxid\"")
-        );
+                    "getmempoolentry txid\n"
+                    "\nReturns mempool data for given transaction\n"
+                    "\nArguments:\n"
+                    "1. \"txid\"                   (string, required) The transaction id (must be in mempool)\n"
+                    "\nResult:\n"
+                    "{                           (json object)\n"
+                    + EntryDescriptionString()
+                    + "}\n"
+                      "\nExamples\n"
+                    + HelpExampleCli("getmempoolentry", "\"mytxid\"")
+                    + HelpExampleRpc("getmempoolentry", "\"mytxid\"")
+                    );
     }
 
     uint256 hash = ParseHashV(params[0], "parameter 1");
@@ -664,31 +680,31 @@ UniValue getblockhashes(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 2)
         throw runtime_error(
-            "getblockhashes timestamp\n"
-            "\nReturns array of hashes of blocks within the timestamp range provided.\n"
-            "\nArguments:\n"
-            "1. high         (numeric, required) The newer block timestamp\n"
-            "2. low          (numeric, required) The older block timestamp\n"
-            "3. options      (string, required) A json object\n"
-            "    {\n"
-            "      \"noOrphans\":true   (boolean) will only include blocks on the main chain\n"
-            "      \"logicalTimes\":true   (boolean) will include logical timestamps with hashes\n"
-            "    }\n"
-            "\nResult:\n"
-            "[\n"
-            "  \"hash\"         (string) The block hash\n"
-            "]\n"
-            "[\n"
-            "  {\n"
-            "    \"blockhash\": (string) The block hash\n"
-            "    \"logicalts\": (numeric) The logical timestamp\n"
-            "  }\n"
-            "]\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockhashes", "1231614698 1231024505")
-            + HelpExampleRpc("getblockhashes", "1231614698, 1231024505")
-            + HelpExampleCli("getblockhashes", "1231614698 1231024505 '{\"noOrphans\":false, \"logicalTimes\":true}'")
-            );
+                "getblockhashes timestamp\n"
+                "\nReturns array of hashes of blocks within the timestamp range provided.\n"
+                "\nArguments:\n"
+                "1. high         (numeric, required) The newer block timestamp\n"
+                "2. low          (numeric, required) The older block timestamp\n"
+                "3. options      (string, required) A json object\n"
+                "    {\n"
+                "      \"noOrphans\":true   (boolean) will only include blocks on the main chain\n"
+                "      \"logicalTimes\":true   (boolean) will include logical timestamps with hashes\n"
+                "    }\n"
+                "\nResult:\n"
+                "[\n"
+                "  \"hash\"         (string) The block hash\n"
+                "]\n"
+                "[\n"
+                "  {\n"
+                "    \"blockhash\": (string) The block hash\n"
+                "    \"logicalts\": (numeric) The logical timestamp\n"
+                "  }\n"
+                "]\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblockhashes", "1231614698 1231024505")
+                + HelpExampleRpc("getblockhashes", "1231614698, 1231024505")
+                + HelpExampleCli("getblockhashes", "1231614698 1231024505 '{\"noOrphans\":false, \"logicalTimes\":true}'")
+                );
 
     unsigned int high = params[0].get_int();
     unsigned int low = params[1].get_int();
@@ -737,16 +753,16 @@ UniValue getblockhash(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "getblockhash index\n"
-            "\nReturns hash of block in best-block-chain at index provided.\n"
-            "\nArguments:\n"
-            "1. index         (numeric, required) The block index\n"
-            "\nResult:\n"
-            "\"hash\"         (string) The block hash\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockhash", "1000")
-            + HelpExampleRpc("getblockhash", "1000")
-        );
+                "getblockhash index\n"
+                "\nReturns hash of block in best-block-chain at index provided.\n"
+                "\nArguments:\n"
+                "1. index         (numeric, required) The block index\n"
+                "\nResult:\n"
+                "\"hash\"         (string) The block hash\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblockhash", "1000")
+                + HelpExampleRpc("getblockhash", "1000")
+                );
 
     LOCK(cs_main);
 
@@ -762,35 +778,35 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "getblockheader \"hash\" ( verbose )\n"
-            "\nIf verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.\n"
-            "If verbose is true, returns an Object with information about blockheader <hash>.\n"
-            "\nArguments:\n"
-            "1. \"hash\"          (string, required) The block hash\n"
-            "2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data\n"
-            "\nResult (for verbose = true):\n"
-            "{\n"
-            "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
-            "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
-            "  \"height\" : n,          (numeric) The block height or index\n"
-            "  \"version\" : n,         (numeric) The block version\n"
-            "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
-            "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
-            "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"nonce\" : n,           (numeric) The nonce\n"
-            "  \"bits\" : \"1d00ffff\", (string) The bits\n"
-            "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
-            "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
-            "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
-            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
-            "}\n"
-            "\nResult (for verbose=false):\n"
-            "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
-            + HelpExampleRpc("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
-        );
+                "getblockheader \"hash\" ( verbose )\n"
+                "\nIf verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.\n"
+                "If verbose is true, returns an Object with information about blockheader <hash>.\n"
+                "\nArguments:\n"
+                "1. \"hash\"          (string, required) The block hash\n"
+                "2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data\n"
+                "\nResult (for verbose = true):\n"
+                "{\n"
+                "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
+                "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
+                "  \"height\" : n,          (numeric) The block height or index\n"
+                "  \"version\" : n,         (numeric) The block version\n"
+                "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
+                "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
+                "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
+                "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+                "  \"nonce\" : n,           (numeric) The nonce\n"
+                "  \"bits\" : \"1d00ffff\", (string) The bits\n"
+                "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+                "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
+                "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
+                "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+                "}\n"
+                "\nResult (for verbose=false):\n"
+                "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
+                + HelpExampleRpc("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
+                );
 
     LOCK(cs_main);
 
@@ -821,42 +837,42 @@ UniValue getblock(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "getblock \"hash\" ( verbose )\n"
-            "\nIf verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
-            "If verbose is true, returns an Object with information about block <hash>.\n"
-            "\nArguments:\n"
-            "1. \"hash\"          (string, required) The block hash\n"
-            "2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data\n"
-            "\nResult (for verbose = true):\n"
-            "{\n"
-            "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
-            "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
-            "  \"size\" : n,            (numeric) The block size\n"
-            "  \"strippedsize\" : n,    (numeric) The block size excluding witness data\n"
-            "  \"weight\" : n           (numeric) The block weight (BIP 141)\n"
-            "  \"height\" : n,          (numeric) The block height or index\n"
-            "  \"version\" : n,         (numeric) The block version\n"
-            "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
-            "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
-            "  \"tx\" : [               (array of string) The transaction ids\n"
-            "     \"transactionid\"     (string) The transaction id\n"
-            "     ,...\n"
-            "  ],\n"
-            "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
-            "  \"nonce\" : n,           (numeric) The nonce\n"
-            "  \"bits\" : \"1d00ffff\", (string) The bits\n"
-            "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
-            "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
-            "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
-            "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
-            "}\n"
-            "\nResult (for verbose=false):\n"
-            "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
-            + HelpExampleRpc("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
-        );
+                "getblock \"hash\" ( verbose )\n"
+                "\nIf verbose is false, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
+                "If verbose is true, returns an Object with information about block <hash>.\n"
+                "\nArguments:\n"
+                "1. \"hash\"          (string, required) The block hash\n"
+                "2. verbose           (boolean, optional, default=true) true for a json object, false for the hex encoded data\n"
+                "\nResult (for verbose = true):\n"
+                "{\n"
+                "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
+                "  \"confirmations\" : n,   (numeric) The number of confirmations, or -1 if the block is not on the main chain\n"
+                "  \"size\" : n,            (numeric) The block size\n"
+                "  \"strippedsize\" : n,    (numeric) The block size excluding witness data\n"
+                "  \"weight\" : n           (numeric) The block weight (BIP 141)\n"
+                "  \"height\" : n,          (numeric) The block height or index\n"
+                "  \"version\" : n,         (numeric) The block version\n"
+                "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
+                "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
+                "  \"tx\" : [               (array of string) The transaction ids\n"
+                "     \"transactionid\"     (string) The transaction id\n"
+                "     ,...\n"
+                "  ],\n"
+                "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
+                "  \"mediantime\" : ttt,    (numeric) The median block time in seconds since epoch (Jan 1 1970 GMT)\n"
+                "  \"nonce\" : n,           (numeric) The nonce\n"
+                "  \"bits\" : \"1d00ffff\", (string) The bits\n"
+                "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+                "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
+                "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
+                "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
+                "}\n"
+                "\nResult (for verbose=false):\n"
+                "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
+                + HelpExampleRpc("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
+                );
 
     LOCK(cs_main);
 
@@ -948,23 +964,23 @@ UniValue gettxoutsetinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "gettxoutsetinfo\n"
-            "\nReturns statistics about the unspent transaction output set.\n"
-            "Note this call may take some time.\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"height\":n,     (numeric) The current block height (index)\n"
-            "  \"bestblock\": \"hex\",   (string) the best block hash hex\n"
-            "  \"transactions\": n,      (numeric) The number of transactions\n"
-            "  \"txouts\": n,            (numeric) The number of output transactions\n"
-            "  \"bytes_serialized\": n,  (numeric) The serialized size\n"
-            "  \"hash_serialized\": \"hash\",   (string) The serialized hash\n"
-            "  \"total_amount\": x.xxx          (numeric) The total amount\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("gettxoutsetinfo", "")
-            + HelpExampleRpc("gettxoutsetinfo", "")
-        );
+                "gettxoutsetinfo\n"
+                "\nReturns statistics about the unspent transaction output set.\n"
+                "Note this call may take some time.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"height\":n,     (numeric) The current block height (index)\n"
+                "  \"bestblock\": \"hex\",   (string) the best block hash hex\n"
+                "  \"transactions\": n,      (numeric) The number of transactions\n"
+                "  \"txouts\": n,            (numeric) The number of output transactions\n"
+                "  \"bytes_serialized\": n,  (numeric) The serialized size\n"
+                "  \"hash_serialized\": \"hash\",   (string) The serialized hash\n"
+                "  \"total_amount\": x.xxx          (numeric) The total amount\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("gettxoutsetinfo", "")
+                + HelpExampleRpc("gettxoutsetinfo", "")
+                );
 
     UniValue ret(UniValue::VOBJ);
 
@@ -1091,11 +1107,11 @@ UniValue listconsultations(const UniValue& params, bool fHelp)
             flags fState = consultation.GetLastState();
 
             if((showNotEnoughAnswers && fState == DAOFlags::NIL && vAnswers.size() < 2) ||
-               (showLookingForSupport && fState == DAOFlags::NIL) ||
-               (showReflection && fState == DAOFlags::REFLECTION) ||
-               (showReflection && fState == DAOFlags::ACCEPTED) ||
-               (showFinished && fState == DAOFlags::EXPIRED) ||
-                showAll) {
+                    (showLookingForSupport && fState == DAOFlags::NIL) ||
+                    (showReflection && fState == DAOFlags::REFLECTION) ||
+                    (showReflection && fState == DAOFlags::ACCEPTED) ||
+                    (showFinished && fState == DAOFlags::EXPIRED) ||
+                    showAll) {
                 UniValue o(UniValue::VOBJ);
                 consultation.ToJson(o, view);
                 ret.push_back(o);
@@ -1110,11 +1126,11 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
 
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "cfundstats\n"
-            "\nReturns statistics about the community fund.\n"
-            + HelpExampleCli("cfundstats", "")
-            + HelpExampleRpc("cfundstats", "")
-        );
+                "cfundstats\n"
+                "\nReturns statistics about the community fund.\n"
+                + HelpExampleCli("cfundstats", "")
+                + HelpExampleRpc("cfundstats", "")
+                );
 
     LOCK(cs_main);
 
@@ -1135,46 +1151,54 @@ UniValue cfundstats(const UniValue& params, bool fHelp)
     while(nBlocks > 0 && pindexblock != nullptr) {
         vSeen.clear();
 
-        for(unsigned int i = 0; i < pindexblock->vProposalVotes.size(); i++)
+        auto pVotes = GetProposalVotes(pindexblock->GetBlockHash());
+        if (pVotes != nullptr)
         {
-            if(!view.GetProposal(pindexblock->vProposalVotes[i].first, proposal))
-                continue;
-
-            if(vSeen.count(pindexblock->vProposalVotes[i].first) == 0)
+            for (unsigned int i = 0; i < pVotes->size(); i++)
             {
-                if(vCacheProposalsRPC.count(pindexblock->vProposalVotes[i].first) == 0)
-                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first] = make_pair(make_pair(0,0), 0);
+                if(!view.GetProposal((*pVotes)[i].first, proposal))
+                    continue;
 
-                if(pindexblock->vProposalVotes[i].second == 1)
-                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first].first.first += 1;
-                else if(pindexblock->vProposalVotes[i].second == -1)
-                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first].second += 1;
-                else if (pindexblock->vProposalVotes[i].second == 0)
-                    vCacheProposalsRPC[pindexblock->vProposalVotes[i].first].first.second += 1;
+                if(vSeen.count((*pVotes)[i].first) == 0)
+                {
+                    if(vCacheProposalsRPC.count((*pVotes)[i].first) == 0)
+                        vCacheProposalsRPC[(*pVotes)[i].first] = make_pair(make_pair(0,0), 0);
 
-                vSeen[pindexblock->vProposalVotes[i].first]=true;
+                    if((*pVotes)[i].second == 1)
+                        vCacheProposalsRPC[(*pVotes)[i].first].first.first += 1;
+                    else if((*pVotes)[i].second == -1)
+                        vCacheProposalsRPC[(*pVotes)[i].first].second += 1;
+                    else if ((*pVotes)[i].second == 0)
+                        vCacheProposalsRPC[(*pVotes)[i].first].first.second += 1;
+
+                    vSeen[(*pVotes)[i].first]=true;
+                }
             }
         }
 
-        for(unsigned int i = 0; i < pindexblock->vPaymentRequestVotes.size(); i++)
+        auto prVotes = GetPaymentRequestVotes(pindexblock->GetBlockHash());
+        if (prVotes != nullptr)
         {
-            if(!view.GetPaymentRequest(pindexblock->vPaymentRequestVotes[i].first, prequest))
-                continue;
+            for(unsigned int i = 0; i < prVotes->size(); i++)
+            {
+                if(!view.GetPaymentRequest((*prVotes)[i].first, prequest))
+                    continue;
 
-            if(!view.GetProposal(prequest.proposalhash, proposal))
-                continue;
-            if(vSeen.count(pindexblock->vPaymentRequestVotes[i].first) == 0) {
-                if(vCachePaymentRequestRPC.count(pindexblock->vPaymentRequestVotes[i].first) == 0)
-                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first] = make_pair(make_pair(0,0), 0);
+                if(!view.GetProposal(prequest.proposalhash, proposal))
+                    continue;
+                if(vSeen.count((*prVotes)[i].first) == 0) {
+                    if(vCachePaymentRequestRPC.count((*prVotes)[i].first) == 0)
+                        vCachePaymentRequestRPC[(*prVotes)[i].first] = make_pair(make_pair(0,0), 0);
 
-                if(pindexblock->vPaymentRequestVotes[i].second == 1)
-                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first].first.first += 1;
-                else if(pindexblock->vPaymentRequestVotes[i].second == -1)
-                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first].second += 1;
-                else if (pindexblock->vPaymentRequestVotes[i].second == 0)
-                    vCachePaymentRequestRPC[pindexblock->vPaymentRequestVotes[i].first].first.second += 1;
+                    if((*prVotes)[i].second == 1)
+                        vCachePaymentRequestRPC[(*prVotes)[i].first].first.first += 1;
+                    else if((*prVotes)[i].second == -1)
+                        vCachePaymentRequestRPC[(*prVotes)[i].first].second += 1;
+                    else if ((*prVotes)[i].second == 0)
+                        vCachePaymentRequestRPC[(*prVotes)[i].first].first.second += 1;
 
-                vSeen[pindexblock->vPaymentRequestVotes[i].first]=true;
+                    vSeen[(*prVotes)[i].first]=true;
+                }
             }
         }
 
@@ -1274,39 +1298,39 @@ UniValue gettxout(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 2 || params.size() > 3)
         throw runtime_error(
-            "gettxout \"txid\" n ( includemempool )\n"
-            "\nReturns details about an unspent transaction output.\n"
-            "\nArguments:\n"
-            "1. \"txid\"       (string, required) The transaction id\n"
-            "2. n              (numeric, required) vout number\n"
-            "3. includemempool  (boolean, optional) Whether to include the mem pool\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"bestblock\" : \"hash\",    (string) the block hash\n"
-            "  \"confirmations\" : n,       (numeric) The number of confirmations\n"
-            "  \"value\" : x.xxx,           (numeric) The transaction value in " + CURRENCY_UNIT + "\n"
-            "  \"scriptPubKey\" : {         (json object)\n"
-            "     \"asm\" : \"code\",       (string) \n"
-            "     \"hex\" : \"hex\",        (string) \n"
-            "     \"reqSigs\" : n,          (numeric) Number of required signatures\n"
-            "     \"type\" : \"pubkeyhash\", (string) The type, eg pubkeyhash\n"
-            "     \"addresses\" : [          (array of string) array of navcoin addresses\n"
-            "        \"navcoinaddress\"     (string) navcoin address\n"
-            "        ,...\n"
-            "     ]\n"
-            "  },\n"
-            "  \"version\" : n,            (numeric) The version\n"
-            "  \"coinbase\" : true|false   (boolean) Coinbase or not\n"
-            "}\n"
+                "gettxout \"txid\" n ( includemempool )\n"
+                "\nReturns details about an unspent transaction output.\n"
+                "\nArguments:\n"
+                "1. \"txid\"       (string, required) The transaction id\n"
+                "2. n              (numeric, required) vout number\n"
+                "3. includemempool  (boolean, optional) Whether to include the mem pool\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"bestblock\" : \"hash\",    (string) the block hash\n"
+                "  \"confirmations\" : n,       (numeric) The number of confirmations\n"
+                "  \"value\" : x.xxx,           (numeric) The transaction value in " + CURRENCY_UNIT + "\n"
+                                                                                                       "  \"scriptPubKey\" : {         (json object)\n"
+                                                                                                       "     \"asm\" : \"code\",       (string) \n"
+                                                                                                       "     \"hex\" : \"hex\",        (string) \n"
+                                                                                                       "     \"reqSigs\" : n,          (numeric) Number of required signatures\n"
+                                                                                                       "     \"type\" : \"pubkeyhash\", (string) The type, eg pubkeyhash\n"
+                                                                                                       "     \"addresses\" : [          (array of string) array of navcoin addresses\n"
+                                                                                                       "        \"navcoinaddress\"     (string) navcoin address\n"
+                                                                                                       "        ,...\n"
+                                                                                                       "     ]\n"
+                                                                                                       "  },\n"
+                                                                                                       "  \"version\" : n,            (numeric) The version\n"
+                                                                                                       "  \"coinbase\" : true|false   (boolean) Coinbase or not\n"
+                                                                                                       "}\n"
 
-            "\nExamples:\n"
-            "\nGet unspent transactions\n"
-            + HelpExampleCli("listunspent", "") +
-            "\nView the details\n"
-            + HelpExampleCli("gettxout", "\"txid\" 1") +
-            "\nAs a json rpc call\n"
-            + HelpExampleRpc("gettxout", "\"txid\", 1")
-        );
+                                                                                                       "\nExamples:\n"
+                                                                                                       "\nGet unspent transactions\n"
+                + HelpExampleCli("listunspent", "") +
+                "\nView the details\n"
+                + HelpExampleCli("gettxout", "\"txid\" 1") +
+                "\nAs a json rpc call\n"
+                + HelpExampleRpc("gettxout", "\"txid\", 1")
+                );
 
     LOCK(cs_main);
 
@@ -1356,17 +1380,17 @@ UniValue verifychain(const UniValue& params, bool fHelp)
     int nCheckDepth = GetArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     if (fHelp || params.size() > 2)
         throw runtime_error(
-            "verifychain ( checklevel numblocks )\n"
-            "\nVerifies blockchain database.\n"
-            "\nArguments:\n"
-            "1. checklevel   (numeric, optional, 0-4, default=" + strprintf("%d", nCheckLevel) + ") How thorough the block verification is.\n"
-            "2. numblocks    (numeric, optional, default=" + strprintf("%d", nCheckDepth) + ", 0=all) The number of blocks to check.\n"
-            "\nResult:\n"
-            "true|false       (boolean) Verified or not\n"
-            "\nExamples:\n"
-            + HelpExampleCli("verifychain", "")
-            + HelpExampleRpc("verifychain", "")
-        );
+                "verifychain ( checklevel numblocks )\n"
+                "\nVerifies blockchain database.\n"
+                "\nArguments:\n"
+                "1. checklevel   (numeric, optional, 0-4, default=" + strprintf("%d", nCheckLevel) + ") How thorough the block verification is.\n"
+                                                                                                     "2. numblocks    (numeric, optional, default=" + strprintf("%d", nCheckDepth) + ", 0=all) The number of blocks to check.\n"
+                                                                                                                                                                                     "\nResult:\n"
+                                                                                                                                                                                     "true|false       (boolean) Verified or not\n"
+                                                                                                                                                                                     "\nExamples:\n"
+                + HelpExampleCli("verifychain", "")
+                + HelpExampleRpc("verifychain", "")
+                );
 
     LOCK(cs_main);
 
@@ -1445,46 +1469,46 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getblockchaininfo\n"
-            "Returns an object containing various state info regarding block chain processing.\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"chain\": \"xxxx\",        (string) current network name as defined in BIP70 (main, test, regtest)\n"
-            "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
-            "  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n"
-            "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
-            "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
-            "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
-            "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
-            "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
-            "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
-            "  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n"
-            "  \"softforks\": [            (array) status of softforks in progress\n"
-            "     {\n"
-            "        \"id\": \"xxxx\",        (string) name of softfork\n"
-            "        \"version\": xx,         (numeric) block version\n"
-            "        \"enforce\": {           (object) progress toward enforcing the softfork rules for new-version blocks\n"
-            "           \"status\": xx,       (boolean) true if threshold reached\n"
-            "           \"found\": xx,        (numeric) number of blocks with the new version found\n"
-            "           \"required\": xx,     (numeric) number of blocks required to trigger\n"
-            "           \"window\": xx,       (numeric) maximum size of examined window of recent blocks\n"
-            "        },\n"
-            "        \"reject\": { ... }      (object) progress toward rejecting pre-softfork blocks (same fields as \"enforce\")\n"
-            "     }, ...\n"
-            "  ],\n"
-            "  \"bip9_softforks\": {          (object) status of BIP9 softforks in progress\n"
-            "     \"xxxx\" : {                (string) name of the softfork\n"
-            "        \"status\": \"xxxx\",    (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n"
-            "        \"bit\": xx,             (numeric) the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)\n"
-            "        \"startTime\": xx,       (numeric) the minimum median time past of a block at which the bit gains its meaning\n"
-            "        \"timeout\": xx          (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n"
-            "     }\n"
-            "  }\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getblockchaininfo", "")
-            + HelpExampleRpc("getblockchaininfo", "")
-        );
+                "getblockchaininfo\n"
+                "Returns an object containing various state info regarding block chain processing.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"chain\": \"xxxx\",        (string) current network name as defined in BIP70 (main, test, regtest)\n"
+                "  \"blocks\": xxxxxx,         (numeric) the current number of blocks processed in the server\n"
+                "  \"headers\": xxxxxx,        (numeric) the current number of headers we have validated\n"
+                "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
+                "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
+                "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
+                "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
+                "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+                "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
+                "  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n"
+                "  \"softforks\": [            (array) status of softforks in progress\n"
+                "     {\n"
+                "        \"id\": \"xxxx\",        (string) name of softfork\n"
+                "        \"version\": xx,         (numeric) block version\n"
+                "        \"enforce\": {           (object) progress toward enforcing the softfork rules for new-version blocks\n"
+                "           \"status\": xx,       (boolean) true if threshold reached\n"
+                "           \"found\": xx,        (numeric) number of blocks with the new version found\n"
+                "           \"required\": xx,     (numeric) number of blocks required to trigger\n"
+                "           \"window\": xx,       (numeric) maximum size of examined window of recent blocks\n"
+                "        },\n"
+                "        \"reject\": { ... }      (object) progress toward rejecting pre-softfork blocks (same fields as \"enforce\")\n"
+                "     }, ...\n"
+                "  ],\n"
+                "  \"bip9_softforks\": {          (object) status of BIP9 softforks in progress\n"
+                "     \"xxxx\" : {                (string) name of the softfork\n"
+                "        \"status\": \"xxxx\",    (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n"
+                "        \"bit\": xx,             (numeric) the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)\n"
+                "        \"startTime\": xx,       (numeric) the minimum median time past of a block at which the bit gains its meaning\n"
+                "        \"timeout\": xx          (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n"
+                "     }\n"
+                "  }\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getblockchaininfo", "")
+                + HelpExampleRpc("getblockchaininfo", "")
+                );
 
     LOCK(cs_main);
 
@@ -1543,7 +1567,7 @@ struct CompareBlocksByHeight
            equal. Use the pointers themselves to make a distinction. */
 
         if (a->nHeight != b->nHeight)
-          return (a->nHeight > b->nHeight);
+            return (a->nHeight > b->nHeight);
 
         return a < b;
     }
@@ -1553,34 +1577,34 @@ UniValue getchaintips(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getchaintips\n"
-            "Return information about all known tips in the block tree,"
-            " including the main chain as well as orphaned branches.\n"
-            "\nResult:\n"
-            "[\n"
-            "  {\n"
-            "    \"height\": xxxx,         (numeric) height of the chain tip\n"
-            "    \"hash\": \"xxxx\",         (string) block hash of the tip\n"
-            "    \"branchlen\": 0          (numeric) zero for main chain\n"
-            "    \"status\": \"active\"      (string) \"active\" for the main chain\n"
-            "  },\n"
-            "  {\n"
-            "    \"height\": xxxx,\n"
-            "    \"hash\": \"xxxx\",\n"
-            "    \"branchlen\": 1          (numeric) length of branch connecting the tip to the main chain\n"
-            "    \"status\": \"xxxx\"        (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n"
-            "  }\n"
-            "]\n"
-            "Possible values for status:\n"
-            "1.  \"invalid\"               This branch contains at least one invalid block\n"
-            "2.  \"headers-only\"          Not all blocks for this branch are available, but the headers are valid\n"
-            "3.  \"valid-headers\"         All blocks are available for this branch, but they were never fully validated\n"
-            "4.  \"valid-fork\"            This branch is not part of the active chain, but is fully validated\n"
-            "5.  \"active\"                This is the tip of the active main chain, which is certainly valid\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getchaintips", "")
-            + HelpExampleRpc("getchaintips", "")
-        );
+                "getchaintips\n"
+                "Return information about all known tips in the block tree,"
+                " including the main chain as well as orphaned branches.\n"
+                "\nResult:\n"
+                "[\n"
+                "  {\n"
+                "    \"height\": xxxx,         (numeric) height of the chain tip\n"
+                "    \"hash\": \"xxxx\",         (string) block hash of the tip\n"
+                "    \"branchlen\": 0          (numeric) zero for main chain\n"
+                "    \"status\": \"active\"      (string) \"active\" for the main chain\n"
+                "  },\n"
+                "  {\n"
+                "    \"height\": xxxx,\n"
+                "    \"hash\": \"xxxx\",\n"
+                "    \"branchlen\": 1          (numeric) length of branch connecting the tip to the main chain\n"
+                "    \"status\": \"xxxx\"        (string) status of the chain (active, valid-fork, valid-headers, headers-only, invalid)\n"
+                "  }\n"
+                "]\n"
+                "Possible values for status:\n"
+                "1.  \"invalid\"               This branch contains at least one invalid block\n"
+                "2.  \"headers-only\"          Not all blocks for this branch are available, but the headers are valid\n"
+                "3.  \"valid-headers\"         All blocks are available for this branch, but they were never fully validated\n"
+                "4.  \"valid-fork\"            This branch is not part of the active chain, but is fully validated\n"
+                "5.  \"active\"                This is the tip of the active main chain, which is certainly valid\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getchaintips", "")
+                + HelpExampleRpc("getchaintips", "")
+                );
 
     LOCK(cs_main);
 
@@ -1680,20 +1704,20 @@ UniValue getmempoolinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getmempoolinfo\n"
-            "\nReturns details on the active state of the TX memory pool.\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"size\": xxxxx,               (numeric) Current tx count\n"
-            "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
-            "  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n"
-            "  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n"
-            "  \"mempoolminfee\": xxxxx       (numeric) Minimum fee for tx to be accepted\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getmempoolinfo", "")
-            + HelpExampleRpc("getmempoolinfo", "")
-        );
+                "getmempoolinfo\n"
+                "\nReturns details on the active state of the TX memory pool.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"size\": xxxxx,               (numeric) Current tx count\n"
+                "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
+                "  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n"
+                "  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n"
+                "  \"mempoolminfee\": xxxxx       (numeric) Minimum fee for tx to be accepted\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getmempoolinfo", "")
+                + HelpExampleRpc("getmempoolinfo", "")
+                );
 
     return mempoolInfoToJSON();
 }
@@ -1703,17 +1727,17 @@ UniValue getstempoolinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
         throw runtime_error(
-            "getstempoolinfo\n"
-            "\nReturns details on the active state of the dandelion stem pool.\n"
-            "\nResult:\n"
-            "{\n"
-            "  \"size\": xxxxx,               (numeric) Current tx count\n"
-            "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
-            "}\n"
-            "\nExamples:\n"
-            + HelpExampleCli("getstempoolinfo", "")
-            + HelpExampleRpc("getstempoolinfo", "")
-        );
+                "getstempoolinfo\n"
+                "\nReturns details on the active state of the dandelion stem pool.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"size\": xxxxx,               (numeric) Current tx count\n"
+                "  \"bytes\": xxxxx,              (numeric) Sum of all tx sizes\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("getstempoolinfo", "")
+                + HelpExampleRpc("getstempoolinfo", "")
+                );
 
     return stempoolInfoToJSON();
 }
@@ -1722,11 +1746,11 @@ UniValue getproposal(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "getproposal \"hash\"\n"
-            "\nShows information about the given proposal.\n"
-            "\nArguments:\n"
-            "1. hash   (string, required) the hash of the proposal\n"
-        );
+                "getproposal \"hash\"\n"
+                "\nShows information about the given proposal.\n"
+                "\nArguments:\n"
+                "1. hash   (string, required) the hash of the proposal\n"
+                );
 
     LOCK(cs_main);
 
@@ -1746,11 +1770,11 @@ UniValue getconsultation(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "getconsultation \"hash\"\n"
-            "\nShows information about the given consultation.\n"
-            "\nArguments:\n"
-            "1. hash   (string, required) the hash of the consultation\n"
-        );
+                "getconsultation \"hash\"\n"
+                "\nShows information about the given consultation.\n"
+                "\nArguments:\n"
+                "1. hash   (string, required) the hash of the consultation\n"
+                );
 
     LOCK(cs_main);
 
@@ -1770,11 +1794,11 @@ UniValue getconsultationanswer(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "getconsultationanswer \"hash\"\n"
-            "\nShows information about the given consultation answer.\n"
-            "\nArguments:\n"
-            "1. hash   (string, required) the hash of the consultation answer\n"
-        );
+                "getconsultationanswer \"hash\"\n"
+                "\nShows information about the given consultation answer.\n"
+                "\nArguments:\n"
+                "1. hash   (string, required) the hash of the consultation answer\n"
+                );
 
     LOCK(cs_main);
 
@@ -1799,7 +1823,7 @@ UniValue getpaymentrequest(const UniValue& params, bool fHelp)
                 "\nShows information about the given payment request.\n"
                 "\nArguments:\n"
                 "1. hash   (string, required) the hash of the payment request\n"
-        );
+                );
 
     LOCK(cs_main);
 
@@ -1820,15 +1844,15 @@ UniValue invalidateblock(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "invalidateblock \"hash\"\n"
-            "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n"
-            "\nArguments:\n"
-            "1. hash   (string, required) the hash of the block to mark as invalid\n"
-            "\nResult:\n"
-            "\nExamples:\n"
-            + HelpExampleCli("invalidateblock", "\"blockhash\"")
-            + HelpExampleRpc("invalidateblock", "\"blockhash\"")
-        );
+                "invalidateblock \"hash\"\n"
+                "\nPermanently marks a block as invalid, as if it violated a consensus rule.\n"
+                "\nArguments:\n"
+                "1. hash   (string, required) the hash of the block to mark as invalid\n"
+                "\nResult:\n"
+                "\nExamples:\n"
+                + HelpExampleCli("invalidateblock", "\"blockhash\"")
+                + HelpExampleRpc("invalidateblock", "\"blockhash\"")
+                );
 
     std::string strHash = params[0].get_str();
     uint256 hash(uint256S(strHash));
@@ -1858,16 +1882,16 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw runtime_error(
-            "reconsiderblock \"hash\"\n"
-            "\nRemoves invalidity status of a block and its descendants, reconsider them for activation.\n"
-            "This can be used to undo the effects of invalidateblock.\n"
-            "\nArguments:\n"
-            "1. hash   (string, required) the hash of the block to reconsider\n"
-            "\nResult:\n"
-            "\nExamples:\n"
-            + HelpExampleCli("reconsiderblock", "\"blockhash\"")
-            + HelpExampleRpc("reconsiderblock", "\"blockhash\"")
-        );
+                "reconsiderblock \"hash\"\n"
+                "\nRemoves invalidity status of a block and its descendants, reconsider them for activation.\n"
+                "This can be used to undo the effects of invalidateblock.\n"
+                "\nArguments:\n"
+                "1. hash   (string, required) the hash of the block to reconsider\n"
+                "\nResult:\n"
+                "\nExamples:\n"
+                + HelpExampleCli("reconsiderblock", "\"blockhash\"")
+                + HelpExampleRpc("reconsiderblock", "\"blockhash\"")
+                );
 
     std::string strHash = params[0].get_str();
     uint256 hash(uint256S(strHash));
@@ -1894,36 +1918,36 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
-    { "communityfund",      "cfundstats",             &cfundstats,             true  },
-    { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },
-    { "blockchain",         "getbestblockhash",       &getbestblockhash,       true  },
-    { "blockchain",         "getblockcount",          &getblockcount,          true  },
-    { "blockchain",         "getblock",               &getblock,               true  },
-    { "blockchain",         "getblockdeltas",         &getblockdeltas,         false },
-    { "blockchain",         "getblockhashes",         &getblockhashes,         true  },
-    { "blockchain",         "getblockhash",           &getblockhash,           true  },
-    { "blockchain",         "getblockheader",         &getblockheader,         true  },
-    { "blockchain",         "getchaintips",           &getchaintips,           true  },
-    { "blockchain",         "getdifficulty",          &getdifficulty,          true  },
-    { "blockchain",         "getmempoolancestors",    &getmempoolancestors,    true  },
-    { "blockchain",         "getmempooldescendants",  &getmempooldescendants,  true  },
-    { "blockchain",         "getmempoolentry",        &getmempoolentry,        true  },
-    { "blockchain",         "getmempoolinfo",         &getmempoolinfo,         true  },
-    { "blockchain",         "getstempoolinfo",        &getstempoolinfo,        true  },
-    { "communityfund",      "getproposal",            &getproposal,            true  },
-    { "communityfund",      "getpaymentrequest",      &getpaymentrequest,      true  },
-    { "blockchain",         "getrawmempool",          &getrawmempool,          true  },
-    { "blockchain",         "gettxout",               &gettxout,               true  },
-    { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
-    { "blockchain",         "verifychain",            &verifychain,            true  },
-    { "dao",                "listconsultations",      &listconsultations,      true  },
-    { "dao",                "getconsultation",        &getconsultation,        true  },
-    { "dao",                "getconsultationanswer",  &getconsultationanswer,  true  },
-    { "dao",                "getcfunddbstatehash",    &getcfunddbstatehash,    true  },
+  { "communityfund",      "cfundstats",             &cfundstats,             true  },
+  { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },
+  { "blockchain",         "getbestblockhash",       &getbestblockhash,       true  },
+  { "blockchain",         "getblockcount",          &getblockcount,          true  },
+  { "blockchain",         "getblock",               &getblock,               true  },
+  { "blockchain",         "getblockdeltas",         &getblockdeltas,         false },
+  { "blockchain",         "getblockhashes",         &getblockhashes,         true  },
+  { "blockchain",         "getblockhash",           &getblockhash,           true  },
+  { "blockchain",         "getblockheader",         &getblockheader,         true  },
+  { "blockchain",         "getchaintips",           &getchaintips,           true  },
+  { "blockchain",         "getdifficulty",          &getdifficulty,          true  },
+  { "blockchain",         "getmempoolancestors",    &getmempoolancestors,    true  },
+  { "blockchain",         "getmempooldescendants",  &getmempooldescendants,  true  },
+  { "blockchain",         "getmempoolentry",        &getmempoolentry,        true  },
+  { "blockchain",         "getmempoolinfo",         &getmempoolinfo,         true  },
+  { "blockchain",         "getstempoolinfo",        &getstempoolinfo,        true  },
+  { "communityfund",      "getproposal",            &getproposal,            true  },
+  { "communityfund",      "getpaymentrequest",      &getpaymentrequest,      true  },
+  { "blockchain",         "getrawmempool",          &getrawmempool,          true  },
+  { "blockchain",         "gettxout",               &gettxout,               true  },
+  { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
+  { "blockchain",         "verifychain",            &verifychain,            true  },
+  { "dao",                "listconsultations",      &listconsultations,      true  },
+  { "dao",                "getconsultation",        &getconsultation,        true  },
+  { "dao",                "getconsultationanswer",  &getconsultationanswer,  true  },
+  { "dao",                "getcfunddbstatehash",    &getcfunddbstatehash,    true  },
 
-    /* Not shown in help */
-    { "hidden",             "invalidateblock",        &invalidateblock,        true  },
-    { "hidden",             "reconsiderblock",        &reconsiderblock,        true  },
+  /* Not shown in help */
+  { "hidden",             "invalidateblock",        &invalidateblock,        true  },
+  { "hidden",             "reconsiderblock",        &reconsiderblock,        true  },
 };
 
 void RegisterBlockchainRPCCommands(CRPCTable &tableRPC)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -774,7 +774,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->hashProof      = diskindex.hashProof;
                 if (diskindex.vProposalVotes.size() > 0)
                 {
-                    auto pVotes = InsertProposalVotes(diskindex.GetBlockHash());
+                    auto pVotes = insertProposalVotes(diskindex.GetBlockHash());
                     *pVotes = diskindex.vProposalVotes;
                 }
                 if (diskindex.vPaymentRequestVotes.size() > 0)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -182,7 +182,11 @@ public:
     bool ReadTimestampBlockIndex(const uint256 &hash, unsigned int &logicalTS);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex);
+    bool LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256&)> insertBlockIndex,
+                            boost::function<std::vector<std::pair<uint256, int>>*(const uint256&)> insertProposalVotes,
+                            boost::function<std::vector<std::pair<uint256, int>>*(const uint256&)> insertPaymentRequestVotes,
+                            boost::function<std::map<uint256, bool>*(const uint256&)> insertSupport,
+                            boost::function<std::map<uint256, uint64_t>*(const uint256&)> insertConsultationVotes);
     bool ReadProposalIndex(const uint256 &proposalid, CProposal &proposal);
     bool WriteProposalIndex(const std::vector<std::pair<uint256, CProposal> >&vect);
     bool GetProposalIndex(std::vector<CProposal>&vect);


### PR DESCRIPTION
This pull request optimizes the memory storage of the block indexes.

Block indexes store for every block the block header and some information needed for the chain validation. They are permanently kept in memory to speed up the validation process. Part of this extra data are the votes of the community fund/dao. Even if the votes of a block were empty, they were still using some memory space. This means even the first blocks of the chain (when no community fund was active) were taking memory space as if they had votes. This effect has been exaggerated with the introduction of the dao upgrade.

After the patch, a different set of data structures are used. Only blocks which include votes of a particular type attach data to those structures, hence reducing considerably the memory use. Other unused fields like prevoutStake and nStakeTime are also removed from memory.

What to test:

- memory use is effectively reduced when using this branch
- stressor tests run succesfully
- chain sync tests