### PR TITLE
Fix for osx build running out of log space travis

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -156,14 +156,6 @@ $(NAVCOIND_BIN): FORCE
 $(NAVCOIN_CLI_BIN): FORCE
 	$(MAKE) -C src $(@F)
 
-check-recursive:
-	$(MAKE) -C src/bls/build
-	$(MAKE) -C src check
-
-install-recursive:
-	$(MAKE) -C src/bls/build
-	$(MAKE) -C src install
-
 if USE_LCOV
 
 baseline.info:

--- a/Makefile.am
+++ b/Makefile.am
@@ -156,6 +156,14 @@ $(NAVCOIND_BIN): FORCE
 $(NAVCOIN_CLI_BIN): FORCE
 	$(MAKE) -C src $(@F)
 
+check-recursive:
+	$(MAKE) -C src/bls/build
+	$(MAKE) -C src check
+
+install-recursive:
+	$(MAKE) -C src/bls/build
+	$(MAKE) -C src install
+
 if USE_LCOV
 
 baseline.info:

--- a/ci/test_05_before_script.sh
+++ b/ci/test_05_before_script.sh
@@ -21,7 +21,7 @@ if [[ $HOST = *-mingw32 ]]; then
 fi
 if [ -z "$NO_DEPENDS" ]; then
   BEGIN_FOLD depends
-  DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS || ( echo "Depends Build failure. Verbose build follows." && CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS V=1 ; false )
   END_FOLD
 
   if [[ $HOST = *-mingw32 ]]; then

--- a/ci/test_05_before_script.sh
+++ b/ci/test_05_before_script.sh
@@ -21,7 +21,7 @@ if [[ $HOST = *-mingw32 ]]; then
 fi
 if [ -z "$NO_DEPENDS" ]; then
   BEGIN_FOLD depends
-  DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS || ( echo "Depends Build failure. Verbose build follows." && CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS V=1 ; false )
+  DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS || ( echo "Depends Build failure. Verbose build follows." && CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS V=1 ; false )
   END_FOLD
 
   if [[ $HOST = *-mingw32 ]]; then

--- a/ci/test_05_before_script.sh
+++ b/ci/test_05_before_script.sh
@@ -20,7 +20,9 @@ if [[ $HOST = *-mingw32 ]]; then
   DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
 fi
 if [ -z "$NO_DEPENDS" ]; then
-  DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  BEGIN_FOLD depends
+  DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  END_FOLD
 
   if [[ $HOST = *-mingw32 ]]; then
     # Copy the missing headers that windows build needs

--- a/ci/test_05_before_script.sh
+++ b/ci/test_05_before_script.sh
@@ -20,9 +20,7 @@ if [[ $HOST = *-mingw32 ]]; then
   DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
 fi
 if [ -z "$NO_DEPENDS" ]; then
-  BEGIN_FOLD depends
   DOCKER_EXEC CONFIG_SHELL= ./contrib/run_with_dots make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS || ( echo "Depends Build failure. Verbose build follows." && CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS V=1 ; false )
-  END_FOLD
 
   if [[ $HOST = *-mingw32 ]]; then
     # Copy the missing headers that windows build needs

--- a/contrib/run_with_dots
+++ b/contrib/run_with_dots
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+"$@" &
+
+while kill -0 $!; do
+    printf '.' > /dev/tty
+    sleep 2
+done
+
+printf '\n' > /dev/tty

--- a/contrib/run_with_dots
+++ b/contrib/run_with_dots
@@ -1,10 +1,10 @@
 #!/bin/bash
-
-"$@" &
-
-while kill -0 $!; do
-    printf '.' > /dev/tty
-    sleep 2
+"$@" > /dev/null 2>&1 &
+PID=$!
+echo "Running: $@"
+while [ -d /proc/$PID ]; do
+	echo -n "."
+	sleep 1
 done
-
-printf '\n' > /dev/tty
+echo "."
+echo "Done: $@"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,9 @@ endif
 $(LIBSECP256K1): $(wildcard secp256k1/src/*.h) $(wildcard secp256k1/src/*.c) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 
+$(LIBBLS):
+	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D)
+
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization
 # But to build the less dependent modules first, we manually select their order here:
 EXTRA_LIBRARIES += \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -558,7 +558,6 @@ EXTRA_DIST = $(CTAES_DIST)
 
 clean-local:
 	-$(MAKE) -C secp256k1 clean
-	-$(MAKE) -C tor clean
 	-$(MAKE) -C univalue clean
 	-$(MAKE) -C bls/build clean
 	-rm -f leveldb/*/*.gcda leveldb/*/*.gcno leveldb/helpers/memenv/*.gcda leveldb/helpers/memenv/*.gcno


### PR DESCRIPTION
This PR should fix the issue with log file being too large on OSX build.