### PR TITLE
Add extra data about supply in RPC commands

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -258,6 +258,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     int nCountProposals = 0;
     int nCountPaymentRequests = 0;
     int nCountTransactions = 0;
+    CAmount nValueTransactions = 0;
 
     CAmount nPOWBlockReward = block.IsProofOfWork() ? GetBlockSubsidy(blockindex->nHeight, Params().GetConsensus()) : 0;
 
@@ -297,17 +298,24 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         }
         else
         {
-            if (tx.nVersion == CTransaction::PROPOSAL_VERSION)
+            if ((tx.nVersion&0xF) == CTransaction::PROPOSAL_VERSION)
                 nCountProposals++;
-            else if(tx.nVersion == CTransaction::PAYMENT_REQUEST_VERSION)
+            else if((tx.nVersion&0xF) == CTransaction::PAYMENT_REQUEST_VERSION)
                 nCountPaymentRequests++;
             else
+            {
                 nCountTransactions++;
+                for (auto &out: tx.vout)
+                {
+                    nValueTransactions += out.nValue;
+                }
+            }
         }
 
     }
     result.pushKV("tx", txs);
     result.pushKV("tx_count", nCountTransactions);
+    result.pushKV("tx_value_count", nValueTransactions);
     result.pushKV("proposal_count", nCountProposals);
     result.pushKV("payment_request_count", nCountPaymentRequests);
     result.pushKV("proposal_votes_count", nCountProposalVotes);
@@ -915,8 +923,10 @@ struct CCoinsStats
     uint64_t nSerializedSize;
     uint256 hashSerialized;
     CAmount nTotalAmount;
+    CAmount nTotalColdAmount;
+    CAmount nTotalColdv2Amount;
 
-    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}
+    CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0), nTotalColdAmount(0), nTotalColdv2Amount(0) {}
 };
 
 //! Calculate statistics about the unspent transaction output set
@@ -932,6 +942,8 @@ static bool GetUTXOStats(CStateView *view, CCoinsStats &stats)
     }
     ss << stats.hashBlock;
     CAmount nTotalAmount = 0;
+    CAmount nTotalColdAmount = 0;
+    CAmount nTotalColdv2Amount = 0;
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         uint256 key;
@@ -946,6 +958,8 @@ static bool GetUTXOStats(CStateView *view, CCoinsStats &stats)
                     ss << VARINT(i+1);
                     ss << out;
                     nTotalAmount += out.nValue;
+                    if (out.scriptPubKey.IsColdStaking()) nTotalColdAmount += out.nValue;
+                    if (out.scriptPubKey.IsColdStakingv2()) nTotalColdv2Amount += out.nValue;
                 }
             }
             stats.nSerializedSize += 32 + pcursor->GetValueSize();
@@ -957,6 +971,8 @@ static bool GetUTXOStats(CStateView *view, CCoinsStats &stats)
     }
     stats.hashSerialized = ss.GetHash();
     stats.nTotalAmount = nTotalAmount;
+    stats.nTotalColdAmount = nTotalColdAmount;
+    stats.nTotalColdv2Amount = nTotalColdv2Amount;
     return true;
 }
 
@@ -994,6 +1010,8 @@ UniValue gettxoutsetinfo(const UniValue& params, bool fHelp)
         ret.pushKV("bytes_serialized", (int64_t)stats.nSerializedSize);
         ret.pushKV("hash_serialized", stats.hashSerialized.GetHex());
         ret.pushKV("total_amount", ValueFromAmount(stats.nTotalAmount));
+        ret.pushKV("total_cold_amount", ValueFromAmount(stats.nTotalColdAmount));
+        ret.pushKV("total_coldv2_amount", ValueFromAmount(stats.nTotalColdv2Amount));
     }
     return ret;
 }


### PR DESCRIPTION
This PR adds some extra data about the supply (how much sits in cold staking and cold staking v2) which is used for data collection and statistics in some layer 2 tools.

It also adds total value transacted in the output of `getblock`.