### PR TITLE
Fix possible node crash if the stake was stale

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11140,6 +11140,8 @@ bool CheckProofOfStake(CBlockIndex* pindexPrev, const CTransaction& tx, unsigned
 
     if (fColdStaking)
     {
+        if (!view.HaveInputs(tx)) return error("%s: Coin stake %s is stale\n", __func__, tx.GetHash().ToString());
+
         CAmount valueIn = view.GetValueIn(tx);
         CAmount valueOut = 0;
 


### PR DESCRIPTION
This pull request fixes a bug which can cause a node to crash when the stake is stale. This can be easily tested running various instances of a node staking with the same wallet.