### PR TITLE
Protocol version 80021

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7739,6 +7739,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     if (pfrom->nVersion != 0)
     {
         bool fObsolete = false;
+        bool fBan = true;
         string reason = "";
 
         if(pfrom->nVersion < 70015)
@@ -7759,12 +7760,28 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             fObsolete = true;
         }
 
+        if(pfrom->nVersion < 80020 && IsBLSCTEnabled(chainActive.Tip(), Params().GetConsensus()))
+        {
+            reason = "xNAV has been enabled and you are using an old version of Navcoin, please update.";
+            fObsolete = true;
+        }
+
+        if(pfrom->nVersion >= 80020 && pfrom->nVersion < 80021 && IsBLSCTEnabled(chainActive.Tip(), Params().GetConsensus()))
+        {
+            reason = "You are using an old version of Navcoin, please update.";
+            fObsolete = true;
+            fBan = false;
+        }
+
         if(fObsolete)
         {
             pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE, reason);
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return false;
+            if (fBan)
+            {
+                LOCK(cs_main);
+                Misbehaving(pfrom->GetId(), 100);
+                return false;
+            }
         }
     }
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 80020;
+static const int PROTOCOL_VERSION = 80021;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
This PR bumps protocol version to 80021.

Peers with prot.version older than 80020 are banned.
Peers with prot.version 80020 receive a message about the need to update to 80021 (xNAV INV PR #836)

Do not merge until 6.1 release is ready.