### PR TITLE
Fixed a bug that caused the dark theme splash screen to look white

### DIFF
--- a/src/qt/res/themes/light/styles.qss
+++ b/src/qt/res/themes/light/styles.qss
@@ -138,3 +138,7 @@ QTreeView::branch:open:has-children:has-siblings {
     border-image: none;
     image: url(:/light/icon_branch_open);
 }
+
+#SplashBackground {
+    background: white;
+}

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -37,6 +37,9 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     QString versionText     = QString::fromStdString(FormatFullVersion());
     QString titleAddText    = networkStyle->getTitleAddText();
 
+    // Name the BG for the splash screen
+    setObjectName("SplashBackground");
+
     // Size of the splash screen
     splashSize = QSize(480 * scale(), 320 * scale());
 
@@ -108,12 +111,6 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
 
     // Set window title
     setWindowTitle(titleText + " " + titleAddText);
-    QPalette pal = palette();
-
-    // Set white background
-    pal.setColor(QPalette::Background, Qt::white);
-    setAutoFillBackground(true);
-    setPalette(pal);
 
     // Resize window and move to center of desktop, disallow resizing
     QRect r(QPoint(), splashSize);


### PR DESCRIPTION
There was a hard coded color value for the splash screen background color that caused the dark theme to have a white background, which lead to the text (version text and loading messages to be unreadable/invisible when starting the wallet in dark theme)