### PR TITLE
Tx structure memory optimisation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -339,6 +339,7 @@ libnavcoin_consensus_a_SOURCES = \
   sph_simd.h \
   sph_skein.h \
   sph_types.h \
+  support/cleanse.cpp \
   hashblock.h \
   hash.cpp \
   hash.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -522,7 +522,7 @@ if GLIBC_BACK_COMPAT
 endif
 
 libnavcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS) $(BOOST_LIBS) $(SODIUM_LIBS)
-libnavcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBBLS) $(SODIUM_LIBS) $(SSL_LIBS)
+libnavcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBBLS) $(SODIUM_LIBS)
 libnavcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(srcdir)/bls/src -I$(srcdir)/bls/build/_deps/relic-build/include -I$(srcdir)/bls/build/_deps/relic-src/include -DBUILD_NAVCOIN_INTERNAL
 libnavcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -522,7 +522,7 @@ if GLIBC_BACK_COMPAT
 endif
 
 libnavcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS) $(BOOST_LIBS) $(SODIUM_LIBS)
-libnavcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBBLS) $(SODIUM_LIBS)
+libnavcoinconsensus_la_LIBADD = $(LIBSECP256K1) $(LIBBLS) $(SODIUM_LIBS) $(SSL_LIBS)
 libnavcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(srcdir)/bls/src -I$(srcdir)/bls/build/_deps/relic-build/include -I$(srcdir)/bls/build/_deps/relic-src/include -DBUILD_NAVCOIN_INTERNAL
 libnavcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 

--- a/src/blsct/bulletproofs.h
+++ b/src/blsct/bulletproofs.h
@@ -19,6 +19,7 @@
 #include <amount.h>
 #include <blsct/scalar.h>
 #include <bls.hpp>
+#include <streams.h>
 #include <utilstrencodings.h>
 
 #include <boost/thread/mutex.hpp>
