### PR TITLE
[FIX] Generate random key if not viewing key available

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5254,9 +5254,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             {
                 blsctKey v;
 
-                if (pwalletMain)
-                    pwalletMain->GetBLSCTViewKey(v);
-                else
+                if (pwalletMain) {
+                    if (!pwalletMain->GetBLSCTViewKey(v)) {
+                        v = blsctKey(bls::PrivateKey::FromBN(Scalar::Rand().bn));
+                    }
+                }else
                     v = blsctKey(bls::PrivateKey::FromBN(Scalar::Rand().bn));
 
                 CTransaction tx = block.vtx[1];


### PR DESCRIPTION
This pull request prevents a segfault crash when verifying a block which redirected its rewards to a xNAV address if the verifier node has an old wallet and does not have a view key.