### PR TITLE
Fixed the missing transaction size in send coins dialog

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -334,8 +334,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
         std::vector<shared_ptr<CReserveBLSCTBlindingKey>> *reserveBLSCTKey = transaction.getPossibleBLSCTBlindingKey();
 
-        CWalletTx *newTx;
-        newTx = new CWalletTx();
+        CWalletTx *newTx = transaction.getTransaction();
 
         fCreated = wallet->CreateTransaction(vec, *newTx, *keyChange, *reserveBLSCTKey, nFeeRequired, nChangePosRet, strFailReason, fPrivate, coinControl, true, selectedCoins);
         if (newTx->fSpendsColdStaking)

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -10,7 +10,6 @@
 
 WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &recipients) :
     recipients(recipients),
-    walletTransaction(0),
     keyChange(0),
     fee(0),
     fSpendsColdStaking(false)
@@ -36,7 +35,7 @@ CWalletTx *WalletModelTransaction::getTransaction()
 
 unsigned int WalletModelTransaction::getTransactionSize()
 {
-    return (!walletTransaction ? 0 : ::GetVirtualTransactionSize(*walletTransaction));
+    return (!walletTransaction ? 0 : GetVirtualTransactionSize(*walletTransaction));
 }
 
 CAmount WalletModelTransaction::getTransactionFee()

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -48,7 +48,7 @@ public:
     bool fSpendsColdStaking;
 
 private:
-    CWalletTx *walletTransaction;
+    CWalletTx *walletTransaction = new CWalletTx();
     CReserveKey *keyChange;
     std::vector<shared_ptr<CReserveBLSCTBlindingKey>> *blsctBlindingKey;
     CAmount fee;


### PR DESCRIPTION
send coins dialog was not showing the size of the tx, this PR fixes that issue

closes #716