### PR TITLE
Fix typo

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -48,7 +48,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 1 },
     { "getbalance", 2 },
     { "getblockhash", 0 },
-    { "viewaggregatesession", 0},
+    { "viewaggregationession", 0},
     { "move", 2 },
     { "move", 3 },
     { "sendfrom", 2 },


### PR DESCRIPTION
Fixes a typo which prevented to correctly parse "true" as a boolean when passed to the `viewaggregationsession` RPC command.

## What to test

RPC command `viewaggregationsession true` works.