### PR TITLE
[TEST] Fixed some functional tests that were checking for state == 0 for expired proposals or prequests

### DIFF
--- a/qa/rpc-tests/cfund-paymentrequest-state-expired.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-expired.py
@@ -54,7 +54,7 @@ class CommunityFundPaymentRequestStateTest(NavCoinTestFramework):
             i = i + 1
 
         # Validate that the status of the payment request is expired
-        assert (self.nodes[0].getpaymentrequest(paymentrequestid0)["state"] == 0)
+        assert (self.nodes[0].getpaymentrequest(paymentrequestid0)["state"] == 3)
         assert (self.nodes[0].getpaymentrequest(paymentrequestid0)["status"] == "expired")
 
         # Move to the last block of the voting cycle, where the payment request state changes

--- a/qa/rpc-tests/cfund-proposal-state-expired.py
+++ b/qa/rpc-tests/cfund-proposal-state-expired.py
@@ -42,7 +42,7 @@ class CommunityFundProposalStateTest(NavCoinTestFramework):
             i = i + 1
 
         # Validate that the status of the proposal is expired
-        assert (self.nodes[0].getproposal(proposalid0)["state"] == 0)
+        assert (self.nodes[0].getproposal(proposalid0)["state"] == 3)
         assert (self.nodes[0].getproposal(proposalid0)["status"] == "expired")
 
         # Move to the last block of the voting cycle, where the proposal state changes


### PR DESCRIPTION
I noticed this test was checking for state == 0, but if I remember correctly state == 3 is expired.