### PR TITLE
dotNAV

### DIFF
--- a/contrib/stressor_dotnav.sh
+++ b/contrib/stressor_dotnav.sh
@@ -1,0 +1,1193 @@
+#!/bin/bash 
+
+
+# This file serves the purpose of testing the network behavior under extreme load of
+# random transactions and tokens/nfts transactions.
+# Blocks are being mined through proof of stake process so this script usually takes hours
+# to finish depending on the setup. Tests that are included are:
+#
+# 	1. Create random transactions
+# 	2. Register names
+# 	3. Update names and subdomain names
+# 	4. Renew names
+#       5. Check all nodes resolve names the same way
+# 	6. Perform random verifychain checks to simulate network reorg back to genesis
+# 	7. Randomly turn off nodes and then turn them back on
+# 	8. Randomly boot up a fresh node to test syncing from genesis block
+# 	9. Randomly create new network topologies to loosely connect the nodes
+# 	10. Split the network down into user defined number of subnetworks and perform tests
+# 	    1-5, re-combine all subnetworks afterwards into 1 to see if all networks follow
+# 	    the longest chain correctly
+# 	11. Final verifychain check back to genesis
+#
+
+# NOTE: This stresser is written in bash(4.4) environment. OSX users may need to install gshuf and substitude all shuf with gshuf.
+
+### Need to configure this!!
+
+### Path to binaries
+navpath=../src
+
+### How many voting cycles to run the stresser
+cycles=40
+
+### Number of nodes to start. (Setting node_count=1 will overwrite settings for stressing_node_count, array_stressing_nodes, array_verifychain_nodes)
+node_count=8
+
+### Number of nodes to be creating proposals, consultations, and  voting.
+stressing_node_count=6
+
+### If manual selection of stressing nodes is preferred, specify below, or leave it an empty array. If specified, node count must match stressing_node_count
+array_stressing_nodes=()
+
+### Nodes to check verifychain, 8 random nodes will be picked if left empty "()", more nodes make verifychain process faster but try to use no more than 8 nodes
+array_verifychain_nodes=()
+
+### How many extra blocks should be staked when the stresser is done
+extra_blocks_to_stake=30
+extra_blocks_to_stake_randomness=30
+
+
+### Length in seconds for a stress round
+seconds_round=60
+
+### Network topology, a random topology will be generated if left empty "()", or specify nodes to be connect by pairs (EX to have a network with topology of
+###
+### 0-1-2-8- 9-10
+### | | |    |  |
+### 3 4 5   11-12
+###   | |    |  |
+###   6-7   13-14
+###             |
+###            15
+###
+### specify the array as ("0 1" "1 2" "2 8" "8 9" "9 10" "0 3" "1 4" "2 5" "9 11" "10 12" "11 12" "4 6" "5 7" "11 13" "12 14" "6 7" "13 14" "14 15")
+array_topology=()
+
+###How many networ to split into
+network_count=4
+
+### How many voting cycels to run in the splitting network phase
+cycles_network_split=40
+
+### How long the sleep time is in a stress round ( say a stress round is 60 sec, sleep 4 sec after all the tests are run once)
+stress_sleep_time=4
+
+
+#################### Advanced Settings ##################
+
+###Set to 1 to active the test
+bool_random_tx=1
+bool_random_verifychain_check=0
+bool_stopstart_nodes=1
+bool_random_new_topology=1
+bool_sync_new_node=1
+bool_network_split=1
+
+
+#######################################################################################Functions
+
+function initialize_network {
+	array_p2p_port=()
+	array_rpc_port=()
+	array_data=()
+	array_user=()
+	array_pwd=()
+}
+
+function initialize_node {
+	array_p2p_port[$1]=$( bc <<< "10000+$1" )
+	array_rpc_port[$1]=$( bc <<< "30000+$1" )
+	data_=$(mktemp -d)
+	array_data[$1]=$data_
+	array_user[$1]=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-_\$\?" < /dev/urandom | head -c 10)
+	array_pwd[$1]=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-_\$\?" < /dev/urandom | head -c 10)
+	echo "-datadir=${array_data[$1]} -rpcport=${array_rpc_port[$1]}"
+	start_node $1
+	array_active_nodes[$1]=$1
+	array_all_nodes[$1]=$1
+}
+
+function remove_node {
+	unset array_active_nodes[$1]
+	unset array_all_nodes[$1]
+	unset array_data[$1]
+	unset array_user[$1]
+	unset array_pwd[$1]
+	unset array_p2p_port[$1]
+	unset array_rpc_port[$1]
+	unset array_stopped_nodes[$1]
+}
+
+
+trap ctrl_c INT
+
+function ctrl_c() {
+	terminate 1
+}
+
+function copy_array {
+	declare -n array=$1
+	unset $2
+	for i in ${!array[@]};
+	do
+		eval "$2[$i]=\"${array[$i]}\""
+	done
+}
+
+
+function nav_cli {
+	$navpath/navcoin-cli -datadir=${array_data[$1]} -rpcport=${array_rpc_port[$1]} -devnet $2 $3 $4 $5 $6 2> /dev/null
+}
+
+function terminate {
+	if [ "$1" == 1 ];
+	then
+		fail_logs_D=$(echo "/tmp/stresser_fail_logs_$RANDOM")
+		mkdir $fail_logs_D
+		for i in $(seq 0 1 $( bc <<< "$node_count-1") );
+		do
+			folder_name=$(echo "${array_data[$i]}" | cut -c 10-)
+			nav_cli $i listproposals > ${array_data[$i]}/devnet/listproposals.out
+			nav_cli $i listconsultations > ${array_data[$i]}/devnet/listconsultations.out
+			cp ${array_data[$i]}/devnet/debug.log $fail_logs_D/debug-out-node$i-$folder_name
+			cp ${array_data[$i]}/devnet/listproposals.out $fail_logs_D/listproposals.out-node$i-$folder_name
+			cp ${array_data[$i]}/devnet/listconsultations.out $fail_logs_D/listconsultations.out-node$i-$folder_name
+		done
+		echo debug.log files, listconsultations.out, listproposals.out files are copied to $fail_logs_D
+	fi
+	for i in ${array_active_nodes[@]};
+	do
+		nav_cli $i stop
+	done
+	echo "Stopping all nodes..."
+	sleep 30
+	echo Done
+	killall -9 navcoind
+	exit $1
+}
+
+function connect_nodes {
+	nav_cli "$1" "addnode 127.0.0.1:$( bc <<< 10000+$2 ) add"
+	nav_cli "$1" "addnode 127.0.0.1:$( bc <<< 10000+$2 ) onetry"
+}
+
+function disconnect_nodes {
+	nav_cli "$1" "addnode 127.0.0.1:$( bc <<< 10000+$2 ) remove"
+	nav_cli "$1" "disconnectnode 127.0.0.1:$( bc <<< 10000+$2 )"
+}
+
+
+function select_random_nodes {
+	if [ "$2" == 1 ];
+	then
+		array_random_nodes=($(shuf -i 1-$( bc <<< "$node_count-1" ) -n $1))
+	else
+		array_random_nodes=($(shuf -i 0-$( bc <<< "$node_count-1" ) -n $1))
+	fi
+}
+
+function shuffle_array {
+	local array=("$@")
+	shuffled_array=($(shuf -e ${array[@]}))
+}
+
+
+#Establish topology using set variable $network_topology
+function connect_network {
+	local local_array=("$@")
+	if [ "${#local_array[@]}" -lt 1 ];
+	then
+		return
+	fi
+	for i in ${!local_array[@]};
+	do
+		local connection_pair=(${local_array[$i]})
+		out=$(connect_nodes ${connection_pair[0]} ${connection_pair[1]})
+	done
+	sleep 1
+	check_connection "${local_array[@]}"
+}
+
+function disconnect_network {
+	local local_array=("$@")
+	for i in ${!local_array[@]};
+	do
+		local connection_pair=(${local_array[$i]})
+		out=$(disconnect_nodes ${connection_pair[0]} ${connection_pair[1]})
+	done
+	sleep 5
+}
+
+#Checks if topology is correctly connected
+function check_connection {
+	local array=("$@")
+	check_connection_done=0
+	for i in ${!array[@]};
+	do
+		local connection_pair=(${array[$i]})
+		check=$(nav_cli ${connection_pair[0]} getpeerinfo | grep "\"addr\": \"127.0.0.1:$( bc <<< "10000+${connection_pair[1]}" )\"")
+		if [ -z "$check" ];
+		then
+			echo "Node ${connection_pair[0]} failed to connect to node ${connection_pair[1]}"
+			echo " "
+			echo "Trying to reconnect to all nodes...please wait"
+			sleep 5
+			connect_network "${array[@]}"
+			break
+		fi
+	done
+	if [ "$check_connection_done" == 0 ];
+	then
+		echo "All nodes are connected!"
+		check_connection_done=1
+	fi
+}
+
+function create_random_network_topology {
+	unset array_topology_node_pairs
+	local local_array_create_random_network_topology=("$@")
+	if [ "${#local_array_create_random_network_topology[@]}" -eq 1 ];
+	then
+		return
+	fi
+	array_network_connection_pool=()
+        for j in $(seq 0 1 $( bc <<< "${#local_array_create_random_network_topology[@]}-2" ));
+        do
+                for k in $(seq $( bc <<< "$j+1" ) 1 $( bc <<< "${#local_array_create_random_network_topology[@]}-1" ));
+                do
+                        array_network_connection_pool+=("${local_array_create_random_network_topology[$j]} ${local_array_create_random_network_topology[$k]}")
+                done
+        done
+	if [ "${#local_array_create_random_network_topology[@]}" -lt 100 ];
+	then
+		network_density_upper_bound=$( echo $(echo "e(1.4*l(${#local_array_create_random_network_topology[@]}-1))" | bc -l)/1 | bc )
+	else
+		network_density_upper_bound=$( echo "${#local_array_create_random_network_topology[@]}*8" | bc )
+	fi
+	#network_denstiy is used to create a somewhat loosely connect network topology
+	network_density_lower_bound=$( echo "${#local_array_create_random_network_topology[@]} - 1" | bc )
+        network_density=$( shuf -i $network_density_lower_bound-$network_density_upper_bound -n 1 )
+	array_topology_index=($(shuf -i 0-$( bc <<< "${#array_network_connection_pool[@]} - 1") -n $network_density))
+	for i in $(seq 0 1 $( bc <<< "$network_density-1" ));
+        do
+		array_topology_node_pairs[$i]=${array_network_connection_pool[${array_topology_index[$i]}]}
+	done
+
+        check_network_connected array_topology_node_pairs
+
+        while [ "${#array_connected_nodes[@]}" -lt "${#local_array_create_random_network_topology[@]}" ];
+        do
+                create_random_network_topology "${local_array_create_random_network_topology[@]}"
+        done
+}
+
+function check_network_connected {
+	unset array_to_be_checked_connected
+	copy_array $1 array_to_be_checked_connected
+        connection_progression_old=0
+        connection_progression_new=2
+	unset array_connected_nodes
+	for i in ${array_to_be_checked_connected[@]};
+	do
+		if [ -n $i ];
+		then
+			array_connected_nodes=($i)
+			break
+		fi
+	done
+        while [ "$connection_progression_old" != "$connection_progression_new" ];
+	do
+                connection_progression_old=$connection_progression_new
+		for i in ${!array_to_be_checked_connected[@]};
+                do
+			array_connection=(${array_to_be_checked_connected[$i]})
+                        for j in ${!array_connected_nodes[@]};
+                        do
+                                within_network=0
+                                if [ "${array_connection[0]}" == "${array_connected_nodes[$j]}" ];
+                                then
+                                        for k in $(seq 0 1 $( bc <<< " ${#array_connected_nodes[@]}-1" ));
+                                        do
+                                                if [ "${array_connection[1]}" == "${array_connected_nodes[$k]}" ];
+                                                then
+                                                        within_network=1
+                                                fi
+                                        done
+                                        if [ "$within_network" == 0 ];
+                                        then
+                                                array_connected_nodes+=("${array_connection[1]}")
+                                                array_to_be_checked_connected[$i]=""
+                                                ((connection_progression_new++))
+                                        fi
+                                elif [ "${array_connection[1]}" == "${array_connected_nodes[$j]}" ];
+                                then
+                                        for k in $(seq 0 1 $( bc <<< " ${#array_connected_nodes[@]}-1" ));
+                                        do
+                                                if [ "${array_connection[0]}" == "${array_connected_nodes[$k]}" ];
+                                                then
+                                                        within_network=1
+                                                fi
+                                        done
+                                        if [ "$within_network" == 0 ];
+                                        then
+                                                array_connected_nodes+=("${array_connection[0]}")
+                                                array_to_be_checked_connected[$i]=""
+                                                ((connection_progression_new++))
+                                        fi
+                                fi
+                        done
+                done
+	done
+}
+
+function stop_selected_nodes {
+	if [ "$attempts" == 10 ];
+	then
+		echo Cannot find suitable nodes to stop
+		copy_array array_topology_node_pairs_backcup array_topology_node_pairs
+		copy_array array_topology_node_pairs_stopped_backup array_topology_node_pairs_stopped
+		return
+	fi
+	echo "Stopping nodes ${array_nodes_to_stop[@]}"
+	for i in ${array_nodes_to_stop[@]};
+	do
+		stop_node $i
+	done
+
+	sleep 5
+	for i in ${array_nodes_to_stop[@]};
+	do
+		unset array_active_nodes[$i]
+		if [ -n ${array_stressing_nodes[$i]} ];
+		then
+			array_stopped_stressing_nodes[$i]=${array_stressing_nodes[$i]}
+			unset array_stressing_nodes[$i]
+		fi
+		array_stopped_nodes[$i]=$i
+	done
+#	echo Currently active nodes are: ${array_active_nodes[@]} inactive ones are: ${array_stopped_nodes[@]}
+#	echo array topology node pairs is ${array_topology_node_pairs[@]}
+#	echo array topology node pairs stopped is ${array_topology_node_pairs_stopped[@]} with size of ${#array_topology_node_pairs_stopped[@]}
+
+}
+
+function select_random_nodes_to_stop {
+	attempts=0
+	copy_array array_topology_node_pairs array_topology_node_pairs_backcup
+	copy_array array_topology_node_pairs_stopped array_topology_node_pairs_stopped_backup
+	echo "Trying to find nodes to stop while avoiding network splitting..."
+	unset array_connected_nodes
+	while [ "${#array_connected_nodes[@]}" -lt "$( bc <<< "$node_count-$1" )" ] && [ "$attempts" -lt 10 ];
+        do
+		unset array_topology_node_pairs
+		copy_array array_topology_node_pairs_backcup array_topology_node_pairs
+		copy_array array_topology_node_pairs_stopped_backup array_topology_node_pairs_stopped
+		((attempts++))
+		shuffle_array "${array_active_nodes[@]}"
+		unset array_nodes_to_stop
+		for i in $(seq 0 1 $( bc <<< "$1 - 1" ));
+		do
+			array_nodes_to_stop[${shuffled_array[$i]}]=${shuffled_array[$i]}
+		done
+		check_stopping_nodes_cause_network_split "${array_nodes_to_stop[@]}"
+        done
+}
+
+function check_stopping_nodes_cause_network_split {
+	local local_array=("$@")
+	for i in ${!array_topology_node_pairs[@]};
+	do
+		local node_pair=(${array_topology_node_pairs[$i]})
+		for j in ${local_array[@]}
+		do
+			if [ "${node_pair[0]}" == "$j" ] || [ "${node_pair[1]}" == "$j" ];
+			then
+				array_topology_node_pairs_stopped[$i]=${array_topology_node_pairs[$i]}
+				unset array_topology_node_pairs[$i]
+				node_pair=()
+			fi
+		done
+	done
+	check_network_connected array_topology_node_pairs
+}
+
+function start_random_stopped_nodes {
+	local local_array=()
+	if [ ${#array_stopped_nodes[@]} == 0 ];
+	then
+		echo "All nodes are already active."
+	else
+		for i in ${!array_stopped_nodes[@]};
+		do
+			dice=$( bc <<< "$RANDOM % 2" )
+			if [ "$dice" -eq 1 ];
+			then
+				local_array[$i]=$i
+				start_stopped_node $i
+			else
+				echo skipping starting node $i
+			fi
+		done
+		echo Waiting 30 seconds for navcoind...
+		sleep 30
+		for j in ${!local_array[@]};
+		do
+			connect_node_to_network $j
+			echo "Nodes $j balance: $(nav_cli $j getbalance) tNAV"
+		done
+	fi
+	echo Currently active nodes are: ${array_active_nodes[@]} inactive ones are: ${array_stopped_nodes[@]}
+}
+
+function start_stopped_node {
+	echo Starting node $1...
+	start_node $1
+	unset array_stopped_nodes[$1]
+	array_active_nodes[$1]=$1
+	if [ -n ${array_stopped_stressing_nodes[$1]} ];
+	then
+		array_stressing_nodes[$1]=${array_stopped_stressing_nodes[$1]}
+		unset array_stopped_stressing_nodes[$1]
+	fi
+}
+
+function connect_node_to_network {
+	echo Connecting node $1 to the network...
+	for i in ${!array_topology_node_pairs_stopped[@]};
+	do
+	local node_connection=(${array_topology_node_pairs_stopped[$i]})
+		if [ "$1" == "${node_connection[0]}" ] || [ "$1" == "${node_connection[1]}" ];
+		then
+			local match=0
+			for k in ${array_stopped_nodes[@]};
+			do
+				if [ "$k" == "${node_connection[0]}" ] || [ "$k" == "${node_connection[1]}" ];
+				then
+					match=1
+				fi
+			done
+			if [ "$match" == 0 ] && [ -z ${array_topology_node_pairs[$i]} ];
+			then
+				array_topology_node_pairs[$i]=${array_topology_node_pairs_stopped[$i]}
+				unset array_topology_node_pairs_stopped[$i]
+			fi
+		fi
+	done
+	connect_network "${array_topology_node_pairs[@]}"
+}
+
+function wait_until_sync {
+	sleep 5
+	local local_array=("$@")
+	local local_array_best_hash=()
+	wait_until_sync_done=0
+	for i in ${local_array[@]};
+	do
+		local_array_best_hash[$i]=$(nav_cli $i getbestblockhash)
+		echo best block hash of node $i:
+		echo "$(nav_cli $i getbestblockhash)"
+	done
+	if [ $(printf "%s\n" "${local_array_best_hash[@]}" | LC_CTYPE=C sort -z -u | uniq | grep -n -c .) -gt 1 ];
+	then
+		echo best block hash mismatch!!!
+#		echo array topoloy node pairs is "${array_topology_node_pairs[@]}"
+#		echo array topology node pairs stopped is "${array_topology_node_pairs_stopped[@]}"
+		sleep 1
+		shuffle_array "${local_array[@]}"
+		node=${shuffled_array[0]}
+		$(nav_cli $node "generate 1")
+		echo now on blcok $(nav_cli $node "getblockcount")
+		if [ "$network_split_started" == 1 ];
+		then
+			for wusi in $(seq 0 1 $( bc <<< "$network_count-1" ));
+			do
+				echo Syncing network $wusi...
+				eval "connect_network \"\${array_topology_node_pairs_network$nc[@]}\""
+			done
+		else
+			connect_network "${array_topology_node_pairs[@]}"
+		fi
+		sleep 2
+		wait_until_sync "${local_array[@]}"
+	fi
+	if [ "$wait_until_sync_done" == 0 ];
+	then
+		echo Best block hashes matched!
+		wait_until_sync_done=1
+	fi
+}
+
+function random_transactions {
+	dice=$(bc <<< "$RANDOM % 100")
+	if [ $dice -lt 75 ];
+        then
+		transaction_amount=$( bc <<< "$RANDOM%1000" )
+		shuffle_array "${array_stressing_nodes[@]}"
+		node_send=${shuffled_array[0]}
+		node_receive=${shuffled_array[1]}
+		if [ $dice -lt 30 ];
+		then
+			out=$(nav_cli ${array_stressing_nodes[$node_send]} sendtoaddress ${array_address[$node_receive]} $transaction_amount)
+		else
+			out=$(nav_cli ${array_stressing_nodes[$node_send]} privatesendtoaddress ${array_address[$node_receive]} $transaction_amount)
+		fi
+	fi
+}
+
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+function dice_register_name {
+	dice=$(bc <<< "$RANDOM % 100")
+	if [ $dice -lt 50 ];
+	then
+                shuffle_array "${array_stressing_nodes[@]}"
+		namelength=$(bc <<< "$RANDOM %65")
+                node=${shuffled_array[0]}
+		random_name=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-\." < /dev/urandom | head -c $namelength)
+#		random_symbol=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-_\$\?" < /dev/urandom | head -c 3)
+		out=$(nav_cli $node registername $random_name.nav)
+		if [ ! -z $out ]
+		then
+			echo 'create name success!'
+			array_dotnavnames+=("$random_name.nav")
+			echo 'dotnavnames= ' ${array_dotnavnames[@]}
+		fi
+	fi
+}
+
+
+function dice_update_name {
+	dice=$(bc <<< "$RANDOM % 100")
+	if [ $dice -lt 80 ];
+	then
+                shuffle_array "${array_stressing_nodes[@]}"
+                node=${shuffled_array[0]}
+		subdomainlength=$(bc <<< "$RANDOM % 20 + 1")
+		for name in ${array_dotnavnames[@]}
+		do
+			random_key=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-\." < /dev/urandom | head -c $(bc <<< "$RANDOM % 10 + 1"))
+			random_value=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-\." < /dev/urandom | head -c $(bc<<< "$RANDOM % 20+ 1"))
+			random_subdomain=$(env LC_CTYPE=C tr -dc "a-zA-Z0-9-\." < /dev/urandom | head -c $(bc<<< "$RANDOM % $subdomainlength + 1"))
+			if [ $(bc <<< "$RANDOM % 3") -lt 2 ];
+			then
+				out=$(nav_cli $node updatename $name $random_key $random_value)
+				if [ ! -z $out ]
+				then
+					echo 'update name success!'
+				fi
+			else
+				out=$(nav_cli $node updatename $random_subdomain.$name $random_key $random_value)
+				if [ ! -z $out ]
+				then
+					echo 'update subdomain name success!'
+					array_dotnavnames+=("$random_subdomain.$name")
+					echo 'dotnavnames= ' ${array_dotnavnames[@]}
+				fi
+			fi
+		done
+	fi
+}
+
+function dice_renew_name {
+	dice=$(bc <<< "$RANDOM % 100")
+        if [ $dice -lt 50 ];
+        then
+		shuffle_array "${array_stressing_nodes[@]}"
+		nodee=${shuffled_array[0]}
+		shuffle_array "${array_dotnavnames[@]}"
+		name=${shuffled_array[0]}
+	        out=$(nav_cli $node renewname $name)
+		if [ ! -z $out ]
+		then
+			echo 'renew name success!'
+		fi
+        fi
+
+}
+
+function check_dotnav_hash {
+        sleep 1
+        local local_array=("$@")
+        local local_array_tokenhash=()
+        for i in ${local_array[@]};
+        do
+		echo 'Node ' $i ' resolving names'
+		local local_array_namehash=()
+		for name in ${array_dotnavnames[@]}
+		do
+			echo 'resolving name' $name
+			echo $(nav_cli $i resolvename $name)
+			local_array_namehash+=($(nav_cli $i resolvename $name | jq -c |shasum|awk '{print $1}'))
+		done
+		local_array_tokenhash[i]=$(echo ${local_array_namehash[@]} | shasum|awk '{print $1}')
+		echo best block hash of node $i:
+		echo "$(nav_cli $i getbestblockhash)"
+        done
+	echo 'all registered names=' ${array_dotnavnames[@]}
+	echo 'dot nav hashes = ' ${local_array_tokenhash[@]}
+
+        if [ $(printf "%s\n" "${local_array_tokenhash[@]}" | LC_CTYPE=C sort -z -u | uniq | grep -n -c .) -gt 1  ];
+        then
+                if [ "$bool_assert_state_mismatch" != 1 ];
+                then
+                        echo DOTNAV HASH MISMATCH! Syncing again to make sure best block hashes match.
+                        bool_assert_state_mismatch=1
+                        wait_until_sync "${local_array[@]}"
+                        check_dotnav_hash "${local_array[@]}"
+                else
+                        echo DOTNAV HASH MISMATCH!
+                        for i in ${!local_array_tokenhash[@]};
+                        do
+                                echo the dotnav hashes of nodes $i are ${local_array_tokenhash[$i]}
+                        done
+                        terminate 1
+                fi
+        fi
+        echo Dotnav hash check OK!
+        bool_assert_state_mismatch=0
+}
+
+
+function check_consensus_parameters {
+	consensusparameter_tmp=($(nav_cli $1 getconsensusparameters | tr -d "[],\n"))
+	if [ "${#consensusparameter_tmp[@]}" -gt 10 ];
+	then
+		copy_array consensusparameter_tmp consensusparameter_new
+	fi
+	for i in $(seq 0 1 $( bc <<< "${#consensusparameter_new[@]}-1" ));
+	do
+		if [ "${consensusparameter_new[$i]}" != "${consensusparameter_old[$i]}" ];
+		then
+			echo Consensus Parameter ${consensus_parameter_name[$i]} changed from ${consensusparameter_old[$i]} to ${consensusparameter_new[$i]}!!!
+		fi
+		done
+	consensusparameter_old=("${consensusparameter_new[@]}")
+}
+
+function stress {
+
+	for i in ${array_stressing_nodes[@]};
+	do
+		out=$(nav_cli $i "staking true")
+	done
+	time=$(bc <<< $(date +%s)+$1)
+	while [ $time -gt $(date +%s) ]
+	do
+		dice_register_name
+		dice_update_name
+		dice_renew_name
+		if [ "$bool_random_tx" == 1 ];
+		then
+			random_transactions
+		fi
+		check_cycle
+		sleep $stress_sleep_time
+	done
+}
+
+function check_node {
+	blocks=`nav_cli $2 getinfo|jq .blocks`
+	block_increment=${#array_verifychain_nodes[@]}
+	for i in $(seq $1 $block_increment $blocks);
+	do
+		verifyoutput=`nav_cli $2 verifychain 4 $i`
+		if [[ "$verifyoutput" == "false" ]];
+		then
+			verifyoutput+=`echo ' - ' && echo failed at $(grep 'ERROR: VerifyDB()' ${array_data[$2]}/devnet/debug.log |tail -1|sed 's/.*block at \(\d*\)/\1/')`
+			terminate 1
+		fi
+		echo Node $2 - Rewinding to \
+		$(bc <<< $blocks-$i) \
+		- reconnecting up to $blocks \
+		- verifychain 4 $i -\> $verifyoutput;
+	done
+	verifyoutput=`nav_cli $2 verifychain 4 0`
+	echo "Node $2 - Doing verifychain 4 0 -> $verifyoutput"
+	echo "node $2 finished"
+}
+
+function check_cycle {
+	shuffle_array "${array_stressing_nodes[@]}"
+	node=${shuffled_array[0]}
+	blocks=$(nav_cli $node getinfo|jq .blocks)
+	if [ "$( bc <<< "$blocks - $last_cycle_end_block_height" )" -gt  "$voting_cycle_length" ];
+	then
+		last_cycle_end_block_height=$(echo "$last_cycle_end_block_height+$voting_cycle_length" | bc )
+		voting_cycle_length=${consensusparameter_new[0]}
+		((this_cycle++))
+	fi
+}
+
+function random_verifychain_check {
+
+	echo "Performing random verifycahin check..."
+
+	echo "Selecting random verifychain nodes..."
+	shuffle_array "${array_active_nodes[@]}"
+	if [ "${#array_active_nodes[@]}" -lt 7 ];
+	then
+		for i in $(seq 0 1 $( bc <<< "${#array_active_nodes[@]} - 1" ));
+		do
+			array_verifychain_nodes[$i]=${shuffled_array[$i]}
+		done
+	else
+		for i in $(seq 0 1 7 );
+		do
+			array_verifychain_nodes[$i]=${shuffled_array[$i]}
+		done
+	fi
+	echo ''
+	echo Running verifychain test with node ${array_verifychain_nodes[@]}...
+	echo ''
+
+	starting_block=0
+	for i in ${!array_verifychain_nodes[@]};
+	do
+		((starting_block++))
+		check_node $starting_block ${array_verifychain_nodes[$i]} &
+	done
+	wait
+}
+
+function start_node {
+        $(echo $navpath)/navcoind -datadir=${array_data[$1]} -port=${array_p2p_port[$1]} -rpcport=${array_rpc_port[$1]} -devnet -daemon -debug=dao -debug=statehash -ntpminmeasures=-1 -dandelion=0 -disablesafemode -staking=0 2> /dev/null
+#       gdb -batch -ex "run" -ex "bt" --args $(echo $navpath)/navcoind -datadir=${array_data[$1]} -port=${array_p2p_port[$1]} -rpcport=${array_rpc_port[$1]} -devnet -debug=dao -debug=statehash -ntpminmeasures=0 -dandelion=0 -disablesafemode -staking=0 > out.gdb &
+}
+
+function stop_node {
+	out=$(nav_cli $1 stop)
+}
+
+##########################################################Script body
+
+initialize_network
+
+for i in $(seq 0 1 $( bc <<< "$node_count-1" ));
+do
+	initialize_node $i
+done
+
+echo ''
+echo Waiting 30 seconds for navcoind...
+
+#Sleep to let navoind boot up, on slower systems the value may need to be much higher
+sleep 30
+
+if [ "$node_count" == 1 ];
+then
+	array_stressing_nodes=0
+	array_verifychain_nodes=0
+	stressing_node_count=1
+else
+	if [ -z $array_topology ];
+	then
+		echo "Creating random network topology..."
+		create_random_network_topology "${array_active_nodes[@]}"
+		echo "Created topology that has ${#array_topology_node_pairs[@]} connections out of max connections ${#array_network_connection_pool[@]} in the network"
+		echo "Network topology: ${array_topology_node_pairs[@]}"
+	else
+		echo "Using speficyfied network topology ${array_topology_node_pairs[@]}"
+	fi
+
+
+	echo "running script with $stressing_node_count stressing nodes in a network of $node_count nodes"
+
+	if [ -z $array_stressing_nodes ];
+	then
+		echo "Selecting random stressing nodes..."
+		shuffle_array "${array_active_nodes[@]}"
+		for i in $(seq 0 1 $( bc <<< "$stressing_node_count-1" ));
+		do
+			array_stressing_nodes[${shuffled_array[$i]}]=${shuffled_array[$i]}
+		done
+	else
+		echo "Using specified stressing nodes"
+	fi
+
+	echo "array_stressing_nodes = ${array_stressing_nodes[@]}"
+
+	if [ -z $array_verifychain_nodes ];
+	then
+		echo "Selecting random verifychain nodes..."
+		shuffle_array "${array_active_nodes[@]}"
+		for i in $(seq 0 1 7);
+		do
+			array_verifychain_nodes[$i]=${shuffled_array[$i]}
+		done
+	else
+	        echo "Using specified verifychain nodes"
+	fi
+
+	echo "array_verifychain_nodes = ${array_verifychain_nodes[@]}"
+
+
+	connect_network "${array_topology_node_pairs[@]}"
+fi
+
+out=$(nav_cli 0 "generate 10")
+
+#Distribute funds to stressing nodes
+array_address=()
+for n in ${!array_stressing_nodes[@]};
+do
+        array_address[$n]=$(nav_cli ${array_stressing_nodes[$n]} getnewaddress)
+done
+for i in {1..10};
+do
+	for j in ${array_address[@]};
+	do
+		out=$(nav_cli 0 "sendtoaddress $j 10000")
+	done
+	out=$(nav_cli 0 "generate 1")
+done
+sleep 1
+for n in ${array_stressing_nodes[@]};
+do
+	echo "Node $n balance: $(nav_cli $n getbalance) NAV"
+done
+
+
+#Create blocks to make block count greater than 300
+blocks=$(nav_cli 0 getblockcount)
+echo 'blocks=' $blocks
+while [ $blocks -lt 300 ];
+do
+	out=$(nav_cli 0 "generate 10")
+	blocks=$(nav_cli 0 getblockcount)
+done
+
+echo 'Distributing xNAV to nodes...'
+
+array_private_address=()
+for n in ${!array_stressing_nodes[@]};
+do
+        array_private_address[$n]=$(nav_cli ${array_stressing_nodes[$n]} getnewprivateaddress)
+done
+for i in {1..10};
+do
+	for j in ${array_private_address[@]};
+	do
+		out=$(nav_cli 0 "sendtoaddress $j 10000")
+	done
+	out=$(nav_cli 0 "generate 1")
+done
+sleep 30
+for n in ${array_stressing_nodes[@]};
+do
+	echo "Node $n balance: $(nav_cli $n getwalletinfo | jq '.private_balance') xNAV"
+done
+
+out=$(nav_cli 0 "generate 10")
+donation=$(bc <<< "$RANDOM % 10000")
+out=$(nav_cli 0 "donatefund $donation")
+
+echo ''
+echo Waiting until all nodes are synced
+
+wait_until_sync "${array_active_nodes[@]}"
+
+consensus_parameter_count=$(nav_cli 0 getconsensusparameters | jq length)
+echo 'consensus parameter count =' $consensus_parameter_count
+for i in $(seq 0 1 $( bc <<< "$consensus_parameter_count - 1" ));
+do
+	eval "consensus_parameter_name[\$i]=\$(nav_cli 0 \"getconsensusparameters true\" | jq -r '.[] | select(.id==$i) | .desc')"
+done
+consensusparameter_old=($(nav_cli 0 getconsensusparameters | tr -d "[],\n"))
+consensusparameter_original=("${consensusparameter_old[@]}")
+voting_cycle_length=${consensusparameter_old[0]}
+blocks=$(nav_cli 0 getinfo|jq .blocks)
+initial_cycle=$(bc <<< $blocks/$voting_cycle_length)
+wait_until_cycle=$(bc <<< "$initial_cycle + $cycles")
+this_cycle=$(bc <<< $blocks/$voting_cycle_length)
+current_block=$(nav_cli 0 getinfo|jq .blocks)
+last_cycle_end_block_height=$( bc <<< "$blocks - $blocks % $voting_cycle_length" )
+shuffle_array "${array_stressing_nodes[@]}"
+node=${shuffled_array[0]}
+check_consensus_parameters $node
+node_count_to_stop=$(echo "sqrt($node_count)" | bc )
+
+while [ $wait_until_cycle -gt $this_cycle ]; do
+
+
+	echo ''
+	echo ''
+	echo Stressing for $seconds_round seconds...
+
+	stress $seconds_round
+
+	echo Waiting until nodes are synced...
+
+	wait_until_sync "${array_active_nodes[@]}"
+
+	for i in ${array_stressing_nodes[@]};
+	do
+		out=$(nav_cli $i "staking false")
+		echo "Node $i balance: $(nav_cli $i getwalletinfo | jq '.private_balance') xNAV"
+	done
+
+	echo Checking token hashes match...
+
+	check_dotnav_hash "${array_active_nodes[@]}"
+	shuffle_array "${array_stressing_nodes[@]}"
+	node=${shuffled_array[0]}
+	check_consensus_parameters $node
+
+	if [ "$node_count" == 1 ];
+	then
+		out=$(nav_cli 0 "generate 5")
+	fi
+
+	if [ "$bool_random_verifychain_check" == 1 ];
+	then
+		dice=$( bc <<< "$RANDOM % 60" )
+		if [ "$dice" == 1 ];
+		then
+			random_verifychain_check
+		fi
+	fi
+	if [ "$bool_stopstart_nodes" == 1 ];
+	then
+		dice=$( bc <<< "$RANDOM % 3" )
+		node_count_to_stop_this_round=$( bc <<< "$RANDOM % $node_count_to_stop + 1" )
+		if [ "${#array_active_nodes[@]}" -gt "$( bc <<< "$node_count_to_stop_this_round + 2" )" ];
+		then
+			if [ "$dice" != 1 ];
+			then
+				select_random_nodes_to_stop $node_count_to_stop_this_round
+				stop_selected_nodes
+			fi
+		fi
+		if [ "$dice" == 1 ];
+		then
+			start_random_stopped_nodes
+		fi
+	fi
+	if [ "$bool_random_new_topology" == 1 ];
+	then
+		dice=$( bc <<< "$RANDOM % 10" )
+		if [ "$dice" == 1 ];
+		then
+
+			attempts=0
+			copy_array array_topology_node_pairs array_topology_node_pairs_backcup
+			copy_array array_topology_node_pairs_stopped array_topology_node_pairs_stopped_backup
+			unset array_connected_nodes
+			echo "Trying to create a new network topology while avoiding network splitting..."
+			while [ "${#array_connected_nodes[@]}" -lt "${#array_active_nodes[@]}" ] && [ "$attempts" -lt 10 ];
+			do
+				copy_array array_topology_node_pairs_backup array_topology_node_pairs
+				copy_array array_topology_node_pairs_stopped_backup array_topology_node_pairs_stopped
+				create_random_network_topology ${array_all_nodes[@]}
+				unset array_topology_node_pairs_stopped
+				check_stopping_nodes_cause_network_split "${array_stopped_nodes[@]}"
+				((attempts++))
+			done
+			if [ "$attempts" == 10 ];
+			then
+				copy_array array_topology_node_pairs_backup array_topology_node_pairs
+				copy_array array_topology_node_pairs_stopped_backup array_topology_node_pairs_stopped
+			else
+				disconnect_network "${array_topology_node_pairs_backup[@]}"
+				connect_network "${array_topology_node_pairs[@]}"
+				echo "Created topology that has ${#array_topology_node_pairs[@]} connections out of max connections ${#array_network_connection_pool[@]} in the network"
+			fi
+			echo array topoloy node pairs is "${array_topology_node_pairs[@]}" with index "${!array_topology_node_pairs[@]}"
+			echo array topology node pairs stopped is "${array_topology_node_pairs_stopped[@]}" with index "${!array_topology_node_pairs_stopped[@]}"
+		fi
+	fi
+
+	if [ "$bool_sync_new_node" == 1 ];
+	then
+		dice=$( bc <<< "$RANDOM % 10" )
+		if [ "$dice" == 0 ];
+		then
+			echo Initializing a new node to test syncing from genesis...
+			shuffle_array "${array_active_nodes[@]}"
+			node=${shuffled_array[0]}
+			((node_count++))
+			array_topology_node_pairs+=("$node_count $node")
+			#echo "array topology node pairs is now ${array_topology_node_pairs[@]}"
+			initialize_node $node_count
+			echo Waiting 30 sec for navcoind...
+			sleep 30
+			connect_network "${array_topology_node_pairs[@]}"
+			sleep 30
+			wait_until_sync "${array_active_nodes[@]}"
+			check_dotnav_hash "${array_active_nodes[@]}"
+			echo Removing test sync node...
+			stop_node $node_count
+			sleep 30
+			remove_node $node_count
+			for i in ${!array_topology_node_pairs[@]};
+			do
+				unset connection
+				connection=(${array_topology_node_pairs[$i]})
+				if [ "$node_count" == "${connection[0]}" ] || [ "$node_count" == "${connection[1]}" ];
+				then
+					unset array_topology_node_pairs[$i]
+				fi
+			done
+			((node_count--))
+		fi
+	fi
+	cycles_left=$(bc <<< "$wait_until_cycle - $this_cycle")
+	previous_block=$current_block
+	current_block=$blocks
+	shuffle_array "${array_stressing_nodes[@]}"
+	node=${shuffled_array[0]}
+	echo Current block: $current_block Current cycle: $this_cycle - $cycles_left cycle\(s\) left to finish.
+	echo Tokens and NFTs created: $(nav_cli $node listtokens  | jq ".[].name" |  wc -l)
+	echo Active nodes: ${array_active_nodes[@]} Inactive nodes: ${array_stopped_nodes[@]}
+#	for j in $(seq 0 1 $( bc <<< "$node_count-1"));
+#	do
+#		echo Reorganizations Node $j: $(prev=0;for i in $(grep height= ${array_data[$j]}/devnet/debug.log|sed -n -e '/height\='$previous_block'/,$p'|sed -n 's/.*height\=\([0-9]*\) .*/\1/p'); do if [ $i -lt $prev ]; then echo $i; fi; prev=$i; done)
+#	done
+done
+
+##############################Network Splitting
+if [ "$bool_network_split" == 1 ];
+then
+	echo Stopping and then starting all nodes...
+	for i in ${array_active_nodes[@]};
+	do
+		echo Stopping node $i...
+		stop_node $i
+	done
+	sleep 10
+	for i in ${array_all_nodes[@]};
+	do
+		echo Starting node $i...
+		start_node $i
+	done
+	echo Waiting 30 sec for navcoind...
+	sleep 30
+	echo Splitting the network into $network_count sub networks...
+	network_split_started=1
+	counter=0
+	for i in ${array_stressing_nodes[@]};
+	do
+		if [ "$counter" == "$network_count" ];
+		then
+			counter=0
+		fi
+		eval "array_stressing_nodes_network$counter[$i]=$i"
+		eval "array_all_nodes_network$counter[$i]=$i"
+		((counter++))
+	done
+	counter=0
+	for i in ${array_all_nodes[@]};
+	do
+		if [ "$counter" == "$network_count" ];
+		then
+			counter=0
+		fi
+		match=0
+		for j in ${array_stressing_nodes[@]};
+		do
+			if [ "$j" == "$i" ];
+			then
+				match=1
+			fi
+		done
+		if [ "$match" != 1 ];
+		then
+			eval "array_all_nodes_network$counter[$i]=$i"
+		fi
+		((counter++))
+	done
+	copy_array array_topology_node_pairs array_topology_node_pairs_backup
+	for nc in $(seq 0 1 $( bc <<< "$network_count-1" ));
+	do
+		eval "echo stressing nodes in network $nc: \${array_stressing_nodes_network$nc[@]}"
+		eval "echo nodes in network $nc: \${array_all_nodes_network$nc[@]} index: \${!array_all_nodes_network$nc[@]}"
+		eval "create_random_network_topology \"\${array_all_nodes_network$nc[@]}\""
+		copy_array array_topology_node_pairs array_topology_node_pairs_network$nc
+		eval "echo topology of network$nc is: \"\${array_topology_node_pairs_network$nc[@]}\""
+		eval "connect_network \"\${array_topology_node_pairs_network$nc[@]}\""
+	done
+	wait_until_cycle=$(bc <<< "$this_cycle + $cycles_network_split")
+	while [ $wait_until_cycle -gt $this_cycle ]; do
+		echo ''
+		echo Stressing for $seconds_round seconds...
+		stress $seconds_round
+		for nc in $(seq 0 1 $( bc  <<< "$network_count - 1" ));
+		do
+			echo Waiting until nodes are synced...
+			eval "wait_until_sync \"\${array_all_nodes_network$nc[@]}\""
+			echo Checking token hashes match...
+			eval "check_dotnav_hash \"\${array_all_nodes_network$nc[@]}\""
+			eval "shuffle_array \"\${array_all_nodes_network$nc[@]}\""
+			node=${shuffled_array[0]}
+			check_consensus_parameters $node
+			blocks=$(nav_cli $node getinfo|jq .blocks)
+			echo Tokens and NFTs created: $(nav_cli $node listtokens  | jq ".[].name" |  wc -l)
+		done
+		cycles_left=$(bc <<< "$wait_until_cycle - $this_cycle")
+		previous_block=$current_block
+		current_block=$blocks
+		shuffle_array "${array_stressing_nodes[@]}"
+		node=${shuffled_array[0]}
+		echo Current block: $current_block
+		echo Current cycle: $this_cycle - $cycles_left cycle\(s\) left to finish.
+		for i in ${array_stressing_nodes[@]};
+		do
+			out=$(nav_cli $i "staking false")
+			echo "Node $i balance: $(nav_cli $i getwalletinfo | jq '.private_balance') xNAV"
+		done
+		done
+
+	create_random_network_topology "${array_all_nodes[@]}"
+	connect_network "${array_topology_node_pairs[@]}"
+	wait_until_sync "${array_all_nodes[@]}"
+	check_dotnav_hash "${array_all_nodes[@]}"
+fi
+#############################
+
+
+extra_blocks=$(bc <<< "($RANDOM%$extra_blocks_to_stake_randomness)+$extra_blocks_to_stake")
+blocks=$(nav_cli $node getinfo|jq .blocks)
+wait_until=$(bc <<< "$blocks+$extra_blocks")
+echo ''
+echo Stopping stresser. Waiting until $extra_blocks blocks are staked
+for i in ${array_stressing_nodes[@]};
+do
+	out=$(nav_cli $i "staking true")
+done
+while [ $blocks -lt $wait_until ];
+do
+	sleep 30
+	blocks=$(nav_cli $node getinfo|jq .blocks)
+	echo $(bc <<< "$wait_until-$blocks") blocks left...
+done
+for i in ${array_stressing_nodes[@]};
+do
+        out=$(nav_cli $i "staking false")
+done
+echo ''
+echo Waiting until all nodes are synced
+wait_until_sync "${array_active_nodes[@]}"
+echo Ok! Block: $(nav_cli $node getinfo|jq .blocks) Cycle: $(bc <<< $(nav_cli $node getinfo|jq .blocks)/$voting_cycle_length).
+echo Tokens and NFTs created: $(nav_cli $node listtokens  | jq ".[].name" |  wc -l)
+
+echo ''
+echo Running verifychain test with node ${verifychain_nodes[@]}...
+echo ''
+
+starting_block=0
+for i in ${!array_verifychain_nodes[@]};
+do
+	((starting_block++))
+	check_node $starting_block ${array_verifychain_nodes[$i]} &
+done
+
+wait
+
+for n in ${array_stressing_nodes[@]};
+do
+        echo "Node $n balance: $(nav_cli $n getbalance) tNAV"
+done
+
+
+echo "script finished successfully"
+terminate 0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -333,6 +333,7 @@ libnavcoin_consensus_a_SOURCES = \
   consensus/programs.h \
   consensus/program_actions.h \
   ctokens/ctokens.h \
+  ctokens/tokenid.h \
   dotnav/namedata.h \
   dotnav/namerecord.h \
   dotnav/names.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -329,9 +329,14 @@ libnavcoin_consensus_a_SOURCES = \
   consensus/merkle.h \
   consensus/params.h \
   consensus/validation.h \
+  consensus/programs.cpp \
   consensus/programs.h \
   consensus/program_actions.h \
   ctokens/ctokens.h \
+  dotnav/namedata.h \
+  dotnav/namerecord.h \
+  dotnav/names.h \
+  dotnav/names.cpp \
   aes_helper.c \
   blake.c \
   bmw.c \

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -255,7 +255,7 @@ public:
         try {
             return bls::PrivateKey::FromBytes(&k.front()).GetG1Element();
         } catch(...) {
-            return bls::G1Element();
+            return bls::PrivateKey::FromBN(Scalar::Rand().bn);
         }
     }
 
@@ -263,7 +263,7 @@ public:
         try {
             return bls::PrivateKey::FromBytes(&k.front());
         } catch(...) {
-            return bls::G1Element();
+            return bls::PrivateKey::FromBN(Scalar::Rand().bn);
         }
     }
 
@@ -276,7 +276,7 @@ public:
             bls::PrivateKey buf = bls::PrivateKey::FromBytes(&k.front());
             return bls::HDKeys::DeriveChildSk(buf, i);
         } catch(...) {
-            return bls::PrivateKey();
+            return bls::PrivateKey::FromBN(Scalar::Rand().bn);
         }
     }
 
