### PR TITLE
Only start timer after connecting model signals

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -284,6 +284,8 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         updateWatchOnlyLabels(model->haveWatchOnly());
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
+
+        model->StartBalanceTimer();
     }
 
     // update the display unit, to not use the default ("NAV")

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -172,6 +172,8 @@ public:
     // Wallet backup
     bool backupWallet(const QString &filename);
 
+    void StartBalanceTimer();
+
     // RAI object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
     {


### PR DESCRIPTION
This PR fixes the GUI bug which did not update the staking statistics until a transaction arrived.

The fix consists on only starting the timer which checks for changes on the balances once the wallet model signals have been connected with the overview page slots.