### PR TITLE
[RPC] gettransactionkeys

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -517,7 +517,7 @@ UniValue gettransactionkeys(const UniValue& params, bool fHelp)
             LOCK(cs_main);
             CStateViewCache view(pcoinsTip);
             if (!GetTransaction(txin.prevout.hash, prevtx, Params().GetConsensus(), hashBlock, view, true))
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+                continue;
         }
 
         if (prevtx.vout[txin.prevout.n].IsBLSCT())


### PR DESCRIPTION
This PR adds a new RPC command to show a transaction input and output keys when combined with txindex.

This helps to greatly improve sync time when using a xNAV light wallet.

Use:

`gettransactionkeys rehash`

Example output:

```
{
  "vin": [
    {
      "txid": "e9a87d14c9afddde24aea40e6da9de48b276b20b0fbee1c3a3518a84d4652a25",
      "vout": 0,
      "outputKey": "89bef7ddb16cef274628d49531a879b75f01e37a7489ed63b315a4c451bd07e785d4b4075c002698ce2efa0aa21d6f19",
      "spendingKey": "b93ad3309d2672c45b1b35ff61de199ecd0ac463d5d7e6d0117dec4a20bded6cf92297cb32c5efd0fa63ed81dd53bf52"
    }
  ],
  "vout": [
    {
      "outputKey": "afc9bc88f80174b46aedee2c01dc5faf0a4c6f8389b42c4c88c88a69a754f44442bab0fdf2079be4d6346914d4fabe99",
      "spendingKey": "a0735dcf02303c50cbc0afe3371900efd73031534a9cc9e5d6b48976b84107de3ba25f921859ea01c209600c228853a8"
    },
    {
      "outputKey": "81a598defb7878411b440029ef4149265eea8403d2c3bca2f8d78d74a7cf940532fabcafc25564067960ed837e7a0c51",
      "spendingKey": "934312ae9d7b553c682117253b347f0917d7991b0557b19d3d07bfdc257597e016d2492f125a0af00d3935090d023e93"
    },
    {
      "script": "6a"
    }
  ]
}
```