### PR TITLE
Updated how NTP sync at wallet start works

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1339,40 +1339,38 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler, const std
                "setting ntpminmeasures=0. Please be aware that "
                "your system clock needs to be correct in order "
                "to synchronize with the network. ";
-    } else if(nMinMeasures > 0) {
-        while(1)
+    }
+
+    if(nMinMeasures > 0) {
+        // Try to sync NTP 3 times
+        while(nWarningCounter < 3)
         {
+            // We were told to go home
             if(ShutdownRequested())
                 break;
-            if(!NtpClockSync())
-            {
-                sMsg = "A connection could not be made to any ntp server. "
-                       "Please ensure you system clock is correct otherwise "
-                       "your stakes will be rejected by the network";
 
-                if (nWarningCounter == 0)
-                {
-                    uiInterface.ThreadSafeMessageBox(sMsg, "", CClientUIInterface::MSG_ERROR);
-                }
-
-                strMiscWarning = sMsg;
-                AlertNotify(strMiscWarning);
-                LogPrintf(strMiscWarning.c_str());
-
-                uiInterface.InitMessage(_(strprintf("Synchronizing clock attempt %i...", nWarningCounter+1).c_str()));
-
-                nWarningCounter++;
-
-                if(!ShutdownRequested())
-                {
-                    MilliSleep(10000);
-                }
-            }
-            else
-            {
+            // Check if we got a sync with ntp
+            if(NtpClockSync()) {
                 strMiscWarning = "";
                 sMsg = "";
                 break;
+            }
+
+            sMsg = "A connection could not be made to any ntp server. "
+                "Please ensure you system clock is correct otherwise "
+                "your stakes will be rejected by the network";
+
+            strMiscWarning = sMsg;
+            AlertNotify(strMiscWarning);
+            LogPrintf(strMiscWarning.c_str());
+
+            uiInterface.InitMessage(_(strprintf("Synchronizing clock attempt %i...", nWarningCounter+1).c_str()));
+
+            nWarningCounter++;
+
+            if(!ShutdownRequested())
+            {
+                MilliSleep(1500); // Wait for 1 and a half seconds
             }
         }
     }


### PR DESCRIPTION
This PR allows for the wallet to start when NTP sync fails 3 times.

This will allow the wallet to work when network access to NTP servers is blocked for some reason.

But it will still warn the user about the NTP sync issue.

Test scenario:

1. Load wallet as normal (Should connect and find NTP sync)
2. Load wallet with no network (The  wallet should attempt to connect to NTP 3 times, then warn user about the failure)
3. Load wallet with `ntpminmeasures=-1` This should disable the NTP sync completely (no warnings)
4. Load wallet with `ntpminmeasures=0` This should disable the NTP sync, but show a warning about it being off/disabled


closes #800 