### PR TITLE
Remove BLSCT verification benchmark logging

### DIFF
--- a/src/blsct/verification.cpp
+++ b/src/blsct/verification.cpp
@@ -210,7 +210,7 @@ bool VerifyBLSCT(const CTransaction &tx, bls::PrivateKey viewKey, std::vector<Ra
         }
     }
 
-    std::cout << strprintf("%s: took %.2f ms\n", __func__, (GetTimeMicros()-nStart)/1000);
+    //std::cout << strprintf("%s: took %.2f ms\n", __func__, (GetTimeMicros()-nStart)/1000);
     return true;
 }
 


### PR DESCRIPTION
This PR removes logging for how long does the BLSCT verification take.