### PR TITLE
Apply -blsctmix to threads and gui/rpc send

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1887,7 +1887,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
     // Generate coins in the background
     SetStaking(GetBoolArg("-staking", true));
     threadGroup.create_thread(boost::bind(&NavcoinStaker, boost::cref(chainparams)));
-    if (pwalletMain)
+    if (pwalletMain && GetBoolArg("-blsctmix", DEFAULT_MIX))
     {
         threadGroup.create_thread(boost::bind(&AggregationSessionThread));
         threadGroup.create_thread(boost::bind(&CandidateVerificationThread));

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -182,7 +182,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             return;
         }
 
-        if (defaultPrivacy == 0)
+        if (defaultPrivacy == 0 && GetBoolArg("-blsctmix", DEFAULT_MIX))
         {
             QMessageBox msgBox;
             msgBox.setWindowTitle(tr("Increase privacy level"));
@@ -206,7 +206,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             }
         }
 
-        if(defaultPrivacy == 1)
+        if(defaultPrivacy == 1 && && GetBoolArg("-blsctmix", DEFAULT_MIX))
         {
             AggregationSessionDialog msd(this);
             msd.setWalletModel(model);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -206,7 +206,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             }
         }
 
-        if(defaultPrivacy == 1 && && GetBoolArg("-blsctmix", DEFAULT_MIX))
+        if(defaultPrivacy == 1 && GetBoolArg("-blsctmix", DEFAULT_MIX))
         {
             AggregationSessionDialog msd(this);
             msd.setWalletModel(model);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -819,6 +819,11 @@ UniValue privatesendmixtoaddress(const UniValue& params, bool fHelp)
         return JSONRPCError(RPC_MISC_ERROR, "xNAV is not active yet");
     }
 
+    if (!GetBoolArg("-blsctmix", DEFAULT_MIX))
+    {
+        return JSONRPCError(RPC_MISC_ERROR, "-blsctmix is 0");
+    }
+
     if (fHelp || params.size() < 2 || params.size() > 6)
         throw runtime_error(
                 "privatesendmixtoaddress \"navcoinaddress\" amount \"comment\" ( \"comment-to\" \"strdzeel\" subtractfeefromamount )\n"


### PR DESCRIPTION
This PR takes in account if blsctmix has been turned off (blsctmix=0) to disable the background threads and aggregation when sending xNAV.

What to test:

With blsctmix=0 there is no aggregation for xNAV transactions, but there is when it is turned on.