@@ -294,7 +294,7 @@ public:
             }
             return ret;
         } catch(...) {
-            return bls::PrivateKey();
+            return  bls::PrivateKey::FromBN(Scalar::Rand().bn);
         }
     }
 

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -237,10 +237,14 @@ public:
     }
 
     bool operator<(const blsctKey& rhs) const {
-        Scalar l, r;
-        l = bls::PrivateKey::FromBytes(&k.front());
-        r = bls::PrivateKey::FromBytes(&(rhs.k).front());
-        return bn_cmp(l.bn, r.bn);
+        try {
+            Scalar l, r;
+            l = bls::PrivateKey::FromBytes(&k.front());
+            r = bls::PrivateKey::FromBytes(&(rhs.k).front());
+            return bn_cmp(l.bn, r.bn);
+        } catch (...) {
+            return false;
+        }
     }
 
     bool operator==(const blsctKey& rhs) const {
@@ -248,11 +252,19 @@ public:
     }
 
     bls::G1Element GetG1Element() const {
-        return bls::PrivateKey::FromBytes(&k.front()).GetG1Element();
+        try {
+            return bls::PrivateKey::FromBytes(&k.front()).GetG1Element();
+        } catch(...) {
+            return bls::G1Element();
+        }
     }
 
     bls::PrivateKey GetKey() const {
-        return bls::PrivateKey::FromBytes(&k.front());
+        try {
+            return bls::PrivateKey::FromBytes(&k.front());
+        } catch(...) {
+            return bls::G1Element();
+        }
     }
 
     Scalar GetScalar() const {
@@ -260,22 +272,30 @@ public:
     }
 
     bls::PrivateKey PrivateChild(uint32_t i) const {
-        bls::PrivateKey buf = bls::PrivateKey::FromBytes(&k.front());
-        return bls::HDKeys::DeriveChildSk(buf, i);
+        try {
+            bls::PrivateKey buf = bls::PrivateKey::FromBytes(&k.front());
+            return bls::HDKeys::DeriveChildSk(buf, i);
+        } catch(...) {
+            return bls::PrivateKey();
+        }
     }
 
     bls::PrivateKey PrivateChildHash(uint256 h) const {
-        bls::PrivateKey ret = bls::PrivateKey::FromBytes(&k.front());
-        for (auto i = 0; i < 8; i++)
-        {
-            const uint8_t* pos = h.begin() + i*4;
-            uint32_t index = (uint8_t)(pos[0]) << 24 |
-                    (uint8_t)(pos[1]) << 16 |
-                    (uint8_t)(pos[2]) << 8 |
-                    (uint8_t)(pos[3]);
-            ret = bls::HDKeys::DeriveChildSk(ret, index);
+        try {
+            bls::PrivateKey ret = bls::PrivateKey::FromBytes(&k.front());
+            for (auto i = 0; i < 8; i++)
+            {
+                const uint8_t* pos = h.begin() + i*4;
+                uint32_t index = (uint8_t)(pos[0]) << 24 |
+                                 (uint8_t)(pos[1]) << 16 |
+                                 (uint8_t)(pos[2]) << 8  |
+                                 (uint8_t)(pos[3]);
+                ret = bls::HDKeys::DeriveChildSk(ret, index);
+            }
+            return ret;
+        } catch(...) {
+            return bls::PrivateKey();
         }
-        return ret;
     }
 
     bls::G1Element PublicChild(uint32_t i) const {

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -267,7 +267,14 @@ public:
     bls::PrivateKey PrivateChildHash(uint256 h) const {
         bls::PrivateKey ret = bls::PrivateKey::FromBytes(&k.front());
         for (auto i = 0; i < 8; i++)
-            ret = bls::HDKeys::DeriveChildSk(ret, h.GetUint32(i*4));
+        {
+            const uint8_t* pos = h.begin() + i*4;
+            uint32_t index = (uint8_t)(pos[0]) << 24 |
+                    (uint8_t)(pos[1]) << 16 |
+                    (uint8_t)(pos[2]) << 8 |
+                    (uint8_t)(pos[3]);
+            ret = bls::HDKeys::DeriveChildSk(ret, index);
+        }
         return ret;
     }
 

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -255,7 +255,7 @@ public:
         try {
             return bls::PrivateKey::FromBytes(&k.front()).GetG1Element();
         } catch(...) {
-            return bls::PrivateKey::FromBN(Scalar::Rand().bn);
+            return bls::G1Element();
         }
     }
 

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -264,6 +264,13 @@ public:
         return bls::HDKeys::DeriveChildSk(buf, i);
     }
 
