### PR TITLE
[WALLET] Updated the encrypt wallet logic to not replace master key

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1103,6 +1103,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     {
         LOCK(cs_wallet);
         mapMasterKeys[++nMasterKeyMaxID] = kMasterKey;
+
         if (fFileBacked)
         {
             assert(!pwalletdbEncryption);
@@ -1142,18 +1143,6 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
             pwalletdbEncryption = nullptr;
         }
 
-        Lock();
-        Unlock(strWalletPassphrase);
-
-        // if we are using HD, replace the HD master key (seed) with a new one
-        if (!hdChain.masterKeyID.IsNull()) {
-            CKey key;
-            CPubKey masterPubKey = GenerateNewHDMasterKey();
-            if (!SetHDMasterKey(masterPubKey))
-                return false;
-        }
-
-        NewKeyPool();
         Lock();
 
         // Need to completely rewrite the wallet file; if we don't, bdb might keep


### PR DESCRIPTION
closes #695

I've updated the wallet to not replace master key with new key on encryption.

Test scenarios:

* [x] Scenario 1
    * [x] Create wallet
    * [x] Dumped mnemonic
    * [x] Encrypted wallet
    * [x] Dumped mnemonic again
    * [x] Made sure all dumped mnemonic match
* [x] Scenario 2
    * [x] Create wallet
    * [x] Dumped mnemonic 1
    * [x] Encrypted wallet
    * [x] Dumped mnemonic 2
    * [x] Changed password
    * [x] Dumped mnemonic 3
    * [x] Made sure all dumped mnemonic match
* [x] Scenario 3
    * [x] Restored wallet with mnemonic
    * [x] Dumped mnemonic 1
    * [x] Encrypted wallet
    * [x] Dumped mnemonic 2
    * [x] Changed password
    * [x] Dumped mnemonic 3
    * [x] Made sure all dumped mnemonic match