### PR TITLE
[RPC][GUI] Added more progress indicators during wallet start up, also shows via…

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1297,6 +1297,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
     if (fServer)
     {
         uiInterface.InitMessage.connect(SetRPCWarmupStatus);
+        uiInterface.ShowProgress.connect(SetRPCWarmupStatusProgress);
         if (!AppInitServers(threadGroup))
             return InitError(_("Unable to start HTTP server. See debug log for details."));
     }

--- a/src/main.h
+++ b/src/main.h
@@ -42,6 +42,7 @@
 
 #define START_INODE_PAYMENTS_TESTNET 1429456427
 #define START_INODE_PAYMENTS 1429456427
+#define PROGRESS_INTERVAL 15000
 
 static const int64_t MAX_MINT_PROOF_OF_STAKE = 0.1 * COIN;
 
@@ -563,8 +564,6 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
 class CVerifyDB {
 public:
-    CVerifyDB();
-    ~CVerifyDB();
     bool VerifyDB(const CChainParams& chainparams, CStateView *coinsview, int nCheckLevel, int nCheckDepth);
 };
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -155,7 +155,7 @@ static void InitMessage(SplashScreen *splash, const std::string &message)
 
 static void ShowProgress(SplashScreen *splash, const std::string &title, int nProgress)
 {
-    InitMessage(splash, title + strprintf("%d", nProgress) + "%");
+    InitMessage(splash, title + strprintf("%d", nProgress) + (nProgress <= 100 ? "%" : ""));
 }
 
 #ifdef ENABLE_WALLET

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -337,6 +337,11 @@ void SetRPCWarmupStatus(const std::string& newStatus)
     rpcWarmupStatus = newStatus;
 }
 
+void SetRPCWarmupStatusProgress(const std::string& newStatus, int nProgress)
+{
+    SetRPCWarmupStatus(newStatus + strprintf("%d", nProgress) + (nProgress <= 100 ? "%" : ""));
+}
+
 void SetRPCWarmupFinished()
 {
     LOCK(cs_rpcWarmup);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -60,6 +60,7 @@ bool IsRPCRunning();
  * immediately with RPC_IN_WARMUP.
  */
 void SetRPCWarmupStatus(const std::string& newStatus);
+void SetRPCWarmupStatusProgress(const std::string& newStatus, int nProgress);
 /* Mark warmup as done.  RPC calls will be processed from now on.  */
 void SetRPCWarmupFinished();
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <txdb.h>
+#include <ui_interface.h>
 
 #include <chainparams.h>
 #include <hash.h>
@@ -744,8 +745,14 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
 
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
 
+    int nCount = 0;
+
     // Load mapBlockIndex
     while (pcursor->Valid()) {
+        if (++nCount % PROGRESS_INTERVAL == 0) {
+            // Update the progress
+            uiInterface.ShowProgress(_("Loading block guts..."), nCount);
+        }
         boost::this_thread::interruption_point();
         std::pair<char, uint256> key;
         if (pcursor->GetKey(key) && key.first == DB_BLOCK_INDEX) {


### PR DESCRIPTION
closes #654

I'm sure this will be helpful for people wanting CLI progress during wallet start up, and also makes the splash screen have more feedback to the user.

But not sure how much this slows down the start up as it's basically tracking progress for most of the heavy loops in wallet start up.

@aguycalled do you think we should add this?

It's just something that came to mind when I took a look @ pr #654 