### PR TITLE
[RPC] Fix for getaddresshistory balance of multiple addresses

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1219,10 +1219,15 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
             return a_.blockHeight < b_.blockHeight;
         }
     });
-
-    CAmount spending = 0;
-    CAmount stakable = 0;
-    CAmount voting_weight = 0;
+    
+    struct balStruct 
+    {
+        CAmount spending;
+        CAmount stakable;
+        CAmount voting_weight;
+    };
+    
+    std::map<CNavCoinAddress, balStruct> balance;
 
     UniValue result(UniValue::VARR);
 
@@ -1245,16 +1250,20 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
         changes.pushKV("flags", (*it).second.flags);
         entry.pushKV("changes", changes);
 
-        UniValue balance(UniValue::VOBJ);
+        UniValue balanceObj(UniValue::VOBJ);
+        
+        if (balance.count(address) == 0) {
+            balance.insert(std::make_pair(address, (struct balStruct){.spendable = 0, .stakable = 0, .voting_weight = 0}));
+        }
+       
+        balance[address].spending += (*it).second.spendable;
+        balance[address].stakable += (*it).second.stakable;
+        balance[address].voting_weight += (*it).second.voting_weight;
 
-        spending += (*it).second.spendable;
-        stakable += (*it).second.stakable;
-        voting_weight += (*it).second.voting_weight;
-
-        balance.pushKV("balance", spending);
-        balance.pushKV("stakable", stakable);
-        balance.pushKV("voting_weight", voting_weight);
-        entry.pushKV("result", balance);
+        balanceObj.pushKV("balance", balance[address].spending);
+        balanceObj.pushKV("stakable", balance[address].stakable);
+        balanceObj.pushKV("voting_weight", balance[address].voting_weight);
+        entry.pushKV("result", balanceObj);
 
         result.push_back(entry);
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1232,6 +1232,9 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
     UniValue result(UniValue::VARR);
 
     for (std::vector<std::pair<CAddressHistoryKey, CAddressHistoryValue> >::const_iterator it=addressHistory.begin(); it!=addressHistory.end(); it++) {
+        CNavCoinAddress address;
+        address.Set(CKeyID((*it).first.hashBytes2));
+
         if (balance.count(address) == 0) {
             balance.insert(std::make_pair(address, (struct balStruct){.spendable = 0, .stakable = 0, .voting_weight = 0}));
         }
@@ -1248,8 +1251,6 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
         entry.pushKV("txindex", (uint64_t)(*it).first.txindex);
         entry.pushKV("time", (uint64_t)(*it).first.time);
         entry.pushKV("txid", (*it).first.txhash.ToString());
-        CNavCoinAddress address;
-        address.Set(CKeyID((*it).first.hashBytes2));
         entry.pushKV("address", address.ToString());
 
         UniValue changes(UniValue::VOBJ);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1222,7 +1222,7 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
     
     struct balStruct 
     {
-        CAmount spending;
+        CAmount spendable;
         CAmount stakable;
         CAmount voting_weight;
     };
@@ -1256,11 +1256,11 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
             balance.insert(std::make_pair(address, (struct balStruct){.spendable = 0, .stakable = 0, .voting_weight = 0}));
         }
        
-        balance[address].spending += (*it).second.spendable;
+        balance[address].spendable += (*it).second.spendable;
         balance[address].stakable += (*it).second.stakable;
         balance[address].voting_weight += (*it).second.voting_weight;
 
-        balanceObj.pushKV("balance", balance[address].spending);
+        balanceObj.pushKV("balance", balance[address].spendable);
         balanceObj.pushKV("stakable", balance[address].stakable);
         balanceObj.pushKV("voting_weight", balance[address].voting_weight);
         entry.pushKV("result", balanceObj);


### PR DESCRIPTION
When getaddresshistory is queried for multiple addresses, it was showing incorrect accumulated balances. Instead it should show the correct balance of each address.