### PR TITLE
Fix proposal filter accepted expired

### DIFF
--- a/src/qt/daopage.cpp
+++ b/src/qt/daopage.cpp
@@ -506,7 +506,7 @@ void DaoPage::initialize(CProposalMap proposalMap, CPaymentRequestMap paymentReq
 
         flags fState = proposal.GetLastState();
 
-        if (fExclude && (fState == DAOFlags::REJECTED || fState == DAOFlags::EXPIRED || proposal.GetAvailable(coins) == 0))
+        if (fExclude && (fState == DAOFlags::REJECTED || fState == DAOFlags::EXPIRED || fState == DAOFlags::ACCEPTED_EXPIRED || proposal.GetAvailable(coins) == 0))
             continue;
 
         if (mapBlockIndex.count(proposal.txblockhash) == 0)
@@ -2205,7 +2205,7 @@ void DaoChart::updateView() {
 
             auto fState = proposal.GetLastState();
 
-            if (fState == DAOFlags::ACCEPTED || fState == DAOFlags::REJECTED  || fState == DAOFlags::EXPIRED)
+            if (fState == DAOFlags::ACCEPTED || fState == DAOFlags::REJECTED  || fState == DAOFlags::EXPIRED  || fState == DAOFlags::ACCEPTED_EXPIRED)
                 fShouldShowCycleInfo = false;
 
             mapVotes.insert(make_pair(QString("Yes (" + QString::number(proposal.nVotesYes) + ")"), proposal.nVotesYes));


### PR DESCRIPTION
Reported by anquii:

```
using the build for optimized sync, the dao section for “fund proposals” seem to not exclude proposals with state “accepted + expired” even if “Exclude expired and finished” is ticked.
```