@@ -44,6 +45,33 @@ class BulletproofsRangeproof
 {
 public:
     BulletproofsRangeproof() {}
+
+    BulletproofsRangeproof(std::vector<unsigned char> vData) {
+        try
+        {
+            CDataStream strm(vData, 0, 0);
+            strm >> *this;
+        }
+        catch(...)
+        {
+
+        }
+    }
+
+    std::vector<unsigned char> GetVch() const
+    {
+        try
+        {
+            CDataStream strm(0, 0);
+            strm << *this;
+            return std::vector<unsigned char>(strm.begin(), strm.end());
+        }
+        catch(...)
+        {
+
+        }
+        return std::vector<unsigned char>();
+    }
 
     static bool Init();
 

--- a/src/blsct/rpc.cpp
+++ b/src/blsct/rpc.cpp
@@ -277,7 +277,7 @@ UniValue scanviewkey(const UniValue& params, bool fHelp)
                         {
                             try
                             {
-                                proofs.push_back(std::make_pair(0,txout.bp));
+                                proofs.push_back(std::make_pair(0,txout.GetBulletproof()));
                                 bls::G1Element t = bls::G1Element::FromByteVector(txout.outputKey);
                                 bls::PrivateKey k = vk.GetKey();
                                 t = t * k;

--- a/src/blsct/transaction.cpp
+++ b/src/blsct/transaction.cpp
@@ -54,7 +54,7 @@ bool CreateBLSCTOutput(bls::PrivateKey blindingKey, bls::G1Element& nonce, CTxOu
         return false;
     }
 
-    newTxOut.bp = bprp;
+    newTxOut.bp = bprp.GetVch();
 
     if (!GenTxOutputKeys(blindingKey, destKey, newTxOut.spendingKey, newTxOut.outputKey, newTxOut.ephemeralKey))
     {
@@ -146,7 +146,7 @@ bool CandidateTransaction::Validate(const CStateViewCache* inputs) {
     {
         Scalar s = minAmount;
         bls::G1Element l = (BulletproofsRangeproof::H*s.bn).Inverse();
-        bls::G1Element r = tx.vout[i].bp.V[0];
+        bls::G1Element r = tx.vout[i].GetBulletproof().V[0];
         l = l + r;
         if (!(l == minAmountProofs.V[i]))
             return error ("CandidateTransaction::%s: Failed verification from output's amount %d", __func__, i);

--- a/src/blsct/verification.cpp
+++ b/src/blsct/verification.cpp
@@ -58,7 +58,7 @@ bool VerifyBLSCT(const CTransaction &tx, bls::PrivateKey viewKey, std::vector<Ra
             {
                 if (prevOut.HasRangeProof())
                 {
-                    balKey = fElementZero ? prevOut.bp.GetValueCommitments()[0] : balKey + prevOut.bp.GetValueCommitments()[0];
+                    balKey = fElementZero ? prevOut.GetBulletproof().GetValueCommitments()[0] : balKey + prevOut.GetBulletproof().GetValueCommitments()[0];
                     fElementZero = false;
                 }
                 else
@@ -100,7 +100,7 @@ bool VerifyBLSCT(const CTransaction &tx, bls::PrivateKey viewKey, std::vector<Ra
             }
             if (fCheckRange)
             {
-                proofs.push_back(std::make_pair(j, tx.vout[j].bp));
+                proofs.push_back(std::make_pair(j, tx.vout[j].GetBulletproof()));
                 // Shared key v*R - Used as nonce for bulletproof
                 try
                 {
@@ -117,11 +117,11 @@ bool VerifyBLSCT(const CTransaction &tx, bls::PrivateKey viewKey, std::vector<Ra
             {
                 if (fElementZero)
                 {
-                    balKey = tx.vout[j].bp.GetValueCommitments()[0];
+                    balKey = tx.vout[j].GetBulletproof().GetValueCommitments()[0];
                 }
                 else
                 {
-                    bls::G1Element t = tx.vout[j].bp.GetValueCommitments()[0].Inverse();
+                    bls::G1Element t = tx.vout[j].GetBulletproof().GetValueCommitments()[0].Inverse();
                     balKey = balKey + t;
                 }
                 fElementZero = false;
@@ -251,7 +251,7 @@ bool VerifyBLSCTBalanceOutputs(const CTransaction &tx, bls::PrivateKey viewKey, 
             }
             if (fCheckRange)
             {
-                proofs.push_back(std::make_pair(j, tx.vout[j].bp));
+                proofs.push_back(std::make_pair(j, tx.vout[j].GetBulletproof()));
                 // Shared key v*R - Used as nonce for bulletproof
                 try
                 {
@@ -268,11 +268,11 @@ bool VerifyBLSCTBalanceOutputs(const CTransaction &tx, bls::PrivateKey viewKey, 
             {
                 if (fElementZero)
                 {
-                    balKey = tx.vout[j].bp.GetValueCommitments()[0];
+                    balKey = tx.vout[j].GetBulletproof().GetValueCommitments()[0];
                 }
                 else
                 {
-                    bls::G1Element t = tx.vout[j].bp.GetValueCommitments()[0].Inverse();
+                    bls::G1Element t = tx.vout[j].GetBulletproof().GetValueCommitments()[0].Inverse();
                     balKey = balKey + t;
                 }
                 fElementZero = false;

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -123,7 +123,8 @@ public:
                 READWRITE(txout.ephemeralKey);
                 READWRITE(txout.outputKey);
                 READWRITE(txout.spendingKey);
-                READWRITE(txout.bp);
+                BulletproofsRangeproof bp = txout.GetBulletproof();
+                READWRITE(bp);
             }
             else
             {
@@ -140,7 +141,9 @@ public:
                 READWRITE(txout.ephemeralKey);
                 READWRITE(txout.outputKey);
                 READWRITE(txout.spendingKey);
-                READWRITE(txout.bp);
+                BulletproofsRangeproof bp_;
+                READWRITE(bp_);
+                txout.bp = bp_.GetVch();
             }
             else
             {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -55,7 +55,7 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, const bls::G1Ele
     ephemeralKey = ephemeralKeyIn.Serialize();
     outputKey = outputKeyIn.Serialize();
     spendingKey = spendingKeyIn.Serialize();
-    bp = bpIn;
+    bp = bpIn.GetVch();
 }
 
 uint256 CTxOut::GetHash() const
@@ -75,7 +75,7 @@ std::string CTxOut::ToString() const
                          spendingKey.size()>0 ? strprintf(" spendingKey=%s",HexStr(spendingKey)):"",
                          outputKey.size()>0 ? strprintf(" outputKey=%s",HexStr(outputKey)):"",
                          ephemeralKey.size()>0 ? strprintf(" ephemeralKey=%s",HexStr(ephemeralKey)):"",
-                         bp.V.size()>0 ? " rangeProof=1":"");
+                         GetBulletproof().V.size()>0 ? " rangeProof=1":"");
     }
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -154,7 +154,7 @@ class CTxOut
 public:
     CAmount nValue;
     CScript scriptPubKey;
-    BulletproofsRangeproof bp;
+    std::vector<uint8_t> bp;
     std::vector<uint8_t> ephemeralKey;
     std::vector<uint8_t> outputKey;
     std::vector<uint8_t> spendingKey;
@@ -180,7 +180,9 @@ public:
                 READWRITE(ephemeralKey);
                 READWRITE(outputKey);
                 READWRITE(spendingKey);
-                READWRITE(bp);
+                BulletproofsRangeproof bp_;
+                READWRITE(bp_);
+                bp = bp_.GetVch();
             }
             READWRITE(*(CScriptBase*)(&scriptPubKey));
         }
@@ -194,7 +196,8 @@ public:
                 READWRITE(ephemeralKey);
                 READWRITE(outputKey);
                 READWRITE(spendingKey);
-                READWRITE(bp);
+                BulletproofsRangeproof bp_(bp);
+                READWRITE(bp_);
             }
             else
             {
@@ -213,6 +216,13 @@ public:
         spendingKey.clear();
     }
 
+    BulletproofsRangeproof GetBulletproof() const
+    {
+        if (bp.size() == 0)
+            return BulletproofsRangeproof();
+        return BulletproofsRangeproof(bp);
+    }
+
     bool IsBLSCT() const
     {
         return ephemeralKey.size() > 0 || spendingKey.size() > 0 || outputKey.size() > 0;
@@ -220,7 +230,7 @@ public:
 
     bool HasRangeProof() const
     {
-        return bp.V.size() > 0;
+        return GetBulletproof().V.size() > 0;
     }
 
     bool IsNull() const

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -155,7 +155,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, UniValue&
         out.pushKV("spendingKey", HexStr(txout.spendingKey));
         out.pushKV("outputKey", HexStr(txout.outputKey));
         out.pushKV("ephemeralKey", HexStr(txout.ephemeralKey));
-        out.pushKV("rangeProof", txout.bp.V.size() > 0);
+        out.pushKV("rangeProof", txout.GetBulletproof().V.size() > 0);
 
         // Add spent information if spentindex is enabled
         CSpentIndexValue spentInfo;
@@ -241,7 +241,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         out.pushKV("scriptPubKey", o);
         out.pushKV("spendingKey", HexStr(txout.spendingKey));
         out.pushKV("ephemeralKey", HexStr(txout.ephemeralKey));
-        out.pushKV("rangeProof", txout.bp.V.size() > 0);
+        out.pushKV("rangeProof", txout.GetBulletproof().V.size() > 0);
         vout.push_back(out);
     }
     entry.pushKV("vout", vout);

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -5,9 +5,31 @@
 
 #include <support/cleanse.h>
 
-#include <openssl/crypto.h>
+#include <cstring>
+
+#if defined(_MSC_VER)
+#include <Windows.h> // For SecureZeroMemory.
+#endif
 
 void memory_cleanse(void *ptr, size_t len)
 {
-    OPENSSL_cleanse(ptr, len);
+#if defined(_MSC_VER)
+    /* SecureZeroMemory is guaranteed not to be optimized out by MSVC. */
+    SecureZeroMemory(ptr, len);
+#else
+    std::memset(ptr, 0, len);
+
+    /* Memory barrier that scares the compiler away from optimizing out the memset.
+     *
+     * Quoting Adam Langley <agl@google.com> in commit ad1907fe73334d6c696c8539646c21b11178f20f
+     * in BoringSSL (ISC License):
+     *    As best as we can tell, this is sufficient to break any optimisations that
+     *    might try to eliminate "superfluous" memsets.
+     * This method is used in memzero_explicit() the Linux kernel, too. Its advantage is that it
+     * is pretty efficient because the compiler can still implement the memset() efficiently,
+     * just not remove it entirely. See "Dead Store Elimination (Still) Considered Harmful" by
+     * Yang et al. (USENIX Security 2017) for more background.
+     */
+    __asm__ __volatile__("" : : "r"(ptr) : "memory");
+#endif
 }

--- a/src/support/cleanse.h
+++ b/src/support/cleanse.h
@@ -8,6 +8,8 @@
 
 #include <stdlib.h>
 
+/** Secure overwrite a buffer (possibly containing secret data) with zero-bytes. The write
+ * operation will not be optimized out by the compiler. */
 void memory_cleanse(void *ptr, size_t len);
 
 #endif // NAVCOIN_SUPPORT_CLEANSE_H

--- a/src/test/blsct_tests.cpp
+++ b/src/test/blsct_tests.cpp
@@ -284,6 +284,12 @@ BOOST_AUTO_TEST_CASE(blsct)
     BOOST_CHECK(VerifyBLSCT(spendingTx, viewKey, vData, view, state));
     spendingTx.vout[0].nValue = 10;
 
+    BulletproofsRangeproof proofCheck = spendingTx.vout[0].GetBulletproof();
+    BulletproofsRangeproof proofCheck2(proofCheck.GetVch());
+
+    BOOST_CHECK(proofCheck == proofCheck2);
+    BOOST_CHECK(proofCheck.GetVch() == proofCheck2.GetVch());
+
     // Private to Public. Different amount. Balance signature correct. Tx signature complete.
     state = CValidationState();
     BOOST_CHECK(!VerifyBLSCT(spendingTx, viewKey, vData, view, state));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2372,7 +2372,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate)
 
                 bool fValid = true;
 
-                if (GetBLSCTViewKey(k))
+                if (tx.IsBLSCT() && GetBLSCTViewKey(k))
                     fValid=VerifyBLSCT(tx, k.GetKey(), blsctData, view, state, true);
 
                 if (!fValid)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1642,13 +1642,13 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet, CWalletD
                             }
                             catch(...)
                             {
-                                proofs.push_back(std::make_pair(i, out.bp));
+                                proofs.push_back(std::make_pair(i, out.GetBulletproof()));
                                 nonces.push_back(n);
                                 continue;
                             }
 
                         }
-                        proofs.push_back(std::make_pair(i, out.bp));
+                        proofs.push_back(std::make_pair(i, out.GetBulletproof()));
                         nonces.push_back(n);
                     }
 
@@ -1953,7 +1953,7 @@ isminetype CWallet::IsMine(const CTxOut& txout) const
         {
             try
             {
-                proofs.push_back(std::make_pair(0,txout.bp));
+                proofs.push_back(std::make_pair(0,txout.GetBulletproof()));
                 bls::G1Element t = bls::G1Element::FromByteVector(txout.outputKey);
                 bls::PrivateKey k = v.GetKey();
                 t = t * k;


### PR DESCRIPTION
This PR changes the memory structure of a transaction, storing the range proof as a vector instead of a BulletproofsRangeproof element when an output is not private. As the vector's size is 0 when no bulletproof is present, it allows to save the memory used by the range proof for a big part of the transaction history of the chain.

**Test**

- Memory use is reduced with pull request (specially wallets with a long transaction history).
- Node synchronizes in testnet
- Test units pass (./src/test/test_navcoin)