### PR TITLE
[DAO] Do not transition to EXPIRED if previous state is ACCEPTED or REJECTED

### DIFF
--- a/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
+++ b/qa/rpc-tests/cfund-paymentrequest-state-accept-expired-proposal.py
@@ -66,7 +66,7 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
             blocks=slow_gen(self.nodes[0], 1)
             time.sleep(1)
 
-        assert(self.nodes[0].getproposal(proposalid0)["status"] == "pending")
+        assert_equal(self.nodes[0].getproposal(proposalid0)["status"], "pending")
 
         self.nodes[0].invalidateblock(blocks[-1])
         assert(self.nodes[0].getproposal(proposalid0)["status"] == "accepted")
@@ -187,7 +187,7 @@ class CommunityFundPaymentRequestsTest(NavCoinTestFramework):
 
         # Locked amount should be 0, as this was the only payment request and the proposal was expired
         assert(self.nodes[0].cfundstats()["funds"]["locked"] == 0)
-        assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired")
+        assert_equal(self.nodes[0].getproposal(proposalid0)["status"], "accepted, expired")
 
         # No more payment requests are allowed as the proposal is expired
         payment_request_not_created = True

--- a/qa/rpc-tests/cfund-proposal-state-accept.py
+++ b/qa/rpc-tests/cfund-proposal-state-accept.py
@@ -182,14 +182,14 @@ class CommunityFundProposalStateTest(NavCoinTestFramework):
         start_new_cycle(self.nodes[0])
 
         # Should be expired now
-        assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired")
+        assert(self.nodes[0].getproposal(proposalid0)["status"] == "accepted, expired")
 
         slow_gen(self.nodes[0], 1)
 
         start_new_cycle(self.nodes[0])
 
         # Should still be expired
-        assert(self.nodes[0].getproposal(proposalid0)["status"] == "expired")
+        assert(self.nodes[0].getproposal(proposalid0)["status"] == "accepted, expired")
 
 if __name__ == '__main__':
     CommunityFundProposalStateTest().main()

--- a/qa/rpc-tests/cfund-rawtx-paymentrequest-create.py
+++ b/qa/rpc-tests/cfund-rawtx-paymentrequest-create.py
@@ -180,9 +180,10 @@ class CommunityFundCreatePaymentrequestRawTX(NavCoinTestFramework):
         start_new_cycle(self.nodes[0])
         start_new_cycle(self.nodes[0])
         start_new_cycle(self.nodes[0])
+        start_new_cycle(self.nodes[0])
 
         # Proposal 3 should be expired
-        assert (self.nodes[0].getproposal(proposalid3_expired_no_votes)["state"] == 3)
+        assert_equal(self.nodes[0].getproposal(proposalid3_expired_no_votes)["state"], 3)
         assert (self.nodes[0].getproposal(proposalid3_expired_no_votes)["status"] == "expired")
 
         # Create a payment request for an expired proposal

--- a/qa/rpc-tests/dao-consultation-consensus-cycle-length.py
+++ b/qa/rpc-tests/dao-consultation-consensus-cycle-length.py
@@ -53,7 +53,7 @@ class ConsensusConsultationsTest(NavCoinTestFramework):
 
         #cycle 1
 
-        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "pending")
+        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "waiting for support")
         assert_equal(self.nodes[0].getconsultation(proposal)["votingCyclesFromCreation"], 1)
 
         end_cycle(self.nodes[0])

--- a/qa/rpc-tests/dao-consultation-consensus.py
+++ b/qa/rpc-tests/dao-consultation-consensus.py
@@ -56,7 +56,7 @@ class ConsensusConsultationsTest(NavCoinTestFramework):
 
         #cycle 1
 
-        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "pending")
+        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "waiting for support")
         assert_equal(self.nodes[0].getconsultation(proposal)["votingCyclesFromCreation"], 1)
 
         end_cycle(self.nodes[0])
@@ -149,7 +149,7 @@ class ConsensusConsultationsTest(NavCoinTestFramework):
 
         #cycle 1
 
-        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "pending")
+        assert_equal(self.nodes[0].getconsultation(proposal)["status"], "waiting for support")
 
         end_cycle(self.nodes[0])
         slow_gen(self.nodes[0] , 1)

--- a/qa/rpc-tests/dao-consultations-staking.py
+++ b/qa/rpc-tests/dao-consultations-staking.py
@@ -84,10 +84,10 @@ class ConsultationsTest(NavCoinTestFramework):
 
         #cycle 2
 
-        assert(self.nodes[0].getconsultation(created_consultations["one_of_two"])["status"] == "pending")
+        assert(self.nodes[0].getconsultation(created_consultations["one_of_two"])["status"] == "waiting for support")
         assert(self.nodes[0].getconsultation(created_consultations["one_of_two_not_enough_answers"])["status"] == "waiting for support, waiting for having enough supported answers")
         assert(self.nodes[0].getconsultation(created_consultations["one_of_two_not_supported"])["status"] == "waiting for support, waiting for having enough supported answers")
