### PR TITLE
[RPC] Return empty dict instead of throwing exception for unknown staker

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4169,7 +4169,7 @@ UniValue getstakervote(const UniValue& params, bool fHelp)
 
     if (!view.GetCachedVoter(stakerScript, pVoteList))
     {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, string("Could not find staker script ")+HexStr(stakerScript));
+         return ret;
     }
 
     std::map<int, std::map<uint256, int64_t>>* list= pVoteList.GetFullList();


### PR DESCRIPTION
This PR modifies the rpc command `getstakervote` to return an empty dict instead of throwing an exception when queried for an unknown staker.

This is for better integration in electrumx.