+    bls::PrivateKey PrivateChildHash(uint256 i) const {
+        bls::PrivateKey ret = bls::PrivateKey::FromBytes(&k.front());
+        for (auto i = 0; i < 8; i++)
+            ret = bls::HDKeys::DeriveChildSk(ret, i*4);
+        return ret;
+    }
+
     bls::G1Element PublicChild(uint32_t i) const {
         bls::PrivateKey buf = bls::PrivateKey::FromBytes(&k.front());
         return bls::HDKeys::DeriveChildSk(buf, i).GetG1Element();

--- a/src/blsct/key.h
+++ b/src/blsct/key.h
@@ -264,10 +264,10 @@ public:
         return bls::HDKeys::DeriveChildSk(buf, i);
     }
 
-    bls::PrivateKey PrivateChildHash(uint256 i) const {
+    bls::PrivateKey PrivateChildHash(uint256 h) const {
         bls::PrivateKey ret = bls::PrivateKey::FromBytes(&k.front());
         for (auto i = 0; i < 8; i++)
-            ret = bls::HDKeys::DeriveChildSk(ret, i*4);
+            ret = bls::HDKeys::DeriveChildSk(ret, h.GetUint32(i*4));
         return ret;
     }
 

--- a/src/blsct/verification.cpp
+++ b/src/blsct/verification.cpp
@@ -114,6 +114,14 @@ bool VerifyBLSCT(const CTransaction &tx, bls::PrivateKey viewKey, std::vector<Ra
                     txSigningKeys.push_back(program.kParameters[0]);
                     hash = tx.vout[j].GetHash();
                     vMessages.push_back(std::vector<unsigned char>(hash.begin(), hash.end()));
+                } else if (program.action == UPDATE_NAME_FIRST) {
+                    txSigningKeys.push_back(program.kParameters[0]);
+                    hash = tx.vout[j].GetHash();
+                    vMessages.push_back(std::vector<unsigned char>(hash.begin(), hash.end()));
+                } else if (program.action == UPDATE_NAME) {
+                    txSigningKeys.push_back(program.kParameters[0]);
+                    hash = tx.vout[j].GetHash();
+                    vMessages.push_back(std::vector<unsigned char>(hash.begin(), hash.end()));
                 } else if (program.action == MINT) {
                     txSigningKeys.push_back(program.kParameters[0]);
                     hash = tx.vout[j].GetHash();

--- a/src/blsct/verification.h
+++ b/src/blsct/verification.h
@@ -16,6 +16,7 @@
 #include <blsct/bulletproofs.h>
 #include <coins.h>
 #include <consensus/validation.h>
+#include <dotnav/names.h>
 #include <primitives/transaction.h>
 #include <random.h>
 #include <schemes.hpp>

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -150,6 +150,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 0;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -434,6 +435,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -689,7 +691,8 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 10 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
-        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 400; // 400 blocks
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;
@@ -955,6 +958,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -146,9 +146,10 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_MAX_SUPPORT_CYCLES].value = 4;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_REFLECTION_LENGTH].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_GENERATION_PER_BLOCK].value = 2.5 * COIN;
-        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 100 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 10 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 0;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -265,6 +266,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].bit = 33;
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nStartTime = 1637712000; // Nov 24th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nTimeout = 1700784000; // Nov 24th, 2023
+
+        // Deployment of dotNAV update
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].bit = 34;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nStartTime = 1637712000; // Nov 24th, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nTimeout = 1700784000; // Nov 24th, 2023
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -424,9 +430,10 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_MAX_SUPPORT_CYCLES].value = 4;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_REFLECTION_LENGTH].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_GENERATION_PER_BLOCK].value = 2.5 * COIN;
-        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 100 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 10 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -531,6 +538,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].bit = 33;
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nStartTime = 1633704250; // Oct 8th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nTimeout = 1700784000; // Nov 24th, 2023
+
+        // Deployment of dotNAV update
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].bit = 34;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nStartTime = 1633704250; // Nov 24th, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nTimeout = 1700784000; // Nov 24th, 2023
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -674,9 +686,10 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_MAX_SUPPORT_CYCLES].value = 4;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_REFLECTION_LENGTH].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_GENERATION_PER_BLOCK].value = 2.5 * COIN;
-        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 100 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 10 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;
@@ -780,6 +793,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].bit = 33;
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nStartTime = 1633704250; // Oct 8th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nTimeout = 1700784000; // Nov 24th, 2023
+
+        // Deployment of dotNAV update
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].bit = 34;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nStartTime = 1633704250; // Nov 24th, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nTimeout = 1700784000; // Nov 24th, 2023
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -933,9 +951,10 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_MAX_SUPPORT_CYCLES].value = 4;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_CONSULTATION_REFLECTION_LENGTH].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAM_GENERATION_PER_BLOCK].value = 2.5 * COIN;
-        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 100 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAM_NAVNS_FEE].value = 10 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE].value = 0.1 * COIN;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -1039,6 +1058,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].bit = 33;
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nStartTime = 1633704250; // Oct 8th, 2021
         consensus.vDeployments[Consensus::DEPLOYMENT_XNAV_SER].nTimeout = 1700784000; // Nov 24th, 2023
