### PR TITLE
[INDEX] Index cold staking UTXOs by spending address

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2635,7 +2635,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     addressIndex.push_back(make_pair(CAddressIndexKey(type, hashBytes, pindex->nHeight, i, hash, k, false), out.nValue));
 
                     // restore unspent index
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, hashBytes, hash, k), CAddressUnspentValue()));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, hashBytesSpending, hash, k), CAddressUnspentValue()));
 
                     CAddressHistoryKey addressHistoryKey(uint160(hashBytes), uint160(hashBytesSpending), pindex->nHeight, i, hash, tx.nTime);
                     CAddressHistoryKey addressHistoryKey2(hashBytesSpending, hashBytesSpending, pindex->nHeight, i, hash, tx.nTime);
@@ -2773,7 +2773,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         addressIndex.push_back(make_pair(CAddressIndexKey(type, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
 
                         // restore unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey, undo.nHeight)));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytesSpending), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey, undo.nHeight)));
 
                         CAddressHistoryKey addressHistoryKey(hashBytesSpending, hashBytesSpending, pindex->nHeight, i, hash, tx.nTime);
                         CAddressHistoryKey addressHistoryKey2(uint160(hashBytes), uint160(hashBytesSpending), pindex->nHeight, i, hash, tx.nTime);
@@ -3871,6 +3871,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         addressHistoryMap[addressHistoryKeyStaking].voting_weight += prevout.nValue * -1;
                         addressHistoryMap[addressHistoryKeyStaking2].stakable += prevout.nValue * -1;
                         addressHistoryMap[addressHistoryKeyStaking2].voting_weight += prevout.nValue * -1;
+
+                        hashBytes = hashBytesSpending;
                     }
                     else if (prevout.scriptPubKey.IsColdStakingv2())
                     {
@@ -3925,6 +3927,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
                         addressHistoryMap[addressHistoryKeyVoting].voting_weight += prevout.nValue * -1;
                         addressHistoryMap[addressHistoryKeyVoting2].voting_weight += prevout.nValue * -1;
+
+                        hashBytes = hashBytesSpending;
                     }
                     else
                     {
@@ -4056,7 +4060,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(type, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytesSpending), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
                     CAddressHistoryKey addressHistoryKey(uint160(hashBytes), uint160(hashBytesSpending), pindex->nHeight, i, txhash, tx.nTime);
                     CAddressHistoryKey addressHistoryKey2(hashBytesSpending, hashBytesSpending, pindex->nHeight, i, txhash, tx.nTime);
 
@@ -4104,7 +4108,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(type, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(type, uint160(hashBytesSpending), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
                     CAddressHistoryKey addressHistoryKey(uint160(hashBytes), uint160(hashBytesSpending), pindex->nHeight, i, txhash, tx.nTime);
                     CAddressHistoryKey addressHistoryKey2(hashBytesSpending, hashBytesSpending, pindex->nHeight, i, txhash, tx.nTime);
 


### PR DESCRIPTION
This PR changes the behaviour of the spending index, indexing utxos by the spending address in case of cold staking outputs.

Test in devnet:

```
> sendtoaddress n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr 1
> generate 1
> getaddressutxos '{"addresses":["n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr"]}'
[
  {
    "address": "n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr",
    "txid": "a75d396753878a99d86a1b751618a61da20f569827e91658381d887722002938",
    "outputIndex": 1,
    "script": "76a914f9cb3d76f4d82188af99851e03d8472767ea0d7688ac",
    "satoshis": 100000000,
    "height": 301
  }
]
> getcoldstakingaddress n2BSoobWfxkMcVUSghd6hMCVACNDSxxNmN n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr
2agWjSDvB8bwAUSsTfF9qBDVB7KJcfCn64jqiAZp2EoZzqtQ4TXdfnBhhNksyi
> sendtoaddress 2agWjSDvB8bwAUSsTfF9qBDVB7KJcfCn64jqiAZp2EoZzqtQ4TXdfnBhhNksyi 1
> generate 1
> getaddressutxos '{"addresses":["n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr"]}'
[
  {
    "address": "n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr",
    "txid": "a75d396753878a99d86a1b751618a61da20f569827e91658381d887722002938",
    "outputIndex": 1,
    "script": "76a914f9cb3d76f4d82188af99851e03d8472767ea0d7688ac",
    "satoshis": 100000000,
    "height": 301
  },
  {
    "address": "n4Hk2BvuqUb9pSw7btqgeYMkuVi3iPfrEr",
    "txid": "5c921072c20b290d529602f48c13207d39af2ecc1c121c433ed207192cb61d73",
    "outputIndex": 1,
    "script": "c66376a914e2aa1fa5b14f932381761c893d1c92711655b8ae88ac6776a914f9cb3d76f4d82188af99851e03d8472767ea0d7688ac68",
    "satoshis": 100000000,
    "height": 302
  }
]
```