### PR TITLE
Updated depends libsodium to use variables for AR, RANLIB

### DIFF
--- a/depends/packages/sodium.mk
+++ b/depends/packages/sodium.mk
@@ -8,7 +8,7 @@ $(package)_patches=disable-glibc-getrandom-getentropy.patch fix-whitespace.patch
 define $(package)_set_vars
 $(package)_config_opts=--enable-static --disable-shared --with-pic="yes"
 $(package)_config_opts+=--prefix=$(host_prefix)
-$(package)_config_opts_darwin=RANLIB="$(host_prefix)/native/bin/x86_64-apple-darwin16-ranlib" AR="$(host_prefix)/native/bin/x86_64-apple-darwin16-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
+$(package)_config_opts_darwin=RANLIB="$(host_prefix)/native/bin/$(host)-ranlib" AR="$(host_prefix)/native/bin/$(host)-ar" CC="$(host_prefix)/native/bin/$($(package)_cc)"
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
NOTE: Test if building depends for darwin works correctly (Gitian build should do this automatically)