### PR TITLE
Fixed a crash caused by system tray icon not being available

### DIFF
--- a/src/qt/navcoingui.cpp
+++ b/src/qt/navcoingui.cpp
@@ -246,7 +246,9 @@ NavCoinGUI::NavCoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     createToolBars();
 
     // Create system tray icon and notification
-    createTrayIcon(networkStyle);
+    if (QSystemTrayIcon::isSystemTrayAvailable()) {
+        createTrayIcon(networkStyle);
+    }
 
     // Create status bar
     statusBar();


### PR DESCRIPTION
Some linux distros don't support system tray icons, which was causing a crash