### PR TITLE
Fix swap NAV->xNAV

### DIFF
--- a/src/qt/swapxnav.cpp
+++ b/src/qt/swapxnav.cpp
@@ -253,7 +253,7 @@ void SwapXNAVDialog::Ok()
     std::string strError;
     vector<CRecipient> vecSend;
     int nChangePosRet = -1;
-    CRecipient recipient = {scriptPubKey, nAmount, true, fMode};
+    CRecipient recipient = {scriptPubKey, nAmount, false, fMode};
     if (fMode)
     {
         bls::G1Element vk, sk;


### PR DESCRIPTION
This Pull Request fixes a bug which caused swaps from NAV to xNAV to failed when using the SWAP feature of the GUI wallet.