### PR TITLE
Update httpserver.cpp header

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -12,6 +12,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <deque>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
httpserver.cpp:73:10: error: 'deque' in namespace 'std' does not name a template type
   73 |     std::deque<std::unique_ptr<WorkItem>> queue;
      |          ^~~~~
httpserver.cpp:32:1: note: 'std::deque' is defined in header '<deque>'; did you forget to '#include <deque>'?