-        assert(self.nodes[0].getconsultation(created_consultations["range_one_one_hundred"])["status"] == "pending")
+        assert(self.nodes[0].getconsultation(created_consultations["range_one_one_hundred"])["status"] == "waiting for support")
 
         self.end_cycle_stake(self.nodes[0])
         self.stake_block(self.nodes[0] , 1)

--- a/qa/rpc-tests/dao-consultations.py
+++ b/qa/rpc-tests/dao-consultations.py
@@ -74,10 +74,10 @@ class ConsultationsTest(NavCoinTestFramework):
 
         #cycle 1
 
-        assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two"])["status"], "pending")
+        assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two"])["status"], "waiting for support")
         assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two_not_enough_answers"])["status"], "waiting for support, waiting for having enough supported answers")
         assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two_not_supported"])["status"], "waiting for support, waiting for having enough supported answers")
-        assert_equal(self.nodes[0].getconsultation(created_consultations["range_one_one_hundred"])["status"], "pending")
+        assert_equal(self.nodes[0].getconsultation(created_consultations["range_one_one_hundred"])["status"], "waiting for support")
         assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two"])["votingCyclesFromCreation"], 1)
         assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two_not_enough_answers"])["votingCyclesFromCreation"], 1)
         assert_equal(self.nodes[0].getconsultation(created_consultations["one_of_two_not_supported"])["votingCyclesFromCreation"], 1)

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -1055,7 +1055,7 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
                                 {
                                     pindexNew->nCFSupply += proposal->GetAvailable(view);
                                     pindexNew->nCFLocked -= proposal->GetAvailable(view);
-                                    proposal->SetState(pindexNew, DAOFlags::ACEPTED_EXPIRED);
+                                    proposal->SetState(pindexNew, DAOFlags::ACCEPTED_EXPIRED);
                                     LogPrint("daoextra", "%s: Updated nCFSupply %s nCFLocked %s\n", __func__, FormatMoney(pindexNew->nCFSupply), FormatMoney(pindexNew->nCFLocked));
                                 } 
                                 else

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -1042,7 +1042,7 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
                 {
                     if(proposal->IsExpired(pindexNew->GetBlockTime(), view))
                     {
-                        if (oldState != DAOFlags::EXPIRED && oldState != DAOFlags::ACCEPTED && oldState != DAOFlags::REJECTED)
+                        if (oldState != DAOFlags::EXPIRED && oldState != DAOFlags::ACCEPTED_EXPIRED && oldState != DAOFlags::REJECTED)
                         {
                             if (proposal->HasPendingPaymentRequests(view))
                             {
@@ -1055,9 +1055,13 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
                                 {
                                     pindexNew->nCFSupply += proposal->GetAvailable(view);
                                     pindexNew->nCFLocked -= proposal->GetAvailable(view);
+                                    proposal->SetState(pindexNew, DAOFlags::ACEPTED_EXPIRED);
                                     LogPrint("daoextra", "%s: Updated nCFSupply %s nCFLocked %s\n", __func__, FormatMoney(pindexNew->nCFSupply), FormatMoney(pindexNew->nCFLocked));
+                                } 
+                                else
+                                {
+                                    proposal->SetState(pindexNew, DAOFlags::EXPIRED);
                                 }
-                                proposal->SetState(pindexNew, DAOFlags::EXPIRED);
                                 proposal->fDirty = true;
                             }
                         }

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -2854,11 +2854,11 @@ std::string CProposal::GetState(uint32_t currentTime, const CStateViewCache& vie
         if(fState != DAOFlags::REJECTED)
             sFlags = "pending";
     }
-    if(currentTime > 0 && IsExpired(currentTime, view)) {
+    if(fState == DAOFlags::ACCEPTED_EXPIRED)
+        sFlags = "accepted, expired";
+    else if(currentTime > 0 && IsExpired(currentTime, view)) {
         sFlags = "expired";
-        if(fState != DAOFlags::ACCEPTED_EXPIRED)
-            sFlags = "accepted, expired";
-        else if(fState != DAOFlags::EXPIRED)
+        if(fState != DAOFlags::EXPIRED)
             sFlags = "pending";
     }
     if(fState == DAOFlags::PENDING_VOTING_PREQ) {

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -958,7 +958,7 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
                 {
                     if(prequest->IsExpired(view))
                     {
-                        if (oldState != DAOFlags::EXPIRED)
+                        if (oldState != DAOFlags::EXPIRED && oldState != DAOFlags::ACCEPTED && oldState != DAOFlags::REJECTED)
                         {
                             prequest->SetState(pindexNew, DAOFlags::EXPIRED);
                             prequest->fDirty = true;
@@ -1042,7 +1042,7 @@ bool VoteStep(const CValidationState& state, CBlockIndex *pindexNew, const bool 
                 {
                     if(proposal->IsExpired(pindexNew->GetBlockTime(), view))
                     {
-                        if (oldState != DAOFlags::EXPIRED)
+                        if (oldState != DAOFlags::EXPIRED && oldState != DAOFlags::ACCEPTED && oldState != DAOFlags::REJECTED)
                         {
                             if (proposal->HasPendingPaymentRequests(view))
                             {

--- a/src/consensus/dao.cpp
+++ b/src/consensus/dao.cpp
@@ -2856,7 +2856,9 @@ std::string CProposal::GetState(uint32_t currentTime, const CStateViewCache& vie
     }
     if(currentTime > 0 && IsExpired(currentTime, view)) {
         sFlags = "expired";
-        if(fState != DAOFlags::EXPIRED)
+        if(fState != DAOFlags::ACCEPTED_EXPIRED)
+            sFlags = "accepted, expired";
+        else if(fState != DAOFlags::EXPIRED)
             sFlags = "pending";
     }
     if(fState == DAOFlags::PENDING_VOTING_PREQ) {

--- a/src/consensus/dao/flags.h
+++ b/src/consensus/dao/flags.h
@@ -19,6 +19,7 @@ static const flags PAID = 0x6;
 static const flags PASSED = 0x7;
 static const flags REFLECTION = 0x8;
 static const flags SUPPORTED = 0x9;
+static const flags ACCEPTED_EXPIRED = 0x9;
 }
 namespace VoteFlags
 {

--- a/src/consensus/dao/flags.h
+++ b/src/consensus/dao/flags.h
@@ -19,7 +19,7 @@ static const flags PAID = 0x6;
 static const flags PASSED = 0x7;
 static const flags REFLECTION = 0x8;
 static const flags SUPPORTED = 0x9;
-static const flags ACCEPTED_EXPIRED = 0x9;
+static const flags ACCEPTED_EXPIRED = 0x10;
 }
 namespace VoteFlags
 {

--- a/src/qt/daopage.cpp
+++ b/src/qt/daopage.cpp
@@ -561,6 +561,7 @@ void DaoPage::initialize(CProposalMap proposalMap, CPaymentRequestMap paymentReq
             break;
         }
         case DAOFlags::EXPIRED:
+        case DAOFlags::ACCEPTED_EXPIRED:
         {
             p.color = "#ff6600";
             break;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4417,7 +4417,7 @@ UniValue listproposals(const UniValue& params, bool fHelp)
                 "\nList the proposals and all the relating data including payment requests and status.\n"
                 "\nNote passing no argument returns all proposals regardless of state.\n"
                 "\nArguments:\n"
-                "\n1. \"filter\" (string, optional)   \"accepted\" | \"rejected\" | \"expired\" | \"pending\" | \"mine\"\n"
+                "\n1. \"filter\" (string, optional)   \"accepted\" | \"rejected\" | \"expired\" | \"pending\" | \"mine\" | \"accepted_expired\"\n"
                 "\nExamples:\n"
                 + HelpExampleCli("listproposal", "mine accepted")
                 + HelpExampleCli("listproposal", "accepted")
@@ -4432,6 +4432,7 @@ UniValue listproposals(const UniValue& params, bool fHelp)
     bool showAccepted = false;
     bool showRejected = false;
     bool showExpired = false;
+    bool showAcceptedExpired = false;
     bool showPending = false;
     bool showMine = false;
     for(unsigned int i = 0; i < params.size(); i++) {
@@ -4454,6 +4455,10 @@ UniValue listproposals(const UniValue& params, bool fHelp)
         else if(params[i].get_str() == "mine") {
             showAll = false;
             showMine = true;
+        }
+        else if(params[i].get_str() == "accepted_expired") {
+            showAll = false;
+            showAcceptedExpired = true;
         }
     }
 
@@ -4486,6 +4491,7 @@ UniValue listproposals(const UniValue& params, bool fHelp)
                     || (showPending  && (fLastState == DAOFlags::NIL || fLastState == DAOFlags::PENDING_VOTING_PREQ
                                          || fLastState == DAOFlags::PENDING_FUNDS))
                     || (showAccepted && (fLastState == DAOFlags::ACCEPTED))
+                    || (showAcceptedExpired && (fLastState == DAOFlags::ACCEPTED_EXPIRED))
                     || (showRejected && (fLastState == DAOFlags::REJECTED))
                     || (showExpired  &&  proposal.IsExpired(pindexBestHeader->GetBlockTime(), view))) {
                 UniValue o(UniValue::VOBJ);


### PR DESCRIPTION
This PR prevents proposals or payment requests from transitioning to EXPIRED state if they were already ACCEPTED or REJECTED.