### PR TITLE
Update coin control legacy code

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -74,10 +74,6 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("strThirdPartyTxUrls", "https://www.navexplorer.com/tx/%s");
     strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "https://www.navexplorer.com/tx/%s").toString();
 
-    if (!settings.contains("fCoinControlFeatures"))
-        settings.setValue("fCoinControlFeatures", false);
-    fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
-
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -239,8 +235,6 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return nScaling;
         case Language:
             return settings.value("language");
-        case CoinControlFeatures:
-            return fCoinControlFeatures;
         case DatabaseCache:
             return settings.value("nDatabaseCache");
         case ThreadsScriptVerif:
@@ -386,9 +380,6 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 setRestartRequired(true);
             }
             break;
-        case CoinControlFeatures:
-            setCoinControlFeatures(value.toBool());
-            break;
         case DatabaseCache:
             if (settings.value("nDatabaseCache") != value) {
                 settings.setValue("nDatabaseCache", value);
@@ -427,17 +418,6 @@ void OptionsModel::setDisplayUnit(const QVariant &value)
         settings.setValue("nDisplayUnit", nDisplayUnit);
         Q_EMIT displayUnitChanged(nDisplayUnit);
     }
-}
-
-void OptionsModel::setCoinControlFeatures(const bool enabled)
-{
-    if (enabled == fCoinControlFeatures)
-        return;
-
-    QSettings settings;
-    fCoinControlFeatures = enabled;
-    settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
-    Q_EMIT coinControlFeaturesChanged(fCoinControlFeatures);
 }
 
 void OptionsModel::setRestartRequired(bool fRequired)

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -39,7 +39,6 @@ public:
         Theme,                  // QString
         Scaling,                // int
         Language,               // QString
-        CoinControlFeatures,    // bool
         ThreadsScriptVerif,     // int
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
@@ -56,7 +55,6 @@ public:
     void setDirty(bool dirty);
     /** Updates current unit in memory, settings and emits displayUnitChanged(newUnit) signal */
     void setDisplayUnit(const QVariant &value);
-    void setCoinControlFeatures(const bool enabled);
 
     /* Explicit getters */
     bool getHideTrayIcon() { return fHideTrayIcon; }
@@ -81,7 +79,6 @@ private:
     QString language;
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
-    bool fCoinControlFeatures;
     bool fDirty = false;
     /* settings that were overriden by command-line */
     QString strOverriddenByCommandLine;
@@ -93,7 +90,6 @@ private:
     void checkAndMigrate();
 Q_SIGNALS:
     void displayUnitChanged(int unit);
-    void coinControlFeaturesChanged(bool);
     void hideTrayIconChanged(bool);
 };
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -64,7 +64,6 @@ public:
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }
     QString getThirdPartyTxUrls() { return strThirdPartyTxUrls; }
-    bool getCoinControlFeatures() { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
     /* Restart flag helper */

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -134,7 +134,7 @@ void SendCoinsDialog::setModel(WalletModel *model)
 
         // Coin Control
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(coinControlUpdateLabels()));
-        ui->widgetCoinControl->setVisible(model->getOptionsModel()->getCoinControlFeatures());
+        ui->widgetCoinControl->setVisible(fCoinControl);
         coinControlUpdateLabels();
 
         // Toggle the checkbox for change address
@@ -253,8 +253,8 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
-    if (currentTransaction.fSpendsColdStaking && (!model->getOptionsModel()->getCoinControlFeatures() ||
-        (model->getOptionsModel()->getCoinControlFeatures() && !CNavcoinAddress(CoinControlDialog::coinControl->destChange).IsColdStakingAddress(Params()))))
+    if (currentTransaction.fSpendsColdStaking && (!fCoinControl ||
+        (fCoinControl && !CNavcoinAddress(CoinControlDialog::coinControl->destChange).IsColdStakingAddress(Params()))))
     {
         SendConfirmationDialog confirmationDialog(tr("Confirm send coins"),
             tr("This transaction will spend coins stored in a cold staking address.<br>You did not set any cold staking address as custom change destination, so those coins won't be locked anymore by the cold staking smart contract.<br><br>Do you still want to send this transaction?"), SEND_CONFIRM_DELAY, this);
@@ -352,7 +352,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModel::SendCoinsReturn sendStatus;
 
     // now send the prepared transaction
-    if (model->getOptionsModel()->getCoinControlFeatures()) // coin control enabled
+    if (fCoinControl) // coin control enabled
         sendStatus = model->sendCoins(currentTransaction, fPrivate, coinControl, &selectedCoins);
     else
         sendStatus = model->sendCoins(currentTransaction, fPrivate, 0, &selectedCoins);


### PR DESCRIPTION
Coin control isn't working properly on my windows node. 

This PR updates the legacy getCoinControlFeatures flag to fCoinControl that was created in PR832.

Waiting on the PR to fix gitian build to confirm fix on windows.
