### PR TITLE
Fix address history sorting

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -1221,7 +1221,7 @@ UniValue getaddresshistory(const UniValue& params, bool fHelp)
         auto b_ = b.first;
 
         if (a_.blockHeight == b_.blockHeight) {
-            return a_.time < b_.time;
+            return a_.txindex < b_.txindex;
         } else {
             return a_.blockHeight < b_.blockHeight;
         }


### PR DESCRIPTION
Changes to use txindex instead of the transaction timestamp to ensure the coinstake is not oddly positioned when calling getaddresshisotry.

Fixes #748.