### PR TITLE
xNAV transaction mempool policy

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -93,7 +93,10 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
     unsigned int nDataOut = 0;
     txnouttype whichType;
     for(const CTxOut& txout: tx.vout) {
-        if (txout.scriptPubKey,size() == 1 && txout.scriptPubKey[0] == OP_1)
+        if (txout.scriptPubKey.size() == 1 && txout.scriptPubKey[0] == OP_1)
+            continue;
+
+        if (txout.scriptPubKey.IsColdStaking())
             continue;
 
         if (!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled)) {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -93,6 +93,9 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
     unsigned int nDataOut = 0;
     txnouttype whichType;
     for(const CTxOut& txout: tx.vout) {
+        if (txout.scriptPubKey,size() == 1 && txout.scriptPubKey[0] == OP_1)
+            continue;
+
         if (!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled)) {
             reason = "scriptpubkey";
             return false;


### PR DESCRIPTION
Transactions with the standard xNAV script (OP_1) are being rejected from entering the mempool. Users seeing their swaps rejected for this reason.

This PR fixes this bug and #793.