### PR TITLE
Check for null pointer in BuildMixCounters

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5632,6 +5632,9 @@ void CWallet::BuildMixCounters()
     for (TxItems::const_iterator it = txOrdered.begin(); it != txOrdered.end(); ++it)
     {
         CWalletTx *const pcoin = (*it).second.first;
+
+        if (!pcoin) continue;
+
         uint256 hash = pcoin->GetHash();
 
         if (pcoin->IsCTOutput() && pcoin->IsBLSInput())


### PR DESCRIPTION
Fix for crash reported in #dev-navcoin-core

<img width="714" alt="image" src="https://user-images.githubusercontent.com/24814046/110936062-95cf6d00-8330-11eb-85dd-7f15e7970ba5.png">
