### PR TITLE
Fix vote for auto excluded stakers

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1174,7 +1174,7 @@ bool SignBlock(CBlock *pblock, CWallet& wallet, int64_t nFees, std::string sLog)
                                       nCycles++;
                                   if (nCycles >= 10)
                                   {
-                                      pblock->nNonce = 1;
+                                      pblock->nNonce |= 1;
                                       break;
                                   }
                                   fFound = false;


### PR DESCRIPTION
This Pull Request fixes a bug where stakers which were auto excluded from voting because they were inactive for more than 10 voting cycles do not commit their votes in the nNonce parameter of the block.

### How to test

Verify that staked blocks have its nonce value set to greater that 1 even when the wallet has been auto-excluded from voting