+
+        // Deployment of dotNAV update
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].bit = 34;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nStartTime = 1633704250; // Nov 24th, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_DOT_NAV].nTimeout = 1700784000; // Nov 24th, 2023
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,6 +151,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 0;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -436,6 +437,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -693,6 +695,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 400; // 400 blocks
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;
@@ -959,6 +962,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,7 +151,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 0;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
-        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 3 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -437,7 +437,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
-        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 3 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;
@@ -695,7 +695,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 400; // 400 blocks
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
-        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 3 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 5;
@@ -962,7 +962,7 @@ public:
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED].value = 1;
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH].value = 2880 * 400; // 400 days
         consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA].value = 1024; // 1KB
-        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 1 * COIN;
+        consensus.vParameters[Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA].value = 3 * COIN;
 
         /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
         consensus.nCoinbaseMaturity = 50;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -54,7 +54,7 @@ bool CStateView::GetConsultationAnswer(const uint256 &cid, CConsultationAnswer& 
 bool CStateView::GetConsensusParameter(const int &pid, CConsensusParameter& cparameter) const { return false; }
 bool CStateView::GetToken(const uint256 &id, TokenInfo& token) const { return false; }
 bool CStateView::GetNameRecord(const uint256 &id, NameRecordValue& height) const { return false; }
-bool CStateView::GetNameData(const uint256 &id, NameDataValues& data) const { return false; }
+bool CStateView::GetNameData(const uint256 &id, NameDataValues& data) { return false; }
 bool CStateView::HaveCoins(const uint256 &txid) const { return false; }
 bool CStateView::HaveProposal(const uint256 &pid) const { return false; }
 bool CStateView::HavePaymentRequest(const uint256 &prid) const { return false; }
@@ -93,7 +93,7 @@ bool CStateViewBacked::GetConsultationAnswer(const uint256 &cid, CConsultationAn
 bool CStateViewBacked::GetConsensusParameter(const int &pid, CConsensusParameter& cparameter) const { return base->GetConsensusParameter(pid, cparameter); }
 bool CStateViewBacked::GetToken(const uint256 &id, TokenInfo& token) const { return base->GetToken(id, token); }
 bool CStateViewBacked::GetNameRecord(const uint256 &id, NameRecordValue& height) const { return base->GetNameRecord(id, height); }
-bool CStateViewBacked::GetNameData(const uint256 &id, NameDataValues& data) const { return base->GetNameData(id, data); }
+bool CStateViewBacked::GetNameData(const uint256 &id, NameDataValues& data) { return base->GetNameData(id, data); }
 bool CStateViewBacked::HaveCoins(const uint256 &txid) const { return base->HaveCoins(txid); }
 bool CStateViewBacked::HaveProposal(const uint256 &pid) const { return base->HaveProposal(pid); }
 bool CStateViewBacked::HavePaymentRequest(const uint256 &prid) const { return base->HavePaymentRequest(prid); }
@@ -399,7 +399,7 @@ bool CStateViewCache::GetNameRecord(const uint256 &id, NameRecordValue &height) 
     return false;
 }
 
-bool CStateViewCache::GetNameData(const uint256 &id, NameDataValues &data) const {
+bool CStateViewCache::GetNameData(const uint256 &id, NameDataValues &data) {
     NameDataMap::const_iterator it = FetchNameData(id);
     if (it != cacheNameData.end() && it->second.size() > 0) {
         data = it->second;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -786,8 +786,13 @@ bool CStateViewCache::AddNameRecord(const NameRecord& namerecord) const {
 }
 
 bool CStateViewCache::AddNameData(const uint256& id, const NameDataEntry& namerecord) const {
-    if (cacheNameData.count(id))
+    if (cacheNameData.count(id)) {
+        cacheNameData[id].erase(
+            std::remove_if(cacheNameData[id].begin(), cacheNameData[id].end(),
+                [&namerecord](const NameDataEntry & o) { return o.first == namerecord.first && o.second.IsNull(); }),
+            cacheNameData[id].end());
         cacheNameData[id].push_back(namerecord);
+    }
     else
     {
         cacheNameData.insert(std::make_pair(id, NameDataValues()));

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -53,6 +53,8 @@ bool CStateView::GetConsultation(const uint256 &cid, CConsultation& consultation
 bool CStateView::GetConsultationAnswer(const uint256 &cid, CConsultationAnswer& answer) const { return false; }
 bool CStateView::GetConsensusParameter(const int &pid, CConsensusParameter& cparameter) const { return false; }
 bool CStateView::GetToken(const uint256 &id, TokenInfo& token) const { return false; }
+bool CStateView::GetNameRecord(const uint256 &id, NameRecordValue& height) const { return false; }
+bool CStateView::GetNameData(const uint256 &id, NameDataValues& data) const { return false; }
 bool CStateView::HaveCoins(const uint256 &txid) const { return false; }
 bool CStateView::HaveProposal(const uint256 &pid) const { return false; }
 bool CStateView::HavePaymentRequest(const uint256 &prid) const { return false; }
@@ -61,6 +63,8 @@ bool CStateView::HaveConsultation(const uint256 &cid) const { return false; }
 bool CStateView::HaveConsultationAnswer(const uint256 &cid) const { return false; }
 bool CStateView::HaveConsensusParameter(const int &pid) const { return false; }
 bool CStateView::HaveToken(const uint256 &id) const { return false; }
+bool CStateView::HaveNameRecord(const uint256 &id) const { return false; }
+bool CStateView::HaveNameData(const uint256 &id) const { return false; }
 bool CStateView::GetAllProposals(CProposalMap& map) { return false; }
 int CStateView::GetExcludeVotes() const { return 0; }
 bool CStateView::SetExcludeVotes(int count) { return 0; }
@@ -69,11 +73,13 @@ bool CStateView::GetAllVotes(CVoteMap& map) { return false; }
 bool CStateView::GetAllConsultations(CConsultationMap& map) { return false; }
 bool CStateView::GetAllConsultationAnswers(CConsultationAnswerMap& map) { return false; }
 bool CStateView::GetAllTokens(TokenMap& map) { return false; }
+bool CStateView::GetAllNameRecords(NameRecordMap& map) { return false; }
 uint256 CStateView::GetBestBlock() const { return uint256(); }
 bool CStateView::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals,
                             CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                             CConsultationMap& mapConsultations, CConsultationAnswerMap& mapAnswers,
                             CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                            NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
                             const uint256 &hashBlock, const int& nCacheExcludeVotes) { return false; }
 CStateViewCursor *CStateView::Cursor() const { return 0; }
 
@@ -86,6 +92,8 @@ bool CStateViewBacked::GetConsultation(const uint256 &cid, CConsultation &consul
 bool CStateViewBacked::GetConsultationAnswer(const uint256 &cid, CConsultationAnswer &answer) const { return base->GetConsultationAnswer(cid, answer); }
 bool CStateViewBacked::GetConsensusParameter(const int &pid, CConsensusParameter& cparameter) const { return base->GetConsensusParameter(pid, cparameter); }
 bool CStateViewBacked::GetToken(const uint256 &id, TokenInfo& token) const { return base->GetToken(id, token); }
+bool CStateViewBacked::GetNameRecord(const uint256 &id, NameRecordValue& height) const { return base->GetNameRecord(id, height); }
+bool CStateViewBacked::GetNameData(const uint256 &id, NameDataValues& data) const { return base->GetNameData(id, data); }
 bool CStateViewBacked::HaveCoins(const uint256 &txid) const { return base->HaveCoins(txid); }
 bool CStateViewBacked::HaveProposal(const uint256 &pid) const { return base->HaveProposal(pid); }
 bool CStateViewBacked::HavePaymentRequest(const uint256 &prid) const { return base->HavePaymentRequest(prid); }
@@ -94,6 +102,8 @@ bool CStateViewBacked::HaveConsultation(const uint256 &cid) const { return base-
 bool CStateViewBacked::HaveConsultationAnswer(const uint256 &cid) const { return base->HaveConsultationAnswer(cid); }
 bool CStateViewBacked::HaveConsensusParameter(const int &pid) const { return base->HaveConsensusParameter(pid); }
 bool CStateViewBacked::HaveToken(const uint256 &id) const { return base->HaveToken(id); }
+bool CStateViewBacked::HaveNameRecord(const uint256 &id) const { return base->HaveNameRecord(id); }
+bool CStateViewBacked::HaveNameData(const uint256 &id) const { return base->HaveNameData(id); }
 int CStateViewBacked::GetExcludeVotes() const { return base->GetExcludeVotes(); }
 bool CStateViewBacked::SetExcludeVotes(int count) { return base->SetExcludeVotes(count); }
 bool CStateViewBacked::GetCachedVoter(const CVoteMapKey &voter, CVoteMapValue& vote) const { return base->GetCachedVoter(voter, vote); }
@@ -103,14 +113,16 @@ bool CStateViewBacked::GetAllVotes(CVoteMap& map) { return base->GetAllVotes(map
 bool CStateViewBacked::GetAllConsultations(CConsultationMap& map) { return base->GetAllConsultations(map); }
 bool CStateViewBacked::GetAllConsultationAnswers(CConsultationAnswerMap& map) { return base->GetAllConsultationAnswers(map); }
 bool CStateViewBacked::GetAllTokens(TokenMap& map) { return base->GetAllTokens(map); }
+bool CStateViewBacked::GetAllNameRecords(NameRecordMap& map) { return base->GetAllNameRecords(map); }
 uint256 CStateViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CStateViewBacked::SetBackend(CStateView &viewIn) { base = &viewIn; }
 bool CStateViewBacked::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals,
                                   CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                                   CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
                                   CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                                  NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
                                   const uint256 &hashBlock, const int &nCacheExcludeVotes) {
-    return base->BatchWrite(mapCoins, mapProposals, mapPaymentRequests, mapVotes, mapConsultations, mapAnswers, mapConsensus, mapTokens, hashBlock, nCacheExcludeVotes);
+    return base->BatchWrite(mapCoins, mapProposals, mapPaymentRequests, mapVotes, mapConsultations, mapAnswers, mapConsensus, mapTokens, mapNameRecords, mapNameData, hashBlock, nCacheExcludeVotes);
 }
 CStateViewCursor *CStateViewBacked::Cursor() const { return base->Cursor(); }
 
@@ -266,6 +278,44 @@ TokenMap::const_iterator CStateViewCache::FetchToken(const uint256 &id) const {
     return ret;
 }
 
+NameRecordMap::const_iterator CStateViewCache::FetchNameRecord(const uint256 &id) const {
+    NameRecordMap::iterator it = cacheNameRecords.find(id);
+
+    if (it != cacheNameRecords.end())
+    {
+        return it;
+    }
+
+    NameRecordValue tmp;
+
+    if (!base->GetNameRecord(id, tmp) || tmp.IsNull())
+    {
+        return cacheNameRecords.end();
+    }
+
+    NameRecordMap::iterator ret = cacheNameRecords.insert(std::make_pair(id, NameRecordValue())).first;
+    tmp.swap(ret->second);
+
+    return ret;
+}
+
+NameDataMap::const_iterator CStateViewCache::FetchNameData(const uint256 &id) const {
+    NameDataMap::iterator it = cacheNameData.find(id);
+
+    if (it != cacheNameData.end())
+        return it;
+
+    NameDataValues tmp;
+
+    if (!base->GetNameData(id, tmp) || tmp.size() == 0)
+        return cacheNameData.end();
+
+    NameDataMap::iterator ret = cacheNameData.insert(std::make_pair(id, NameDataValues())).first;
+    tmp.swap(ret->second);
+
+    return ret;
+}
+
 
 bool CStateViewCache::GetCoins(const uint256 &txid, CCoins &coins) const {
     CCoinsMap::const_iterator it = FetchCoins(txid);
@@ -339,6 +389,25 @@ bool CStateViewCache::GetToken(const uint256 &id, TokenInfo &token) const {
     return false;
 }
 
+bool CStateViewCache::GetNameRecord(const uint256 &id, NameRecordValue &height) const {
+    NameRecordMap::const_iterator it = FetchNameRecord(id);
+    if (it != cacheNameRecords.end() && !it->second.IsNull()) {
+        height = it->second;
+        return true;
+    }
+
+    return false;
+}
+
+bool CStateViewCache::GetNameData(const uint256 &id, NameDataValues &data) const {
+    NameDataMap::const_iterator it = FetchNameData(id);
+    if (it != cacheNameData.end() && it->second.size() > 0) {
+        data = it->second;
+        return true;
+    }
+    return false;
+}
+
 bool CStateViewCache::GetAllProposals(CProposalMap& mapProposal) {
     mapProposal.clear();
     mapProposal.insert(cacheProposals.begin(), cacheProposals.end());
@@ -402,6 +471,25 @@ bool CStateViewCache::GetAllTokens(TokenMap& mapTokens) {
 
     for (auto it = mapTokens.begin(); it != mapTokens.end();)
         it->second.IsNull() ? mapTokens.erase(it++) : ++it;
+
+    return true;
+}
+
+bool CStateViewCache::GetAllNameRecords(NameRecordMap& mapNameRecords) {
+    mapNameRecords.clear();
+    mapNameRecords.insert(cacheNameRecords.begin(), cacheNameRecords.end());
+
+    NameRecordMap baseMap;
+
+    if (!base->GetAllNameRecords(baseMap))
+        return false;
+
+    for (NameRecordMap::iterator it = baseMap.begin(); it != baseMap.end(); it++)
+        if (!it->second.IsNull())
+            mapNameRecords.insert(std::make_pair(it->first, it->second));
+
+    for (auto it = mapNameRecords.begin(); it != mapNameRecords.end();)
+        it->second == 0 ? mapNameRecords.erase(it++) : ++it;
 
     return true;
 }
@@ -526,6 +614,28 @@ TokenModifier CStateViewCache::ModifyToken(const uint256 &id, int nHeight) {
         }
     }
     return TokenModifier(*this, ret.first, nHeight);
+}
+
+NameRecordModifier CStateViewCache::ModifyNameRecord(const uint256 &id, int nHeight) {
+    assert(!hasModifier);
+    std::pair<NameRecordMap::iterator, bool> ret = cacheNameRecords.insert(std::make_pair(id, 0));
+    if (ret.second) {
+        if (!base->GetNameRecord(id, ret.first->second)) {
+            ret.first->second = 0;
+        }
+    }
+    return NameRecordModifier(*this, ret.first, nHeight);
+}
+
+NameDataModifier CStateViewCache::ModifyNameData(const uint256 &id, int nHeight) {
+    assert(!hasModifier);
+    std::pair<NameDataMap::iterator, bool> ret = cacheNameData.insert(std::make_pair(id, NameDataValues()));
+    if (ret.second) {
+        if (!base->GetNameData(id, ret.first->second)) {
+            ret.first->second.clear();
+        }
+    }
+    return NameDataModifier(*this, ret.first, nHeight);
 }
 
 CPaymentRequestModifier CStateViewCache::ModifyPaymentRequest(const uint256 &prid, int nHeight) {
@@ -663,6 +773,30 @@ bool CStateViewCache::AddToken(const Token& token) const {
     return true;
 }
 
+bool CStateViewCache::AddNameRecord(const NameRecord& namerecord) const {
+    if (HaveNameRecord(namerecord.first))
+        return false;
+
+    if (cacheNameRecords.count(namerecord.first))
+        cacheNameRecords[namerecord.first]=namerecord.second;
+    else
+        cacheNameRecords.insert(std::make_pair(namerecord.first, namerecord.second));
+
+    return true;
+}
+
+bool CStateViewCache::AddNameData(const uint256& id, const NameDataEntry& namerecord) const {
+    if (cacheNameData.count(id))
+        cacheNameData[id].push_back(namerecord);
+    else
+    {
+        cacheNameData.insert(std::make_pair(id, NameDataValues()));
+        cacheNameData[id].push_back(namerecord);
+    }
+
+    return true;
+}
+
 bool CStateViewCache::RemoveProposal(const uint256 &pid) const {
     if (!HaveProposal(pid))
         return false;
@@ -683,6 +817,40 @@ bool CStateViewCache::RemoveToken(const uint256 &id) const {
     cacheTokens[id].SetNull();
 
     assert(cacheTokens[id].IsNull());
+
+    return true;
+}
+
+bool CStateViewCache::RemoveNameRecord(const uint256 &id) const {
+    if (!HaveNameRecord(id))
+        return false;
+
+    cacheNameRecords[id] = NameRecordValue();
+
+    assert(cacheNameRecords[id].IsNull());
+
+    return true;
+}
+
+bool CStateViewCache::RemoveNameData(const NameDataKey &id) const {
+    if (!HaveNameData(id.id))
+        return false;
+
+    if (cacheNameData.count(id.id))
+    {
+        NameDataValues temp;
+
+        for (auto& it: cacheNameData[id.id]) {
+            if (it.first == id.height) {
+                temp.push_back(NameDataEntry(id.height, NameDataValue()));
+            }
+            else {
+                temp.push_back(it);
+            }
+        }
+
+        cacheNameData[id.id] = temp;
+    }
 
     return true;
 }
@@ -787,6 +955,16 @@ bool CStateViewCache::HaveToken(const uint256 &id) const {
     return (it != cacheTokens.end() && !it->second.IsNull());
 }
 
+bool CStateViewCache::HaveNameRecord(const uint256 &id) const {
+    NameRecordMap::const_iterator it = FetchNameRecord(id);
+    return (it != cacheNameRecords.end() && !it->second.IsNull());
+}
+
+bool CStateViewCache::HaveNameData(const uint256 &id) const {
+    NameDataMap::const_iterator it = FetchNameData(id);
+    return (it != cacheNameData.end() && it->second.size());
+}
+
 bool CStateViewCache::HaveCachedVoter(const CVoteMapKey &voter) const {
     CVoteMap::const_iterator it = FetchVote(voter);
     // We're using vtx.empty() instead of IsPruned here for performance reasons,
@@ -833,7 +1011,8 @@ void CStateViewCache::SetBestBlock(const uint256 &hashBlockIn) {
 
 bool CStateViewCache::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals, CPaymentRequestMap &mapPaymentRequests,
                                  CVoteMap& mapVotes, CConsultationMap& mapConsultations, CConsultationAnswerMap& mapAnswers,
-                                 CConsensusParameterMap& mapConsensus, TokenMap& mapTokens, const uint256 &hashBlockIn, const int &nCacheExcludeVotesIn) {
+                                 CConsensusParameterMap& mapConsensus, TokenMap& mapTokens, NameRecordMap& mapNameRecords,
+                                 NameDataMap& mapNameData, const uint256 &hashBlockIn, const int &nCacheExcludeVotesIn) {
     assert(!hasModifier);
     assert(!hasModifierConsensus);
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
@@ -937,13 +1116,27 @@ bool CStateViewCache::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals
         mapTokens.erase(itOld);
     }
 
+    for (NameRecordMap::iterator it = mapNameRecords.begin(); it != mapNameRecords.end();) {
+        NameRecordValue& entry = cacheNameRecords[it->first];
+        entry.swap(it->second);
+        NameRecordMap::iterator itOld = it++;
+        mapNameRecords.erase(itOld);
+    }
+
+    for (NameDataMap::iterator it = mapNameData.begin(); it != mapNameData.end();) {
+        NameDataValues& entry = cacheNameData[it->first];
+        entry.swap(it->second);
+        NameDataMap::iterator itOld = it++;
+        mapNameData.erase(itOld);
+    }
+
     hashBlock = hashBlockIn;
     nCacheExcludeVotes = nCacheExcludeVotesIn;
     return true;
 }
 
 bool CStateViewCache::Flush() {
-    bool fOk = base->BatchWrite(cacheCoins, cacheProposals, cachePaymentRequests, cacheVotes, cacheConsultations, cacheAnswers, cacheConsensus, cacheTokens, hashBlock, nCacheExcludeVotes);
+    bool fOk = base->BatchWrite(cacheCoins, cacheProposals, cachePaymentRequests, cacheVotes, cacheConsultations, cacheAnswers, cacheConsensus, cacheTokens, cacheNameRecords, cacheNameData, hashBlock, nCacheExcludeVotes);
     cacheCoins.clear();
     cacheProposals.clear();
     cachePaymentRequests.clear();
@@ -952,6 +1145,8 @@ bool CStateViewCache::Flush() {
     cacheAnswers.clear();
     cacheConsensus.clear();
     cacheTokens.clear();
+    cacheNameRecords.clear();
+    cacheNameData.clear();
     cachedCoinsUsage = 0;
     nCacheExcludeVotes = -1;
     return fOk;
@@ -1194,6 +1389,48 @@ TokenModifier::~TokenModifier()
     {
         it->second.fDirty = true;
         LogPrint("daoextra", "%s: Modified %stoken %s\n", __func__, height>0?strprintf("at height %d ",height):"",it->first.ToString());
+    }
+}
+
+NameRecordModifier::NameRecordModifier(CStateViewCache& cache_, NameRecordMap::iterator it_, int height_) : cache(cache_), it(it_), height(height_) {
+    assert(!cache.hasModifier);
+    cache.hasModifier = true;
+    prev = it->second;
+}
+
+NameRecordModifier::~NameRecordModifier()
+{
+    assert(cache.hasModifier);
+    cache.hasModifier = false;
+
+    if (it->second.IsNull()) {
+        cache.cacheNameRecords[it->first].SetNull();
+    }
+
+    if (!(prev == it->second))
+    {
+        LogPrint("daoextra", "%s: Modified %sname record %s\n", __func__, height>0?strprintf("at height %d ",height):"",it->first.ToString());
+    }
+}
+
+NameDataModifier::NameDataModifier(CStateViewCache& cache_, NameDataMap::iterator it_, int height_) : cache(cache_), it(it_), height(height_) {
+    assert(!cache.hasModifier);
+    cache.hasModifier = true;
+    prev = it->second;
+}
+
+NameDataModifier::~NameDataModifier()
+{
+    assert(cache.hasModifier);
+    cache.hasModifier = false;
+
+    if (it->second.size() == 0) {
+        cache.cacheNameData[it->first].clear();
+    }
+
+    if (!(prev == it->second))
+    {
+        LogPrint("daoextra", "%s: Modified %sname data %s\n", __func__, height>0?strprintf("at height %d ",height):"",it->first.ToString());
     }
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -302,7 +302,7 @@ NameRecordMap::const_iterator CStateViewCache::FetchNameRecord(const uint256 &id
 NameDataMap::const_iterator CStateViewCache::FetchNameData(const uint256 &id) const {
     NameDataMap::iterator it = cacheNameData.find(id);
 
-    if (it != cacheNameData.end())
+    if (it != cacheNameData.end() && it->second.size() > 0)
         return it;
 
     NameDataValues tmp;

--- a/src/coins.h
+++ b/src/coins.h
@@ -391,7 +391,7 @@ public:
     virtual bool GetAllNameRecords(NameRecordMap& map);
     virtual bool HaveNameRecord(const uint256 &id) const;
 
-    virtual bool GetNameData(const uint256& id, NameDataValues& data) const;
+    virtual bool GetNameData(const uint256& id, NameDataValues& data);
     virtual bool HaveNameData(const uint256& id) const;
 
     virtual int GetExcludeVotes() const;
@@ -452,7 +452,7 @@ public:
     bool GetAllNameRecords(NameRecordMap& map);
     bool HaveNameRecord(const uint256 &id) const;
 
-    bool GetNameData(const uint256 &id, NameDataValues& data) const;
+    bool GetNameData(const uint256 &id, NameDataValues& data);
     bool HaveNameData(const uint256 &id) const;
 
     int GetExcludeVotes() const;
@@ -689,7 +689,7 @@ public:
     bool GetConsensusParameter(const int& pid, CConsensusParameter& cparameter) const;
     bool GetToken(const uint256& pid, TokenInfo& token) const;
     bool GetNameRecord(const uint256& pid, NameRecordValue& height) const;
-    bool GetNameData(const uint256& pid, NameDataValues& data) const;
+    bool GetNameData(const uint256& pid, NameDataValues& data);
     bool GetAllProposals(CProposalMap& map);
     bool GetAllPaymentRequests(CPaymentRequestMap& map);
     bool GetAllVotes(CVoteMap& map);

--- a/src/coins.h
+++ b/src/coins.h
@@ -15,6 +15,8 @@
 
 #include "consensus/dao.h"
 #include "ctokens/ctokens.h"
+#include "dotnav/namerecord.h"
+#include "dotnav/namedata.h"
 
 #include <assert.h>
 #include <stdint.h>
@@ -385,6 +387,13 @@ public:
     virtual bool GetAllTokens(TokenMap& map);
     virtual bool HaveToken(const uint256 &id) const;
 
+    virtual bool GetNameRecord(const uint256 &id, NameRecordValue& height) const;
+    virtual bool GetAllNameRecords(NameRecordMap& map);
+    virtual bool HaveNameRecord(const uint256 &id) const;
+
+    virtual bool GetNameData(const uint256& id, NameDataValues& data) const;
+    virtual bool HaveNameData(const uint256& id) const;
+
     virtual int GetExcludeVotes() const;
     virtual bool SetExcludeVotes(int count);
 
@@ -397,6 +406,7 @@ public:
                             CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                             CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
                             CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                            NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
                             const uint256 &hashBlock, const int &nCacheExcludeVotes);
 
     //! Get a cursor to iterate over the whole state
@@ -438,6 +448,13 @@ public:
     bool GetAllTokens(TokenMap& map);
     bool HaveToken(const uint256 &id) const;
 
+    bool GetNameRecord(const uint256 &id, NameRecordValue& height) const;
+    bool GetAllNameRecords(NameRecordMap& map);
+    bool HaveNameRecord(const uint256 &id) const;
+
+    bool GetNameData(const uint256 &id, NameDataValues& data) const;
+    bool HaveNameData(const uint256 &id) const;
+
     int GetExcludeVotes() const;
     bool SetExcludeVotes(int count);
 
@@ -447,6 +464,7 @@ public:
                     CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                     CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
                     CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                    NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
                     const uint256 &hashBlock, const int &nCacheExcludeVotes);
     CStateViewCursor *Cursor() const;
 };
@@ -571,6 +589,38 @@ public:
     friend class CStateViewCache;
 };
 
+class NameRecordModifier
+{
+private:
+    CStateViewCache& cache;
+    NameRecordMap::iterator it;
+    NameRecordModifier(CStateViewCache& cache_, NameRecordMap::iterator it_, int height=0);
+    NameRecordValue prev;
+    int height;
+
+public:
+    NameRecordValue* operator->() { return &it->second; }
+    NameRecordValue& operator*() { return it->second; }
+    ~NameRecordModifier();
+    friend class CStateViewCache;
+};
+
+class NameDataModifier
+{
+private:
+    CStateViewCache& cache;
+    NameDataMap::iterator it;
+    NameDataModifier(CStateViewCache& cache_, NameDataMap::iterator it_, int height=0);
+    NameDataValues prev;
+    int height;
+
+public:
+    NameDataValues* operator->() { return &it->second; }
+    NameDataValues& operator*() { return it->second; }
+    ~NameDataModifier();
+    friend class CStateViewCache;
+};
+
 class CConsultationAnswerModifier
 {
 private:
@@ -608,6 +658,8 @@ protected:
     mutable CConsultationAnswerMap cacheAnswers;
     mutable CConsensusParameterMap cacheConsensus;
     mutable TokenMap cacheTokens;
+    mutable NameRecordMap cacheNameRecords;
+    mutable NameDataMap cacheNameData;
     mutable int nCacheExcludeVotes;
 
     /* Cached dynamic memory usage for the inner CCoins objects. */
@@ -627,6 +679,8 @@ public:
     bool HaveConsultationAnswer(const uint256 &cid) const;
     bool HaveConsensusParameter(const int& pid) const;
     bool HaveToken(const uint256& id) const;
+    bool HaveNameRecord(const uint256& id) const;
+    bool HaveNameData(const uint256& id) const;
     bool GetProposal(const uint256 &txid, CProposal &proposal) const;
     bool GetPaymentRequest(const uint256 &txid, CPaymentRequest &prequest) const;
     bool GetCachedVoter(const CVoteMapKey &voter, CVoteMapValue& vote) const;
@@ -634,12 +688,15 @@ public:
     bool GetConsultationAnswer(const uint256 &cid, CConsultationAnswer& answer) const;
     bool GetConsensusParameter(const int& pid, CConsensusParameter& cparameter) const;
     bool GetToken(const uint256& pid, TokenInfo& token) const;
+    bool GetNameRecord(const uint256& pid, NameRecordValue& height) const;
+    bool GetNameData(const uint256& pid, NameDataValues& data) const;
     bool GetAllProposals(CProposalMap& map);
     bool GetAllPaymentRequests(CPaymentRequestMap& map);
     bool GetAllVotes(CVoteMap& map);
     bool GetAllConsultations(CConsultationMap& map);
     bool GetAllConsultationAnswers(CConsultationAnswerMap& map);
     bool GetAllTokens(TokenMap& map);
+    bool GetAllNameRecords(NameRecordMap& map);
     bool GetAnswersForConsultation(CConsultationAnswerMap& map, const uint256& parent);
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
@@ -647,17 +704,22 @@ public:
                     CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                     CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
                     CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                    NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
                     const uint256 &hashBlockIn, const int &nCacheExcludeVotes);
     bool AddProposal(const CProposal& proposal) const;
     bool AddPaymentRequest(const CPaymentRequest& prequest) const;
     bool AddCachedVoter(const CVoteMapKey &voter, CVoteMapValue& vote) const;
     bool AddConsultation(const CConsultation& consultation) const;
     bool AddToken(const Token& token) const;
+    bool AddNameRecord(const NameRecord& record) const;
+    bool AddNameData(const uint256& id, const NameDataEntry& record) const;
     bool AddConsultationAnswer(const CConsultationAnswer& answer);
     bool RemoveProposal(const uint256 &pid) const;
     bool RemovePaymentRequest(const uint256 &prid) const;
     bool RemoveCachedVoter(const CVoteMapKey &voter) const;
     bool RemoveToken(const uint256 &pid) const;
+    bool RemoveNameRecord(const uint256 &pid) const;
+    bool RemoveNameData(const NameDataKey &id) const;
     bool RemoveConsultation(const uint256 &cid);
     bool RemoveConsultationAnswer(const uint256 &cid);
 
@@ -694,6 +756,8 @@ public:
     CConsultationAnswerModifier ModifyConsultationAnswer(const uint256 &cid, int nHeight = 0);
     CConsensusParameterModifier ModifyConsensusParameter(const int &pid, int nHeight = 0);
     TokenModifier ModifyToken(const uint256 &id, int nHeight = 0);
+    NameRecordModifier ModifyNameRecord(const uint256 &id, int nHeight = 0);
+    NameDataModifier ModifyNameData(const uint256& id, int nHeight = 0);
 
     /**
      * Return a modifiable reference to a CCoins. Assumes that no entry with the given
@@ -755,6 +819,8 @@ public:
     friend class CConsultationAnswerModifier;
     friend class CConsensusParameterModifier;
     friend class TokenModifier;
+    friend class NameRecordModifier;
+    friend class NameDataModifier;
 
 private:
     CCoinsMap::iterator FetchCoins(const uint256 &txid);
@@ -766,6 +832,8 @@ private:
     CConsultationAnswerMap::const_iterator FetchConsultationAnswer(const uint256 &cid) const;
     CConsensusParameterMap::const_iterator FetchConsensusParameter(const int &pid) const;
     TokenMap::const_iterator FetchToken(const uint256 &id) const;
+    NameRecordMap::const_iterator FetchNameRecord(const uint256 &id) const;
+    NameDataMap::const_iterator FetchNameData(const uint256 &id) const;
 
     /**
      * By making the copy constructor private, we prevent accidentally using it when one intends to create a cache on top of a base cache.

--- a/src/consensus/daoconsensusparams.h
+++ b/src/consensus/daoconsensusparams.h
@@ -49,6 +49,7 @@ enum ConsensusParamsPos
     CONSENSUS_PARAM_NAVNS_FEE,
     CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE,
     CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED,
+    CONSENSUS_PARAMS_DOTNAV_LENGTH,
     MAX_CONSENSUS_PARAMS
 };
 
@@ -82,9 +83,10 @@ static std::string sConsensusParamsDesc[Consensus::MAX_CONSENSUS_PARAMS] = {
     "Percentage of generated NAV going to the Fund",
 
     "Amount of NAV generated per block",
-    "Yearly fee for registering a name in NavNS",
+    "Fee for registering a name in DotNAV",
     "Minimum fee as a fund contribution to submit a DAO vote using a light wallet",
-    "Confidential tokens enabled"
+    "Confidential tokens enabled",
+    "Length in blocks of a dotNAV registration"
 };
 
 static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
@@ -120,7 +122,8 @@ static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
     TYPE_NAV,
     TYPE_NAV,
     TYPE_NAV,
-    TYPE_BOOL
+    TYPE_BOOL,
+    TYPE_NUMBER
 };
 }
 

--- a/src/consensus/daoconsensusparams.h
+++ b/src/consensus/daoconsensusparams.h
@@ -51,6 +51,7 @@ enum ConsensusParamsPos
     CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED,
     CONSENSUS_PARAMS_DOTNAV_LENGTH,
     CONSENSUS_PARAMS_DOTNAV_MAXDATA,
+    CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA,
     MAX_CONSENSUS_PARAMS
 };
 
@@ -88,7 +89,8 @@ static std::string sConsensusParamsDesc[Consensus::MAX_CONSENSUS_PARAMS] = {
     "Minimum fee as a fund contribution to submit a DAO vote using a light wallet",
     "Confidential tokens enabled",
     "Length in blocks of a dotNAV registration",
-    "Max data in bytes attached to a dotNAV name"
+    "Max data in bytes attached to a dotNAV name without cost",
+    "Fee for attaching extra data to a name"
 };
 
 static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
@@ -126,7 +128,8 @@ static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
     TYPE_NAV,
     TYPE_BOOL,
     TYPE_NUMBER,
-    TYPE_NUMBER
+    TYPE_NUMBER,
+    TYPE_NAV
 };
 }
 

--- a/src/consensus/daoconsensusparams.h
+++ b/src/consensus/daoconsensusparams.h
@@ -50,6 +50,7 @@ enum ConsensusParamsPos
     CONSENSUS_PARAMS_DAO_VOTE_LIGHT_MIN_FEE,
     CONSENSUS_PARAMS_CONFIDENTIAL_TOKENS_ENABLED,
     CONSENSUS_PARAMS_DOTNAV_LENGTH,
+    CONSENSUS_PARAMS_DOTNAV_MAXDATA,
     MAX_CONSENSUS_PARAMS
 };
 
@@ -86,7 +87,8 @@ static std::string sConsensusParamsDesc[Consensus::MAX_CONSENSUS_PARAMS] = {
     "Fee for registering a name in DotNAV",
     "Minimum fee as a fund contribution to submit a DAO vote using a light wallet",
     "Confidential tokens enabled",
-    "Length in blocks of a dotNAV registration"
+    "Length in blocks of a dotNAV registration",
+    "Max data in bytes attached to a dotNAV name"
 };
 
 static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
@@ -123,6 +125,7 @@ static ConsensusParamType vConsensusParamsType[MAX_CONSENSUS_PARAMS] =
     TYPE_NAV,
     TYPE_NAV,
     TYPE_BOOL,
+    TYPE_NUMBER,
     TYPE_NUMBER
 };
 }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -39,6 +39,7 @@ enum DeploymentPos
     DEPLOYMENT_DAO_SUPER,
     DEPLOYMENT_BURN_FEES,
     DEPLOYMENT_XNAV_SER,
+    DEPLOYMENT_DOT_NAV,
     MAX_VERSION_BITS_DEPLOYMENTS,
 };
 
@@ -64,7 +65,9 @@ static std::string sDeploymentsDesc[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
     "Activates the privacy protocol blsCT and the private token xNAV",
     "Excludes inactive voters from the DAO quorums",
     "Enables Super proposals and allows combined vote of consensus parameters",
-    "Burns the transaction fees"
+    "Burns the transaction fees",
+    "Version 2 of XNAV (private tokens, nfts and optimizations)",
+    "Enables dotNAV"
 };
 
 /**

--- a/src/consensus/program_actions.h
+++ b/src/consensus/program_actions.h
@@ -12,7 +12,11 @@ enum ProgramActions
     CREATE_TOKEN,
     MINT,
     STOP_MINT,
-    BURN
+    BURN,
+    REGISTER_NAME,
+    UPDATE_NAME_FIRST,
+    UPDATE_NAME,
+    RENEW_NAME
 };
 
 #endif // PROGRAM_ACTIONS_H

--- a/src/consensus/programs.cpp
+++ b/src/consensus/programs.cpp
@@ -17,14 +17,16 @@ std::string PredicateToStr(const std::vector<unsigned char>& program) {
             ret += (p.sParameters[0]) +" ";
             ret += HexStr(p.kParameters[0].Serialize()) +" ";
             ret += (p.sParameters[1]) +" ";
-            ret += (p.sParameters[2]);
+            ret += (p.sParameters[2]) +" ";
+            ret += (p.sParameters[3]);
             break;
         case UPDATE_NAME_FIRST:
             ret += "UPDATE_NAME_FIRST: ";
             ret += (p.sParameters[0]) +" ";
             ret += HexStr(p.kParameters[0].Serialize()) +" ";
             ret += (p.sParameters[1]) +" ";
-            ret += (p.sParameters[2]);
+            ret += (p.sParameters[2]) +" ";
+            ret += (p.sParameters[3]);
             break;
         case STOP_MINT:
             ret += "STOP_MINT:";

--- a/src/consensus/programs.cpp
+++ b/src/consensus/programs.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2018-2021 The Navcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/programs.h>
+
+std::string PredicateToStr(const std::vector<unsigned char>& program) {
+    try {
+        Predicate p(program);
+
+        std::string ret = "";
+
+        switch(p.action)
+        {
+        case UPDATE_NAME:
+            ret += "UPDATE_NAME: ";
+            ret += (p.sParameters[0]) +" ";
+            ret += HexStr(p.kParameters[0].Serialize()) +" ";
+            ret += (p.sParameters[1]) +" ";
+            ret += (p.sParameters[2]);
+            break;
+        case UPDATE_NAME_FIRST:
+            ret += "UPDATE_NAME_FIRST: ";
+            ret += (p.sParameters[0]) +" ";
+            ret += HexStr(p.kParameters[0].Serialize()) +" ";
+            ret += (p.sParameters[1]) +" ";
+            ret += (p.sParameters[2]);
+            break;
+        case STOP_MINT:
+            ret += "STOP_MINT:";
+            ret += HexStr(p.kParameters[0].Serialize());
+            break;
+        case NO_PROGRAM:
+            ret += "NO_PROGRAM";
+            break;
+        case ERR:
+            ret += "ERR: "+HexStr(program);
+            break;
+        case CREATE_TOKEN:
+            ret += "CREATE_TOKEN: ";
+            ret += HexStr(p.kParameters[0].Serialize()) +" ";
+            ret += (p.sParameters[0]) +" ";
+            ret += std::to_string(p.nParameters[0]) +" ";
+            ret += (p.sParameters[1]) +" ";
+            ret += std::to_string(p.nParameters[1]);
+            break;
+        case MINT:
+            ret += "MINT: ";
+            ret += HexStr(p.kParameters[0].Serialize()) +" ";
+            ret += std::to_string(p.nParameters[0]) +" ";
+            ret += HexStr(p.vParameters[0]);
+            break;
+        case BURN:
+            ret += "BURN: ";
+
+            ret += std::to_string(p.nParameters[0]) +" ";
+            ret += HexStr(p.vParameters[0]);
+            break;
+        case REGISTER_NAME:
+            ret += "REGISTER_NAME: ";
+
+            ret += p.hParameters[0].ToString();
+            break;
+        case RENEW_NAME:
+            ret += "RENEW_NAME: ";
+
+            ret += p.sParameters[0];
+            break;
+        }
+        return ret;
+    }  catch (...) {
+        return "ERR";
+    }
+}

--- a/src/consensus/programs.h
+++ b/src/consensus/programs.h
@@ -10,6 +10,8 @@
 #include <bls.hpp>
 #include <streams.h>
 #include <consensus/program_actions.h>
+#include <utilstrencodings.h>
+#include <uint256.h>
 
 class Predicate
 {
@@ -20,6 +22,7 @@ public:
     std::vector<std::string> sParameters;
     std::vector<bls::G1Element> kParameters;
     std::vector<bls::G2Element> sigParameters;
+    std::vector<uint256> hParameters;
 
     Predicate(const ProgramActions& action_) : action(action_) {
         vParameters.clear();
@@ -27,6 +30,7 @@ public:
         sParameters.clear();
         kParameters.clear();
         sigParameters.clear();
+        hParameters.clear();
     }
 
     void Push(const std::vector<unsigned char>& parameter) {
@@ -35,6 +39,10 @@ public:
 
     void Push(const std::string& parameter) {
         sParameters.push_back(parameter);
+    }
+
+    void Push(const uint256& parameter) {
+        hParameters.push_back(parameter);
     }
 
     void Push(const uint64_t& parameter) {
@@ -117,6 +125,48 @@ public:
                 READWRITE(data);
                 Push(data);
             }
+            else if (action == REGISTER_NAME)
+            {
+                uint256 hash;
+                READWRITE(hash);
+                Push(hash);
+            }
+            else if (action == UPDATE_NAME_FIRST)
+            {
+                std::string name;
+                READWRITE(name);
+                Push(name);
+                bls::G1Element pk;
+                READWRITE(pk);
+                Push(pk);
+                std::string key;
+                READWRITE(key);
+                Push(key);
+                std::string value;
+                READWRITE(value);
+                Push(value);
+            }
+            else if (action == UPDATE_NAME)
+            {
+                std::string name;
+                READWRITE(name);
+                Push(name);
+                bls::G1Element pk;
+                READWRITE(pk);
+                Push(pk);
+                std::string key;
+                READWRITE(key);
+                Push(key);
+                std::string value;
+                READWRITE(value);
+                Push(value);
+            }
+            else if (action == RENEW_NAME)
+            {
+                std::string name;
+                READWRITE(name);
+                Push(name);
+            }
         } else {
             if (action == CREATE_TOKEN && kParameters.size() == 1 && sParameters.size() == 2 && nParameters.size() == 2)
             {
@@ -141,8 +191,32 @@ public:
                 READWRITE(nParameters[0]);
                 READWRITE(vParameters[0]);
             }
+            else if (action == REGISTER_NAME && hParameters.size() == 1)
+            {
+                READWRITE(hParameters[0]);
+            }
+            else if (action == UPDATE_NAME_FIRST && sParameters.size() == 3 && kParameters.size() == 1)
+            {
+                READWRITE(sParameters[0]);
+                READWRITE(kParameters[0]);
+                READWRITE(sParameters[1]);
+                READWRITE(sParameters[2]);
+            }
+            else if (action == UPDATE_NAME && sParameters.size() == 3 && kParameters.size() == 1)
+            {
+                READWRITE(sParameters[0]);
+                READWRITE(kParameters[0]);
+                READWRITE(sParameters[1]);
+                READWRITE(sParameters[2]);
+            }
+            else if (action == RENEW_NAME && sParameters.size() == 1)
+            {
+                READWRITE(sParameters[0]);
+            }
         }
     }
 };
+
+std::string PredicateToStr(const std::vector<unsigned char>& program);
 
 #endif // NAVCOIN_PROGRAMS_H

--- a/src/consensus/programs.h
+++ b/src/consensus/programs.h
@@ -139,6 +139,9 @@ public:
                 bls::G1Element pk;
                 READWRITE(pk);
                 Push(pk);
+                std::string subdomain;
+                READWRITE(subdomain);
+                Push(subdomain);
                 std::string key;
                 READWRITE(key);
                 Push(key);
@@ -154,6 +157,9 @@ public:
                 bls::G1Element pk;
                 READWRITE(pk);
                 Push(pk);
+                std::string subdomain;
+                READWRITE(subdomain);
+                Push(subdomain);
                 std::string key;
                 READWRITE(key);
                 Push(key);
@@ -195,19 +201,21 @@ public:
             {
                 READWRITE(hParameters[0]);
             }
-            else if (action == UPDATE_NAME_FIRST && sParameters.size() == 3 && kParameters.size() == 1)
+            else if (action == UPDATE_NAME_FIRST && sParameters.size() == 4 && kParameters.size() == 1)
             {
                 READWRITE(sParameters[0]);
                 READWRITE(kParameters[0]);
                 READWRITE(sParameters[1]);
                 READWRITE(sParameters[2]);
+                READWRITE(sParameters[3]);
             }
-            else if (action == UPDATE_NAME && sParameters.size() == 3 && kParameters.size() == 1)
+            else if (action == UPDATE_NAME && sParameters.size() == 4 && kParameters.size() == 1)
             {
                 READWRITE(sParameters[0]);
                 READWRITE(kParameters[0]);
                 READWRITE(sParameters[1]);
                 READWRITE(sParameters[2]);
+                READWRITE(sParameters[3]);
             }
             else if (action == RENEW_NAME && sParameters.size() == 1)
             {

--- a/src/dotnav/namedata.h
+++ b/src/dotnav/namedata.h
@@ -112,9 +112,9 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(subdomain);
         READWRITE(key);
         READWRITE(value);
+        READWRITE(subdomain);
     }
 };
 

--- a/src/dotnav/namedata.h
+++ b/src/dotnav/namedata.h
@@ -77,6 +77,7 @@ public:
 
 class NameDataValue {
 public:
+    std::string subdomain;
     std::string key;
     std::string value;
 
@@ -84,24 +85,26 @@ public:
         SetNull();
     }
 
-    NameDataValue(const std::string& key_, const std::string& value_) :  key(key_), value(value_) {
+    NameDataValue(const std::string& key_, const std::string& value_, const std::string& subdomain_="") :  key(key_), value(value_), subdomain(subdomain_) {
     };
 
     void SetNull() {
         key = "";
         value = "";
+        subdomain = "";
     }
 
     bool IsNull() const {
-        return key == "" && value == "";
+        return key == "" && value == "" && subdomain == "";
     }
 
     bool operator==(const NameDataValue& other) const {
-        return (key == other.key && value == other.value);
+        return (key == other.key && value == other.value && subdomain == other.subdomain);
     }
 
     void swap(NameDataValue &to) {
         std::swap(to.key, key);
+        std::swap(to.subdomain, subdomain);
         std::swap(to.value, value);
     }
 
@@ -109,6 +112,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(subdomain);
         READWRITE(key);
         READWRITE(value);
     }

--- a/src/dotnav/namedata.h
+++ b/src/dotnav/namedata.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Navcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NAVCOIN_NAME_DATA_H
+#define NAVCOIN_NAME_DATA_H
+
+#include <uint256.h>
+#include <hash.h>
+
+class NameDataKey {
+public:
+    uint256 id;
+    uint64_t height;
+    uint64_t key;
+
+    NameDataKey() {
+        SetNull();
+    }
+
+    NameDataKey(const std::string& name_, const uint64_t& height_, const std::string& key_ = "") :  id(SerializeHash(name_)), height(height_), key(key_ != "" ? SerializeHash(key_).GetCheapHash() : 0) {
+    };
+
+    NameDataKey(const uint256& id_, const uint64_t& height_, const std::string& key_ = "") :  id(id_), height(height_), key(key_ != "" ? SerializeHash(key_).GetCheapHash() : 0) {
+    };
+
+    void SetNull() {
+        height = 0;
+        key = 0;
+        id = uint256();
+    }
+
+    bool IsNull() const {
+        return height == 0 && id == uint256() && key == 0;
+    }
+
+    bool operator==(const NameDataKey& other) const {
+        return (height == other.height && id == other.id && key == other.key);
+    }
+
+    void swap(NameDataKey &to) {
+        std::swap(to.height, height);
+        std::swap(to.id, id);
+        std::swap(to.key, key);
+    }
+
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 32 + 8 + 8;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        id.Serialize(s, nType, nVersion);
+        ser_writedata32be(s, height);
+        if (key != 0)
+            ser_writedata32be(s, key);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        id.Unserialize(s, nType, nVersion);
+        height = ser_readdata32be(s);
+        key = ser_readdata32be(s);
+    }
+
+    bool operator<(const NameDataKey& b) const {
+        if (id == b.id) {
+            if (height == b.height) {
+                return key < b.key;
+            }
+            return height < b.height;
+        } else {
+            return id < b.id;
+        }
+    }
+};
+
+class NameDataValue {
+public:
+    std::string key;
+    std::string value;
+
+    NameDataValue() {
+        SetNull();
+    }
+
+    NameDataValue(const std::string& key_, const std::string& value_) :  key(key_), value(value_) {
+    };
+
+    void SetNull() {
+        key = "";
+        value = "";
+    }
+
+    bool IsNull() const {
+        return key == "" && value == "";
+    }
+
+    bool operator==(const NameDataValue& other) const {
+        return (key == other.key && value == other.value);
+    }
+
+    void swap(NameDataValue &to) {
+        std::swap(to.key, key);
+        std::swap(to.value, value);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(key);
+        READWRITE(value);
+    }
+};
+
+typedef std::pair<uint64_t, NameDataValue> NameDataEntry;
+typedef std::vector<NameDataEntry> NameDataValues;
+typedef std::map<uint256, NameDataValues> NameDataMap;
+
+#endif

--- a/src/dotnav/namerecord.h
+++ b/src/dotnav/namerecord.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Navcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NAVCOIN_NAME_RECORD_H
+#define NAVCOIN_NAME_RECORD_H
+
+#include <uint256.h>
+
+class NameRecordValue {
+public:
+    uint64_t height;
+    uint32_t nVersion;
+    bool fDirty;
+
+    NameRecordValue() {
+        SetNull();
+    }
+
+    NameRecordValue(const uint64_t& height_) :  height(height_), nVersion(0) {
+    };
+
+    void SetNull() {
+        height = -1;
+        nVersion = -1;
+        fDirty = false;
+    }
+
+    bool IsNull() const {
+        return height == -1 && nVersion == -1;
+    }
+
+    bool operator==(const NameRecordValue& other) {
+        return (height == other.height && nVersion == other.nVersion);
+    }
+
+    void swap(NameRecordValue &to) {
+        std::swap(to.nVersion, nVersion);
+        std::swap(to.height, height);
+        std::swap(to.fDirty, fDirty);
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(this->nVersion);
+        READWRITE(height);
+    }
+};
+
+typedef std::map<uint256, NameRecordValue> NameRecordMap;
+typedef std::pair<uint256, NameRecordValue> NameRecord;
+
+
+#endif

--- a/src/dotnav/names.cpp
+++ b/src/dotnav/names.cpp
@@ -112,7 +112,12 @@ std::map<std::string, std::string> Consolidate(const NameDataValues& data, const
 
     for (auto &it: data) {
         if (it.second.key == "_expiry")
+        {
             nExpiry = stoll(it.second.value);
+        }
+    }
+
+    for (auto &it: data) {
         if (nExpiry > height && it.first <= height && (it.second.subdomain == subdomain || it.second.key.substr(0,1) == "_")) {
             if (it.second.value != "")
                 ret[it.second.key] = it.second.value;

--- a/src/dotnav/names.cpp
+++ b/src/dotnav/names.cpp
@@ -25,18 +25,24 @@ bool IsValid(const std::string& name_)
 {
     auto name = to_lower(name_);
 
-    return name.substr(1, name.size()-5).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
-            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz") == std::string::npos &&
-            name.size() <= 64 && name.size() >= 5 && name.substr(name.size()-4, 4) == ".nav";
+    if (name.size() == 0)
+        return false;
+
+    return name.substr(1, name.size()-5).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789-") == std::string::npos &&
+            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
+            name.size() < 64 && name.size() >= 5 && name.substr(name.size()-4, 4) == ".nav";
 }
 
 bool IsValidKey(const std::string& name_)
 {
     auto name = to_lower(name_);
 
-    return name.substr(1).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
-            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz") == std::string::npos &&
-            name.size() <= 64 && name.size() >= 1;
+    if (name.size() == 0)
+        return false;
+
+    return name.find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789-") == std::string::npos &&
+            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
+            name.size() < 64 && name.size() >= 1;
 }
 
 uint256 GetHashIdName(const std::string& name, const bls::G1Element& key)
@@ -69,41 +75,60 @@ std::vector<unsigned char> GetRenewProgram(const std::string& name)
     return ret.GetVchData();
 }
 
-std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value)
+std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value, const std::string& subdomain)
 {
     auto name_ = to_lower(name);
     auto key_ = to_lower(key);
+    auto subdomain_ = to_lower(subdomain);
 
     Predicate ret(UPDATE_NAME);
     ret.Push(name_);
     ret.Push(pk);
+    ret.Push(subdomain_);
     ret.Push(key_);
     ret.Push(value);
     return ret.GetVchData();
 }
 
-std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value)
+std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value, const std::string& subdomain)
 {
     auto name_ = to_lower(name);
     auto key_ = to_lower(key);
+    auto subdomain_ = to_lower(subdomain);
 
     Predicate ret(UPDATE_NAME_FIRST);
     ret.Push(name_);
     ret.Push(pk);
+    ret.Push(subdomain_);
     ret.Push(key_);
     ret.Push(value);
     return ret.GetVchData();
 }
 
-std::map<std::string, std::string> Consolidate(const NameDataValues& data)
+std::map<std::string, std::string> Consolidate(const NameDataValues& data, const int32_t& height, const std::string& subdomain)
 {
     std::map<std::string, std::string> ret;
+    uint64_t nExpiry = ~(uint64_t)0;
 
     for (auto &it: data) {
-        if (it.second.value != "")
-            ret[it.second.key] = it.second.value;
-        else if (ret.count(it.second.key))
-            ret.erase(it.second.key);
+        if (it.second.key == "_expiry")
+            nExpiry = stoll(it.second.value);
+        if (nExpiry > height && it.first <= height && (it.second.subdomain == subdomain || it.second.key.substr(0,1) == "_")) {
+            if (it.second.value != "")
+                ret[it.second.key] = it.second.value;
+            else if (ret.count(it.second.key))
+                ret.erase(it.second.key);
+        }
+    }
+
+    return ret;
+}
+
+size_t CalculateSize(const std::map<std::string, std::string>& map) {
+    size_t ret = 0;
+
+    for (auto &it: map) {
+        ret += it.first.size() + it.second.size();
     }
 
     return ret;

--- a/src/dotnav/names.cpp
+++ b/src/dotnav/names.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Navcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <dotnav/names.h>
+
+namespace DotNav
+{
+
+std::string to_lower(const std::string& str) {
+    std::string ret;
+
+    ret.resize(str.size());
+
+    std::transform(str.begin(),
+                   str.end(),
+                   ret.begin(),
+                   ::tolower);
+
+    return ret;
+}
+bool IsValid(const std::string& name_)
+{
+    auto name = to_lower(name_);
+
+    return name.substr(1, name.size()-5).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
+            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz") == std::string::npos &&
+            name.size() <= 64 && name.size() >= 5 && name.substr(name.size()-4, 4) == ".nav";
+}
+
+bool IsValidKey(const std::string& name_)
+{
+    auto name = to_lower(name_);
+
+    return name.substr(1).find_first_not_of("abcdefghijklmnopqrstuvwxyz01234566789") == std::string::npos &&
+            name.substr(0, 1).find_first_not_of("abcdefghijklmnopqrstuvwxyz") == std::string::npos &&
+            name.size() <= 64 && name.size() >= 1;
+}
+
+uint256 GetHashIdName(const std::string& name, const bls::G1Element& key)
+{
+    auto name_ = to_lower(name);
+
+    return SerializeHash(name_ + HexStr(key.Serialize()));
+}
+
+uint256 GetHashName(const std::string& name)
+{
+    auto name_ = to_lower(name);
+
+    return SerializeHash(name_);
+}
+
+std::vector<unsigned char> GetRegisterProgram(const std::string& name, const bls::G1Element& key)
+{
+    Predicate ret(REGISTER_NAME);
+    ret.Push(GetHashIdName(name, key));
+    return ret.GetVchData();
+}
+
+std::vector<unsigned char> GetRenewProgram(const std::string& name)
+{
+    auto name_ = to_lower(name);
+
+    Predicate ret(RENEW_NAME);
+    ret.Push(name_);
+    return ret.GetVchData();
+}
+
+std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value)
+{
+    auto name_ = to_lower(name);
+    auto key_ = to_lower(key);
+
+    Predicate ret(UPDATE_NAME);
+    ret.Push(name_);
+    ret.Push(pk);
+    ret.Push(key_);
+    ret.Push(value);
+    return ret.GetVchData();
+}
+
+std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value)
+{
+    auto name_ = to_lower(name);
+    auto key_ = to_lower(key);
+
+    Predicate ret(UPDATE_NAME_FIRST);
+    ret.Push(name_);
+    ret.Push(pk);
+    ret.Push(key_);
+    ret.Push(value);
+    return ret.GetVchData();
+}
+
+std::map<std::string, std::string> Consolidate(const NameDataValues& data)
+{
+    std::map<std::string, std::string> ret;
+
+    for (auto &it: data) {
+        if (it.second.value != "")
+            ret[it.second.key] = it.second.value;
+        else if (ret.count(it.second.key))
+            ret.erase(it.second.key);
+    }
+
+    return ret;
+}
+}

--- a/src/dotnav/names.h
+++ b/src/dotnav/names.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2021 The Navcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef NAVCOIN_NAMES_H
+#define NAVCOIN_NAMES_H
+
+#include <consensus/programs.h>
+#include <dotnav/namedata.h>
+#include <utilstrencodings.h>
+#include <util.h>
+#include <hash.h>
+#include <locale>
+
+namespace DotNav
+{
+
+std::string to_lower(const std::string& str);
+bool IsValid(const std::string& name);
+bool IsValidKey(const std::string& name);
+
+uint256 GetHashIdName(const std::string& name, const bls::G1Element& key);
+
+uint256 GetHashName(const std::string& name);
+
+std::vector<unsigned char> GetRegisterProgram(const std::string& name, const bls::G1Element& key);
+
+std::vector<unsigned char> GetRenewProgram(const std::string& name);
+
+std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value);
+
+std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value);
+
+std::map<std::string, std::string> Consolidate(const NameDataValues& data);
+}
+
+#endif // NAVCOIN_

--- a/src/dotnav/names.h
+++ b/src/dotnav/names.h
@@ -29,11 +29,13 @@ std::vector<unsigned char> GetRegisterProgram(const std::string& name, const bls
 
 std::vector<unsigned char> GetRenewProgram(const std::string& name);
 
-std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value);
+std::vector<unsigned char> GetUpdateProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value, const std::string& subdomain="");
 
-std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value);
+std::vector<unsigned char> GetUpdateFirstProgram(const std::string& name, const bls::G1Element& pk, const std::string& key, const std::string& value, const std::string& subdomain="");
 
-std::map<std::string, std::string> Consolidate(const NameDataValues& data);
+std::map<std::string, std::string> Consolidate(const NameDataValues& data, const int32_t& nHeight, const std::string& subdomain="");
+
+size_t CalculateSize(const std::map<std::string, std::string>& map);
 }
 
 #endif // NAVCOIN_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4971,7 +4971,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         }
                     }
                 } catch(...) {
-                    return state.DoS(100, false, REJECT_INVALID, strprintf("error-program-vdata:%s", program.sParameters[0]));
+                    return state.DoS(100, false, REJECT_INVALID, "error-program-vdata");
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1606,7 +1606,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                     return state.DoS(100, false, REJECT_INVALID, "renew-name-missing-contribution");
                                 NameDataValues data;
 
-                                if (viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                     if (!mapData.count("_key"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1506,7 +1506,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
 
                                 NameRecordValue recordvalue;
 
-                                if (!view.GetNameRecord(DotNav::GetHashIdName(program.sParameters[0], program.kParameters[0]), recordvalue))
+                                if (!viewMemPool.GetNameRecord(DotNav::GetHashIdName(program.sParameters[0], program.kParameters[0]), recordvalue))
                                     return state.DoS(100, false, REJECT_INVALID, "wrong-salt-name");
 
                                 if (chainActive.Tip()->nHeight-recordvalue.height < 6)
@@ -1514,7 +1514,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
 
                                 NameDataValues data;
 
-                                if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                     if (mapData.count("_key"))
@@ -1541,13 +1541,13 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                     }
                                 }
 
-                                if (!view.AddNameData(DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue("_expiry", std::to_string(chainActive.Tip()->nHeight+GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH, view))))))
+                                if (!viewMemPool.AddNameData(hash, DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue("_expiry", std::to_string(chainActive.Tip()->nHeight+GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_LENGTH, view))))))
                                     return state.DoS(100, false, REJECT_INVALID, "name-could-not-update");
-                                if (!view.AddNameData(DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue("_key", HexStr(program.kParameters[0].Serialize())))))
+                                if (!viewMemPool.AddNameData(hash, DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue("_key", HexStr(program.kParameters[0].Serialize())))))
                                     return state.DoS(100, false, REJECT_INVALID, "name-could-not-update");
-                                if (!view.AddNameData(DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue(program.sParameters[2], program.sParameters[3], program.sParameters[1]))))
+                                if (!viewMemPool.AddNameData(hash, DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue(program.sParameters[2], program.sParameters[3], program.sParameters[1]))))
                                     return state.DoS(100, false, REJECT_INVALID, "name-could-not-update");
-                                if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                     if (!(txout.scriptPubKey.IsCommunityFundContribution() && txout.nValue >= std::floor(DotNav::CalculateSize(mapData)/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view)))
@@ -1559,7 +1559,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                 LogPrint("dotnav", "%s: updated name first %s %s %s %s\n", __func__, program.sParameters[1], program.sParameters[0], program.sParameters[2], program.sParameters[3]);
                             } else if (program.action == UPDATE_NAME) {
                                 NameDataValues data;
-                                if (!view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (!viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                     return state.DoS(100, false, REJECT_INVALID, strprintf("error-name:%s", program.sParameters[0]));
                                 auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                 if (!mapData.count("_key"))
@@ -1587,10 +1587,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                     }
                                 }
 
-                                if (!view.AddNameData(DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue(program.sParameters[2], program.sParameters[3], program.sParameters[1]))))
+                                if (!viewMemPool.AddNameData(hash, DotNav::GetHashName(program.sParameters[0]), std::make_pair(chainActive.Tip()->nHeight, NameDataValue(program.sParameters[2], program.sParameters[3], program.sParameters[1]))))
                                     return state.DoS(100, false, REJECT_INVALID, "name-could-not-update");
 
-                                if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
 
@@ -1606,7 +1606,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                     return state.DoS(100, false, REJECT_INVALID, "renew-name-missing-contribution");
                                 NameDataValues data;
 
-                                if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                     if (!mapData.count("_key"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1559,7 +1559,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                 LogPrint("dotnav", "%s: updated name first %s %s %s %s\n", __func__, program.sParameters[1], program.sParameters[0], program.sParameters[2], program.sParameters[3]);
                             } else if (program.action == UPDATE_NAME) {
                                 NameDataValues data;
-                                if (!viewMemPool.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                                if (!view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                     return state.DoS(100, false, REJECT_INVALID, strprintf("error-name:%s", program.sParameters[0]));
                                 auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                 if (!mapData.count("_key"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1558,7 +1558,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                             } else if (program.action == UPDATE_NAME) {
                                 NameDataValues data;
                                 if (!view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
-                                    return state.DoS(100, false, REJECT_INVALID, "error-name");
+                                    return state.DoS(100, false, REJECT_INVALID, strprintf("error-name:%s", program.sParameters[0]));
                                 auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                 if (!mapData.count("_key"))
                                     return state.DoS(100, false, REJECT_INVALID, "name-has-no-key");
@@ -4918,7 +4918,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         } else if (program.action == UPDATE_NAME) {
                             NameDataValues data;
                             if (!view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
-                                return state.DoS(100, false, REJECT_INVALID, "error-name");
+                                return state.DoS(100, false, REJECT_INVALID, strprintf("error-name:%s", program.sParameters[0]));
                             if (!(DotNav::IsValidKey(program.sParameters[1]) || program.sParameters[1] == ""))
                                 return state.DoS(100, false, REJECT_INVALID, "invalid-subdomain");
                             if (!(DotNav::IsValidKey(program.sParameters[2]) || program.sParameters[2] == "_key"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5686,7 +5686,7 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            return error("ConnectTip(): ConnectBlock %s failed: ", pindexNew->GetBlockHash().ToString());
+            return error("ConnectTip(): ConnectBlock %s failed: %s", pindexNew->GetBlockHash().ToString(), state.GetRejectReason());
         }
         mapBlockSource.erase(pindexNew->GetBlockHash());
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2990,6 +2990,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                             view.RemoveNameRecord(program.hParameters[0]);
                         } else if (program.action == UPDATE_NAME_FIRST || program.action == UPDATE_NAME || program.action == RENEW_NAME) {
                             view.RemoveNameData(NameDataKey(program.sParameters[0], pindex->nHeight));
+                            LogPrint("dotnav", "%s: removing name data for %s %d\n", __func__, program.sParameters[0], pindex->nHeight);
                         }
                     }
                 } catch(...) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1549,8 +1549,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                 if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
-                                    if (DotNav::CalculateSize(mapData) > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
-                                        return state.DoS(100, false, REJECT_INVALID, "no-space-left");
+                                    if (!(txout.scriptPubKey.IsCommunityFundContribution() && txout.nValue >= std::floor(DotNav::CalculateSize(mapData)/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view)))
+                                        return state.DoS(100, false, REJECT_INVALID, "register-name-missing-contribution");
                                 } else {
                                     return state.DoS(100, false, REJECT_INVALID, "could-not-verify-written-data");
                                 }
@@ -1589,8 +1589,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
 
-                                    if (DotNav::CalculateSize(mapData) > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
-                                        return state.DoS(100, false, REJECT_INVALID, "no-space-left");
+                                    if (!(txout.scriptPubKey.IsCommunityFundContribution() && txout.nValue >= std::floor(DotNav::CalculateSize(mapData)/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view)))
+                                        return state.DoS(100, false, REJECT_INVALID, "register-name-missing-contribution");
                                 } else {
                                     return state.DoS(100, false, REJECT_INVALID, "could-not-verify-written-data");
                                 }
@@ -4878,8 +4878,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                             if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                             {
                                 auto mapData = DotNav::Consolidate(data, pindex->nHeight);
-                                if (DotNav::CalculateSize(mapData) > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
-                                    return state.DoS(100, false, REJECT_INVALID, "no-space-left");
+
+                                if (!(vout.scriptPubKey.IsCommunityFundContribution() && vout.nValue >= std::floor(DotNav::CalculateSize(mapData)/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view)))
+                                    return state.DoS(100, false, REJECT_INVALID, "register-name-missing-contribution");
                             } else {
                                 return state.DoS(100, false, REJECT_INVALID, "could-not-verify-written-data");
                             }
@@ -4930,8 +4931,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                             if (view.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
                             {
                                 auto mapData = DotNav::Consolidate(data, pindex->nHeight);
-                                if (DotNav::CalculateSize(mapData) > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
-                                    return state.DoS(100, false, REJECT_INVALID, "no-space-left");
+                                if (!(vout.scriptPubKey.IsCommunityFundContribution() && vout.nValue >= std::floor(DotNav::CalculateSize(mapData)/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view)))
+                                    return state.DoS(100, false, REJECT_INVALID, "register-name-missing-contribution");
                             } else {
                                 return state.DoS(100, false, REJECT_INVALID, "could-not-verify-written-data");
                             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1518,7 +1518,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                 {
                                     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                                     if (mapData.count("_key"))
-                                        return state.DoS(100, false, REJECT_INVALID, "already-revealed");
+                                        return state.DoS(100, false, REJECT_INVALID, strprintf("already-revealed:%s", program.sParameters[0]));
                                 }
 
                                 if (!(DotNav::IsValid(program.sParameters[0])))
@@ -4868,7 +4868,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                             {
                                 auto mapData = DotNav::Consolidate(data, pindex->nHeight);
                                 if (mapData.count("_key"))
-                                    return state.DoS(100, false, REJECT_INVALID, "already-revealed");
+                                    return state.DoS(100, false, REJECT_INVALID, strprintf("already-revealed:%s", program.sParameters[0]));
                             }
                             if (!(DotNav::IsValid(program.sParameters[0])))
                                 return state.DoS(100, false, REJECT_INVALID, "invalid-name");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1572,6 +1572,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CCriticalSection *mpcs, CCritica
                                     return state.DoS(100, false, REJECT_INVALID, "invalid-subdomain");
                                 if (!(DotNav::IsValidKey(program.sParameters[2]) || program.sParameters[2] == "_key"))
                                     return state.DoS(100, false, REJECT_INVALID, "invalid-key");
+                                if (program.sParameters[3].size() > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
+                                    return state.DoS(100, false, REJECT_INVALID, "too-long-value");
                                 if (program.sParameters[2] == "_key")
                                 {
                                     try {
@@ -4905,6 +4907,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                                 return state.DoS(100, false, REJECT_INVALID, "invalid-subdomain");
                             if (!(DotNav::IsValidKey(program.sParameters[2]) || program.sParameters[2] == "_key"))
                                 return state.DoS(100, false, REJECT_INVALID, "invalid-name");
+                            if (program.sParameters[3].size() > GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))
+                                return state.DoS(100, false, REJECT_INVALID, "too-long-value");
                             auto mapData = DotNav::Consolidate(data, pindex->nHeight);
                             if (!mapData.count("_key"))
                                 return state.DoS(100, false, REJECT_INVALID, "name-has-no-key");

--- a/src/main.h
+++ b/src/main.h
@@ -545,6 +545,7 @@ bool IsVoteCacheStateEnabled(const CBlockIndex* pindexPrev, const Consensus::Par
 bool IsDAOEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 bool IsDaoConsensusEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 bool IsXNavSerEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+bool IsDotNavEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 /** Check whether the static reward has been activated **/
 bool IsStaticRewardEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -71,16 +71,16 @@ std::string CTxOut::ToString() const
 {
     if (IsEmpty()) return "CTxOut(empty)";
     if (IsCommunityFundContribution())
-        return strprintf("CTxOut(nValue=%d.%08d, CommunityFundContribution)", nValue / COIN, nValue % COIN);
+        return strprintf("CTxOut(nValue=%d.%08d, CommunityFundContribution vData=%s)", nValue / COIN, nValue % COIN, vData.size()>0?PredicateToStr(vData):"0");
     else
     {
-        return strprintf("CTxOut(nValue=%s, scriptPubKey=%s%s%s%s%s%s vData=%d)", HasRangeProof() ? "private" : strprintf("%d.%08d", nValue / COIN, nValue % COIN),
+        return strprintf("CTxOut(nValue=%s, scriptPubKey=%s%s%s%s%s%s vData=%s)", HasRangeProof() ? "private" : strprintf("%d.%08d", nValue / COIN, nValue % COIN),
                          scriptPubKey.ToString(),
                          spendingKey.size()>0 ? strprintf(" spendingKey=%s",HexStr(spendingKey)):"",
                          outputKey.size()>0 ? strprintf(" outputKey=%s",HexStr(outputKey)):"",
                          ephemeralKey.size()>0 ? strprintf(" ephemeralKey=%s",HexStr(ephemeralKey)):"",
                          GetBulletproof().V.size()>0 ? " rangeProof=1":"",
-                         tokenId.token==uint256() ? "": strprintf(" tokenId=%s%s", tokenId.token.ToString(), tokenId.subid!=-1?strprintf(",%d",tokenId.subid):""), vData.size());
+                         tokenId.token==uint256() ? "": strprintf(" tokenId=%s%s", tokenId.token.ToString(), tokenId.subid!=-1?strprintf(",%d",tokenId.subid):""), vData.size()>0?PredicateToStr(vData):"0");
     }
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -9,6 +9,7 @@
 #include <amount.h>
 #include <blsct/bulletproofs.h>
 #include <consensus/dao.h>
+#include <consensus/programs.h>
 #include <sph_keccak.h>
 #include <script/script.h>
 #include <serialize.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1569,6 +1569,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     BIP9SoftForkDescPushBack(bip9_softforks, "dao_super", consensusParams, Consensus::DEPLOYMENT_DAO_SUPER);
     BIP9SoftForkDescPushBack(bip9_softforks, "exclude", consensusParams, Consensus::DEPLOYMENT_EXCLUDE);
     BIP9SoftForkDescPushBack(bip9_softforks, "xnav_ser", consensusParams, Consensus::DEPLOYMENT_XNAV_SER);
+    BIP9SoftForkDescPushBack(bip9_softforks, "dot_nav", consensusParams, Consensus::DEPLOYMENT_DOT_NAV);
     obj.pushKV("softforks",      softforks);
     obj.pushKV("bip9_softforks", bip9_softforks);
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -568,7 +568,11 @@ inline void Unserialize(Stream& s, bls::G1Element & a, int nType, int nVersion =
 {
     std::vector<uint8_t> f(bls::G1Element::SIZE);
     Unserialize(s, f, nType, nVersion);
-    a = bls::G1Element::FromByteVector(f);
+    try {
+        a = bls::G1Element::FromByteVector(f);
+    } catch(...) {
+
+    }
 }
 
 
@@ -585,7 +589,11 @@ inline void Unserialize(Stream& s, bls::G2Element & a, int nType, int nVersion =
 {
     std::vector<uint8_t> f(bls::G2Element::SIZE);
     Unserialize(s, f, nType, nVersion);
-    a = bls::G2Element::FromByteVector(f);
+    try {
+        a = bls::G2Element::FromByteVector(f);
+    } catch(...) {
+
+    }
 }
 
 /**

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -199,13 +199,17 @@ bool CStateViewDB::GetNameData(const uint256& id, NameDataValues& map) {
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         std::pair<char, NameDataKey> key;
-        if (pcursor->GetKey(key) && key.first == DB_NAME_DATA && key.second.id == id) {
-            NameDataValue data;
-            if (pcursor->GetValue(data)) {
-                map.push_back(std::make_pair(key.second.height, data));
-                pcursor->Next();
+        if (pcursor->GetKey(key) && key.first == DB_NAME_DATA) {
+            if (key.second.id == id) {
+                NameDataValue data;
+                if (pcursor->GetValue(data)) {
+                    map.push_back(std::make_pair(key.second.height, data));
+                    pcursor->Next();
+                } else {
+                    return error("GetNameData() : failed to read value");
+                }
             } else {
-                return error("GetNameData() : failed to read value");
+                pcursor->Next();
             }
         } else {
             break;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -40,6 +40,8 @@ static const char DB_LAST_BLOCK = 'l';
 static const char DB_EXCLUDE_VOTES = 'X';
 
 static const char DB_TOKENS = 'T';
+static const char DB_NAME_RECORDS = 'n';
+static const char DB_NAME_DATA = 'N';
 
 CStateViewDB::CStateViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true, false, 64)
 {
@@ -67,6 +69,18 @@ bool CStateViewDB::GetToken(const uint256 &id, TokenInfo &token) const {
 
 bool CStateViewDB::HaveToken(const uint256 &id) const {
     return db.Exists(std::make_pair(DB_TOKENS, id));
+}
+
+bool CStateViewDB::GetNameRecord(const uint256 &id, NameRecordValue &height) const {
+    return db.Read(std::make_pair(DB_NAME_RECORDS, id), height);
+}
+
+bool CStateViewDB::HaveNameRecord(const uint256 &id) const {
+    return db.Exists(std::make_pair(DB_NAME_RECORDS, id));
+}
+
+bool CStateViewDB::HaveNameData(const uint256 &id) const {
+    return db.Exists(std::make_pair(DB_NAME_DATA, id));
 }
 
 bool CStateViewDB::GetPaymentRequest(const uint256 &prid, CPaymentRequest &prequest) const {
@@ -166,6 +180,58 @@ bool CStateViewDB::GetAllTokens(TokenMap& map) {
                 pcursor->Next();
             } else {
                 return error("GetAllTokens() : failed to read value");
+            }
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool CStateViewDB::GetNameData(const uint256& id, NameDataValues& map) {
+    map.clear();
+
+    boost::scoped_ptr<CDBIterator> pcursor(db.NewIterator());
+
+    pcursor->Seek(std::make_pair(DB_NAME_DATA, uint256()));
+
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+        std::pair<char, NameDataKey> key;
+        if (pcursor->GetKey(key) && key.first == DB_NAME_DATA && key.second.id == id) {
+            NameDataValue data;
+            if (pcursor->GetValue(data)) {
+                map.push_back(std::make_pair(key.second.height, data));
+                pcursor->Next();
+            } else {
+                return error("GetNameData() : failed to read value");
+            }
+        } else {
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool CStateViewDB::GetAllNameRecords(NameRecordMap &map) {
+    map.clear();
+
+    boost::scoped_ptr<CDBIterator> pcursor(db.NewIterator());
+
+    pcursor->Seek(std::make_pair(DB_NAME_RECORDS, uint256()));
+
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+        std::pair<char, uint256> key;
+        if (pcursor->GetKey(key) && key.first == DB_NAME_RECORDS) {
+            uint64_t height;
+            if (pcursor->GetValue(height)) {
+                map.insert(std::make_pair(key.second, height));
+                pcursor->Next();
+            } else {
+                return error("GetAllNameRecords() : failed to read value");
             }
         } else {
             break;
@@ -283,7 +349,8 @@ bool CStateViewDB::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals,
                               CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                               CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
                               CConsensusParameterMap &mapConsensus,
-                              TokenMap &mapTokens,
+                              TokenMap &mapTokens, NameRecordMap &mapNameRecords,
+                              NameDataMap& mapNameData,
                               const uint256 &hashBlock, const int &nExcludeVotes) {
 
     CDBBatch batch(db);
@@ -385,6 +452,33 @@ bool CStateViewDB::BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals,
         }
         TokenMap::iterator itOld = it++;
         mapTokens.erase(itOld);
+    }
+
+    for (NameRecordMap::iterator it = mapNameRecords.begin(); it != mapNameRecords.end();) {
+        if (it->second.IsNull()) {
+            batch.Erase(std::make_pair(DB_NAME_RECORDS, it->first));
+        } else {
+            batch.Write(std::make_pair(DB_NAME_RECORDS, it->first), it->second);
+        }
+        NameRecordMap::iterator itOld = it++;
+        mapNameRecords.erase(itOld);
+    }
+
+    for (NameDataMap::iterator it = mapNameData.begin(); it != mapNameData.end();) {
+        if (it->second.size() == 0) {
+            batch.Erase(std::make_pair(DB_NAME_DATA, it->first));
+        } else {
+            for (auto &it2: it->second) {
+                if (it2.second.IsNull())
+                {
+                    batch.Erase(std::make_pair(DB_NAME_DATA, NameDataKey(it->first, it2.first)));
+                } else {
+                    batch.Write(std::make_pair(DB_NAME_DATA, NameDataKey(it->first, it2.first, it2.second.key)), it2.second);
+                }
+            }
+        }
+        NameDataMap::iterator itOld = it++;
+        mapNameData.erase(itOld);
     }
 
     if (!hashBlock.IsNull())

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -115,18 +115,26 @@ public:
     bool GetToken(const uint256 &id, TokenInfo &token) const;
     bool HaveToken(const uint256 &id) const;
 
+    bool GetNameRecord(const uint256 &id, NameRecordValue &height) const;
+    bool HaveNameRecord(const uint256 &id) const;
+
+    bool GetNameData(const uint256& id, NameDataValues &data);
+    bool HaveNameData(const uint256& id) const;
+
     uint256 GetBestBlock() const;
     bool BatchWrite(CCoinsMap &mapCoins, CProposalMap &mapProposals,
                     CPaymentRequestMap &mapPaymentRequests, CVoteMap &mapVotes,
                     CConsultationMap &mapConsultations, CConsultationAnswerMap &mapAnswers,
-                    CConsensusParameterMap& mapConsensus, TokenMap& mapTokens, const uint256 &hashBlock,
-                    const int &nExcludeVotes);
+                    CConsensusParameterMap& mapConsensus, TokenMap& mapTokens,
+                    NameRecordMap& mapNameRecords, NameDataMap& mapNameData,
+                    const uint256 &hashBlock, const int &nExcludeVotes);
     bool GetAllProposals(CProposalMap& map);
     bool GetAllPaymentRequests(CPaymentRequestMap& map);
     bool GetAllVotes(CVoteMap &map);
     bool GetAllConsultations(CConsultationMap &map);
     bool GetAllConsultationAnswers(CConsultationAnswerMap &map);
     bool GetAllTokens(TokenMap &map);
+    bool GetAllNameRecords(NameRecordMap &map);
     int GetExcludeVotes() const;
     CStateViewCursor *Cursor() const;
 };

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1268,7 +1268,8 @@ bool CStateViewMemPool::GetNameData(const uint256 &prid, NameDataValues &data)
         data = temp;
         return true;
     }
-    return false;
+    data = temp;
+    return temp.size() > 0;
 }
 
 bool CStateViewMemPool::GetAllPaymentRequests(CPaymentRequestMap& mapPaymentRequests) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -418,6 +418,12 @@ bool CTxMemPool::AddToken(const Token& token)
     return true;
 }
 
+bool CTxMemPool::AddNameRecord(const NameRecord& nr)
+{
+    mapNameRecords.insert(std::make_pair(nr.first, nr.second));
+    return true;
+}
+
 bool CTxMemPool::AddConsultationAnswer(const CConsultationAnswer& answer)
 {
     mapAnswer.insert(std::make_pair(answer.hash, answer));
@@ -1271,6 +1277,10 @@ bool CStateViewMemPool::HaveProposal(const uint256 &txid) const {
     return mempool.mapProposal.count(txid) || base->HaveProposal(txid);
 }
 
+bool CStateViewMemPool::HaveNameRecord(const uint256 &id) const {
+    return mempool.mapNameRecords.count(id) || base->HaveNameRecord(id);
+}
+
 bool CStateViewMemPool::HavePaymentRequest(const uint256 &txid) const {
     return mempool.mapPaymentRequest.count(txid) || base->HavePaymentRequest(txid);
 }
@@ -1301,6 +1311,11 @@ bool CStateViewMemPool::AddConsultation(const CConsultation& consultation) const
 bool CStateViewMemPool::AddToken(const Token& token) const
 {
     return const_cast<CTxMemPool&>(mempool).AddToken(token);
+}
+
+bool CStateViewMemPool::AddNameRecord(const NameRecord& nr) const
+{
+    return const_cast<CTxMemPool&>(mempool).AddNameRecord(nr);
 }
 
 bool CStateViewMemPool::AddConsultationAnswer(const CConsultationAnswer& answer) const

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -432,6 +432,7 @@ bool CTxMemPool::AddNameData(const uint256 &tx, const uint256 &prid, const NameD
         mapNameData.insert(std::make_pair(prid, NameDataValues()));
 
     mapNameData[prid].push_back(record);
+    return true;
 }
 
 bool CTxMemPool::AddConsultationAnswer(const CConsultationAnswer& answer)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -473,6 +473,7 @@ public:
     CPaymentRequestMap mapPaymentRequest;
     CConsultationMap mapConsultation;
     TokenMap mapTokens;
+    NameRecordMap mapNameRecords;
     CConsultationAnswerMap mapAnswer;
 
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
@@ -548,6 +549,7 @@ public:
     bool AddConsultation(const CConsultation& consultation);
     bool AddToken(const Token& token);
     bool AddConsultationAnswer(const CConsultationAnswer& answer);
+    bool AddNameRecord(const NameRecord& namerecord);
 
     void addAddressIndex(const CTxMemPoolEntry &entry, const CStateViewCache &view);
     bool getAddressIndex(std::vector<std::pair<uint160, int> > &addresses,
@@ -795,6 +797,7 @@ public:
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
     bool HaveProposal(const uint256 &pid) const;
+    bool HaveNameRecord(const uint256 &pid) const;
     bool HavePaymentRequest(const uint256 &prid) const;
     bool HaveConsultation(const uint256 &prid) const;
     bool HaveConsultationAnswer(const uint256 &prid) const;
@@ -809,6 +812,7 @@ public:
     bool AddPaymentRequest(const CPaymentRequest& prequest) const;
     bool AddConsultation(const CConsultation& consultation) const;
     bool AddToken(const Token& token) const;
+    bool AddNameRecord(const NameRecord& nr) const;
     bool AddConsultationAnswer(const CConsultationAnswer& answer) const;
 };
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -474,6 +474,8 @@ public:
     CConsultationMap mapConsultation;
     TokenMap mapTokens;
     NameRecordMap mapNameRecords;
+    NameDataMap mapNameData;
+    std::map<uint256, std::vector<std::pair<uint256, NameDataEntry>>> mapNameDataTx;
     CConsultationAnswerMap mapAnswer;
 
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
@@ -550,6 +552,10 @@ public:
     bool AddToken(const Token& token);
     bool AddConsultationAnswer(const CConsultationAnswer& answer);
     bool AddNameRecord(const NameRecord& namerecord);
+
+    bool HaveNameData(const uint256 &prid) const;
+    bool GetNameData(const uint256 &prid, NameDataValues& data);
+    bool AddNameData(const uint256 &txid, const uint256 &prid, const NameDataEntry& record);
 
     void addAddressIndex(const CTxMemPoolEntry &entry, const CStateViewCache &view);
     bool getAddressIndex(std::vector<std::pair<uint160, int> > &addresses,
@@ -805,6 +811,7 @@ public:
     bool GetPaymentRequest(const uint256 &txid, CPaymentRequest &prequest) const;
     bool GetConsultation(const uint256 &txid, CConsultation &consultation) const;
     bool GetConsultationAnswer(const uint256 &txid, CConsultationAnswer &answer) const;
+    bool GetNameRecord(const uint256 &id, NameRecordValue &answer) const;
     bool GetAllPaymentRequests(CPaymentRequestMap& mapPaymentRequests);
     bool GetAllConsultationAnswers(CConsultationAnswerMap& mapConsultationAnswers);
     bool GetAllConsultations(CConsultationMap& mapConsultations);
@@ -814,6 +821,9 @@ public:
     bool AddToken(const Token& token) const;
     bool AddNameRecord(const NameRecord& nr) const;
     bool AddConsultationAnswer(const CConsultationAnswer& answer) const;
+    bool HaveNameData(const uint256 &prid) const;
+    bool GetNameData(const uint256 &prid, NameDataValues& data);
+    bool AddNameData(const uint256 &txid, const uint256 &prid, const NameDataEntry& record);
 };
 
 // We want to sort transactions by coin age priority

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -125,7 +125,7 @@ public:
 
     uint32_t GetUint32(int pos) const
     {
-        const uint8_t* ptr = data + pos * 8;
+        const uint8_t* ptr = data + pos * 4;
         return ((uint32_t)ptr[0]) | \
                ((uint32_t)ptr[1]) << 8 | \
                ((uint32_t)ptr[2]) << 16 | \

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -123,6 +123,15 @@ public:
                ((uint64_t)ptr[7]) << 56;
     }
 
+    uint32_t GetUint32(int pos) const
+    {
+        const uint8_t* ptr = data + pos * 8;
+        return ((uint32_t)ptr[0]) | \
+               ((uint32_t)ptr[1]) << 8 | \
+               ((uint32_t)ptr[2]) << 16 | \
+               ((uint32_t)ptr[3]) << 24 ;
+    }
+
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const
     {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1314,6 +1314,8 @@ UniValue resolvename(const UniValue& params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
     CStateViewCache view(pcoinsTip);
 
+    UniValue ret(UniValue::VOBJ);
+
     if (fHelp || params.size() < 1)
         throw std::runtime_error(
             "resolvename \"name\"\n"
@@ -1348,17 +1350,15 @@ UniValue resolvename(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid name");
 
     if (!view.HaveNameData(DotNav::GetHashName(sName)))
-        throw JSONRPCError(RPC_TYPE_ERROR, "That name is not registered");
+        return ret;
 
     NameDataValues data;
 
     if (!view.GetNameData(DotNav::GetHashName(sName), data))
     {
-        throw JSONRPCError(RPC_TYPE_ERROR, "Could not find the name");
+        return ret;
     }
     auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight, subdomain);
-
-    UniValue ret(UniValue::VOBJ);
 
     for (auto &it: mapData) {
         ret.pushKV(it.first, it.second);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1464,6 +1464,7 @@ UniValue updatename(const UniValue& params, bool fHelp)
         {
             throw JSONRPCError(RPC_TYPE_ERROR, "Name has not an associated key");
         }
+        mapData[sKey] = sValue;
         dataSize = DotNav::CalculateSize(mapData);
         try {
             if (bls::G1Element::FromByteVector(ParseHex(mapData["_key"])) != pkg1)
@@ -1475,7 +1476,7 @@ UniValue updatename(const UniValue& params, bool fHelp)
         }
     }
 
-    uint64_t fee = std::floor((dataSize+sKey.size()+sValue.size())/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view);
+    uint64_t fee = std::floor(dataSize/GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_MAXDATA, view))*GetConsensusParameter(Consensus::CONSENSUS_PARAMS_DOTNAV_FEE_EXTRADATA, view);
 
     auto program = first ? DotNav::GetUpdateFirstProgram(sName, pkg1, sKey, sValue, subdomain) : DotNav::GetUpdateProgram(sName, pkg1, sKey, sValue, subdomain);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2318,7 +2318,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 
         if (!ExtractDestination(txout.scriptPubKey, address))
         {
-            if(!txout.scriptPubKey.IsCommunityFundContribution() && !txout.IsBLSCT())
+            if(!txout.scriptPubKey.IsCommunityFundContribution() && !txout.IsBLSCT() && !txout.scriptPubKey.IsFee())
                 LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s n: %d %s\n",
                          this->GetHash().ToString(), i, txout.ToString());
             address = CNoDestination();
@@ -3896,7 +3896,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                                 strFailReason = strprintf("Could not find the name");
                                 return false;
                             }
-                            auto mapData = DotNav::Consolidate(data);
+                            auto mapData = DotNav::Consolidate(data, chainActive.Tip()->nHeight);
                             if (!mapData.count("_key"))
                             {
                                 strFailReason = strprintf("Name has not an associated key");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3767,6 +3767,9 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     bls::G1Element nonce;
 
                     txout.vData = recipient.vData;
+                    if (txout.vData.size() > 0)
+                        txNew.nVersion |= TX_BLS_CT_FLAG;
+
                     Predicate program(txout.vData);
 
                     if (!recipient.fBLSCT)
@@ -3852,6 +3855,66 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                         }
 
                         bls::G2Element sig = bls::AugSchemeMPL::Sign(tk.GetKey(), std::vector<unsigned char>(txOutHash.begin(), txOutHash.end()));
+                        vBLSSignatures.push_back(sig);
+                    }
+
+                    if (program.kParameters.size() > 0 && program.action == UPDATE_NAME_FIRST) {
+                        uint256 txOutHash = txout.GetHash();
+                        blsctKey s;
+                        if (!GetBLSCTSpendKey(s))
+                        {
+                            strFailReason = strprintf("Missing master spend private key");
+                            return false;
+                        }
+
+                        blsctKey ns = s.PrivateChildHash(SerializeHash("name/"+DotNav::GetHashName(program.sParameters[0]).ToString()));
+
+                        if (ns.GetG1Element() != program.kParameters[0])
+                            strFailReason = strprintf("Can't get name private key");
+
+                        bls::G2Element sig = bls::AugSchemeMPL::Sign(ns.GetKey(), std::vector<unsigned char>(txOutHash.begin(), txOutHash.end()));
+                        vBLSSignatures.push_back(sig);
+                    }
+
+                    if (program.sParameters.size() > 0 && program.action == UPDATE_NAME) {
+                        uint256 txOutHash = txout.GetHash();
+                        blsctKey s;
+                        if (!GetBLSCTSpendKey(s))
+                        {
+                            strFailReason = strprintf("Missing master spend private key");
+                            return false;
+                        }
+
+                        blsctKey ns = s.PrivateChildHash(SerializeHash("name/"+DotNav::GetHashName(program.sParameters[0]).ToString()));
+
+                        {
+                            CStateViewCache inputs(pcoinsTip);
+
+                            NameDataValues data;
+                            if (!inputs.GetNameData(DotNav::GetHashName(program.sParameters[0]), data))
+                            {
+                                strFailReason = strprintf("Could not find the name");
+                                return false;
+                            }
+                            auto mapData = DotNav::Consolidate(data);
+                            if (!mapData.count("_key"))
+                            {
+                                strFailReason = strprintf("Name has not an associated key");
+                                return false;
+                            }
+                            try {
+                                if (bls::G1Element::FromByteVector(ParseHex(mapData["_key"])) != ns.GetG1Element())
+                                {
+                                    strFailReason = strprintf("You don't own the name");
+                                    return false;
+                                }
+                            } catch(...) {
+                                strFailReason = strprintf("Wrong format key of name");
+                                return false;
+                            }
+                        }
+
+                        bls::G2Element sig = bls::AugSchemeMPL::Sign(ns.GetKey(), std::vector<unsigned char>(txOutHash.begin(), txOutHash.end()));
                         vBLSSignatures.push_back(sig);
                     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -9,6 +9,7 @@
 #include <amount.h>
 #include <blsct/aggregationsession.h>
 #include <blsct/transaction.h>
+#include <dotnav/names.h>
 #include <mnemonic/mnemonic.h>
 #include <streams.h>
 #include <tinyformat.h>


### PR DESCRIPTION
This Pull Request introduces the consensus changed needed for a naming system dubbed dotNAV secured by Navcoin's blockchain and signalled for activation with version bit 34 (using block header's nonce).

Names are only allowed with the suffix `.nav` and to have a maximum length of 64 characters. Only allowed characters are alphanumeric and `-`, and the first character can't be a `-`.

Valid names: `satoshi.nav` `satoshi-nakamoto.nav` `satoshi21.nav` `21satoshi.nav`
Invalid names: `-satoshi.nav` `satoshi_nakamoto.nav`

*RPC Command*: `registername name`

Examples:

`registername alex.nav`

Registration has a cost set by a consensus parameter (initially `10 NAV`) and lasts 400 days worth of blocks (modifiable through consensus parameters). Names can be renewed by everyone (not only the owner) with the rpc command `renewname name`. The name's expiry date will be set to 400 days worth of blocks after the moment of the renewal, and it will have the same cost as a registration.

After registration, it requires a minimum of 6 blocks to allow the set of values.

Each name can have different keys, each pointing to an arbitrary value. Those can be exclusively set by the owner of the name and each name has a maximum allowance of 1024 bytes of data.

Domains allow additionally one subdomain, which must stay in the same character set constrains as a name.

*RPC Command*: `updatename name key value`

Examples: 

`updatename alex.nav ip 127.0.0.1`
`updatename alex.nav email alex@nav.community`
`updatename personal.alex.nav email alex.home@nav.community`

Names can be resolved through the RPC command `resolvename name`
